### PR TITLE
docs(release): use compatible API command for visibility change

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -307,7 +307,7 @@ durations. `last_*` fields are retained for compatibility and will be deprecated
 - Visibility check:
   - `gh repo view --json nameWithOwner,isPrivate,visibility,url`
 - Make repo public when release-ready:
-  - `gh repo edit --visibility public --accept-visibility-change-consequences`
+  - `gh api --method PATCH repos/<owner>/<repo> -f private=false -f visibility=public`
 - Protect `main` against direct pushes (require pull requests):
   - `gh api --method PUT repos/<owner>/<repo>/branches/main/protection \
     -H "Accept: application/vnd.github+json" \


### PR DESCRIPTION
## Why
- The previous command used a Work seamlessly with GitHub from the command line.

USAGE
  gh <command> <subcommand> [flags]

CORE COMMANDS
  auth:        Authenticate gh and git with GitHub
  browse:      Open the repository in the browser
  codespace:   Connect to and manage codespaces
  gist:        Manage gists
  issue:       Manage issues
  org:         Manage organizations
  pr:          Manage pull requests
  project:     Work with GitHub Projects.
  release:     Manage releases
  repo:        Manage repositories

GITHUB ACTIONS COMMANDS
  cache:       Manage Github Actions caches
  run:         View details about workflow runs
  workflow:    View details about GitHub Actions workflows

ALIAS COMMANDS
  co:          Alias for "pr checkout"

ADDITIONAL COMMANDS
  alias:       Create command shortcuts
  api:         Make an authenticated GitHub API request
  completion:  Generate shell completion scripts
  config:      Manage configuration for gh
  extension:   Manage gh extensions
  gpg-key:     Manage GPG keys
  label:       Manage labels
  ruleset:     View info about repo rulesets
  search:      Search for repositories, issues, and pull requests
  secret:      Manage GitHub secrets
  ssh-key:     Manage SSH keys
  status:      Print information about relevant issues, pull requests, and notifications across repositories
  variable:    Manage GitHub Actions variables

HELP TOPICS
  actions:     Learn about working with GitHub Actions
  environment: Environment variables that can be used with gh
  exit-codes:  Exit codes used by gh
  formatting:  Formatting options for JSON data exported from gh
  mintty:      Information about using gh with MinTTY
  reference:   A comprehensive reference of all gh commands

FLAGS
  --help      Show help for command
  --version   Show gh version

EXAMPLES
  $ gh issue create
  $ gh repo clone cli/cli
  $ gh pr checkout 321

LEARN MORE
  Use `gh <command> <subcommand> --help` for more information about a command.
  Read the manual at https://cli.github.com/manual flag that is unavailable in this environment.
- The release runbook should use commands that work reliably across CLI versions.

## What changed
- Replaced the visibility-change example in  with the API-based command used in this release prep.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated repository operations guidance with an alternative method for configuring repository visibility settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->