### PR TITLE
refactor(daemon): extract overlay interim stabilizer (#58)

### DIFF
--- a/parakeet-stt-daemon/check_model_lib/cli.py
+++ b/parakeet-stt-daemon/check_model_lib/cli.py
@@ -6,12 +6,6 @@ import argparse
 import tempfile
 from pathlib import Path
 
-from parakeet_stt_daemon.model import (
-    DEFAULT_MODEL_NAME,
-    ParakeetTranscriber,
-    load_parakeet_model,
-)
-
 from check_model_lib.constants import (
     BENCH_AUDIO_DIR,
     DEFAULT_BASELINE_OUTPUT,
@@ -27,6 +21,11 @@ from check_model_lib.constants import (
 )
 from check_model_lib.runner import run_offline_benchmark, run_streaming_probe
 from check_model_lib.runtime import generate_sine, write_wav
+from parakeet_stt_daemon.model import (
+    DEFAULT_MODEL_NAME,
+    ParakeetTranscriber,
+    load_parakeet_model,
+)
 
 
 def _apply_profile_defaults(args: argparse.Namespace) -> None:

--- a/parakeet-stt-daemon/check_model_lib/runner.py
+++ b/parakeet-stt-daemon/check_model_lib/runner.py
@@ -9,11 +9,6 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
-from parakeet_stt_daemon.model import (
-    ParakeetStreamingTranscriber,
-    ParakeetTranscriber,
-    load_parakeet_model,
-)
 
 from check_model_lib.constants import (
     DEFAULT_BASELINE_OUTPUT,
@@ -50,6 +45,11 @@ from check_model_lib.runtime import (
     split_chunks,
 )
 from check_model_lib.thresholds import evaluate_regression_thresholds
+from parakeet_stt_daemon.model import (
+    ParakeetStreamingTranscriber,
+    ParakeetTranscriber,
+    load_parakeet_model,
+)
 
 
 def _run_benchmark_once(

--- a/parakeet-stt-daemon/check_model_lib/runtime.py
+++ b/parakeet-stt-daemon/check_model_lib/runtime.py
@@ -8,9 +8,9 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
-from parakeet_stt_daemon.model import ParakeetStreamingTranscriber
 
 from check_model_lib.constants import SAMPLE_RATE
+from parakeet_stt_daemon.model import ParakeetStreamingTranscriber
 
 
 def _read_wav_samples(path: Path) -> tuple[np.ndarray, int]:

--- a/parakeet-stt-daemon/pyproject.toml
+++ b/parakeet-stt-daemon/pyproject.toml
@@ -58,6 +58,9 @@ extend-exclude = [".venv", ".uv"]
 [tool.ruff.lint]
 select = ["E", "F", "I", "B", "W", "UP", "BLE"]
 
+[tool.ruff.lint.isort]
+known-first-party = ["parakeet_stt_daemon"]
+
 [tool.deptry]
 known_first_party = ["parakeet_stt_daemon"]
 

--- a/parakeet-stt-daemon/src/parakeet_stt_daemon/overlay_interim.py
+++ b/parakeet-stt-daemon/src/parakeet_stt_daemon/overlay_interim.py
@@ -1,0 +1,243 @@
+"""Stabilize Overlay interim text from the Stream path and Seal path.
+
+The Daemon feeds raw Stream path and stop-replay Seal path candidates into this
+module during one Session. The module owns the mutable Overlay transcript tail,
+source sequence counters, overlap reconciliation, pending-tail flush behavior,
+and debug logging for interim text decisions.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from uuid import UUID
+
+import numpy as np
+from loguru import logger
+
+
+@dataclass(frozen=True)
+class OverlayInterimTranscriptContext:
+    session_id: UUID
+    context_samples: int
+    sample_rate: int
+
+
+@dataclass(frozen=True)
+class StabilizedInterimText:
+    text: str
+
+
+@dataclass
+class _OverlayInterimTranscriptState:
+    committed_tokens: list[str] = field(default_factory=list)
+    draft_tokens: list[str] = field(default_factory=list)
+
+
+class OverlayInterimTranscriptStabilizer:
+    """Reconcile one Session's Overlay interim text across Stream and Seal paths."""
+
+    def __init__(self) -> None:
+        self._state = _OverlayInterimTranscriptState()
+        self._source_seq_by_source: dict[str, int] = {}
+
+    def next_source_seq(self, source: str) -> int:
+        current = int(self._source_seq_by_source.get(source, 0))
+        self._source_seq_by_source[source] = current + 1
+        return current
+
+    def accept(
+        self,
+        source: str,
+        source_seq: int,
+        text: str,
+        context: OverlayInterimTranscriptContext,
+    ) -> StabilizedInterimText | None:
+        current_next = int(self._source_seq_by_source.get(source, 0))
+        self._source_seq_by_source[source] = max(current_next, source_seq + 1)
+
+        committed_before = [*self._state.committed_tokens]
+        draft_before = [*self._state.draft_tokens]
+        previous_display_tokens = [*committed_before, *draft_before]
+        previous_display = " ".join(previous_display_tokens)
+        normalized = " ".join(text.split()).strip()
+        if not normalized:
+            self._log_event(
+                context,
+                source=source,
+                source_seq=source_seq,
+                raw_text=text,
+                normalized_text=normalized,
+                previous_display=previous_display,
+                committed_before=committed_before,
+                draft_before=draft_before,
+                raw_tokens=[],
+                overlap=0,
+                committed_after=committed_before,
+                draft_after=draft_before,
+                current_display=previous_display,
+                action="empty",
+            )
+            return None
+
+        raw_tokens = normalized.split()
+        overlap = _longest_casefold_suffix_prefix_overlap(previous_display_tokens, raw_tokens)
+
+        if overlap > 0:
+            self._state.committed_tokens = previous_display_tokens[:-overlap]
+        self._state.draft_tokens = raw_tokens
+
+        committed_after = [*self._state.committed_tokens]
+        draft_after = [*self._state.draft_tokens]
+        current_display = " ".join([*committed_after, *draft_after])
+        action = "emit"
+        if current_display == previous_display:
+            action = "no_change"
+            self._log_event(
+                context,
+                source=source,
+                source_seq=source_seq,
+                raw_text=text,
+                normalized_text=normalized,
+                previous_display=previous_display,
+                committed_before=committed_before,
+                draft_before=draft_before,
+                raw_tokens=raw_tokens,
+                overlap=overlap,
+                committed_after=committed_after,
+                draft_after=draft_after,
+                current_display=current_display,
+                action=action,
+            )
+            return None
+
+        self._log_event(
+            context,
+            source=source,
+            source_seq=source_seq,
+            raw_text=text,
+            normalized_text=normalized,
+            previous_display=previous_display,
+            committed_before=committed_before,
+            draft_before=draft_before,
+            raw_tokens=raw_tokens,
+            overlap=overlap,
+            committed_after=committed_after,
+            draft_after=draft_after,
+            current_display=current_display,
+            action=action,
+        )
+        return StabilizedInterimText(current_display)
+
+    def flush_pending_tail(self) -> StabilizedInterimText | None:
+        display_tokens = [*self._state.committed_tokens, *self._state.draft_tokens]
+        if not display_tokens:
+            return None
+        return StabilizedInterimText(" ".join(display_tokens))
+
+    def record_skip(
+        self,
+        source: str,
+        source_seq: int,
+        context: OverlayInterimTranscriptContext,
+        *,
+        reason: str,
+        error_class: str | None = None,
+    ) -> None:
+        if not _streaming_debug_enabled():
+            return
+        context_secs = (
+            context.context_samples / context.sample_rate if context.sample_rate > 0 else 0.0
+        )
+        logger.info(
+            (
+                "overlay_stabilizer_skip session_id={} source={} source_seq={} "
+                "context_samples={} context_secs={:.3f} reason={} error_class={}"
+            ),
+            context.session_id,
+            source,
+            source_seq,
+            context.context_samples,
+            context_secs,
+            reason,
+            error_class,
+        )
+
+    def _log_event(
+        self,
+        context: OverlayInterimTranscriptContext,
+        *,
+        source: str,
+        source_seq: int,
+        raw_text: str,
+        normalized_text: str,
+        previous_display: str,
+        committed_before: list[str],
+        draft_before: list[str],
+        raw_tokens: list[str],
+        overlap: int,
+        committed_after: list[str],
+        draft_after: list[str],
+        current_display: str,
+        action: str,
+    ) -> None:
+        if not _streaming_debug_enabled():
+            return
+        context_secs = (
+            context.context_samples / context.sample_rate if context.sample_rate > 0 else 0.0
+        )
+        logger.info(
+            (
+                "overlay_stabilizer session_id={} source={} source_seq={} context_samples={} "
+                "context_secs={:.3f} action={} raw_text={} normalized_text={} "
+                "previous_display={} committed_before={} draft_before={} raw_tokens={} "
+                "overlap={} committed_after={} draft_after={} current_display={}"
+            ),
+            context.session_id,
+            source,
+            source_seq,
+            context.context_samples,
+            context_secs,
+            action,
+            json.dumps(raw_text, ensure_ascii=True),
+            json.dumps(normalized_text, ensure_ascii=True),
+            json.dumps(previous_display, ensure_ascii=True),
+            json.dumps(committed_before, ensure_ascii=True),
+            json.dumps(draft_before, ensure_ascii=True),
+            json.dumps(raw_tokens, ensure_ascii=True),
+            overlap,
+            json.dumps(committed_after, ensure_ascii=True),
+            json.dumps(draft_after, ensure_ascii=True),
+            json.dumps(current_display, ensure_ascii=True),
+        )
+
+
+def append_overlay_interim_context(existing: np.ndarray, chunk_audio: np.ndarray) -> np.ndarray:
+    if existing.size == 0:
+        return np.array(chunk_audio, copy=True)
+    return np.concatenate((existing, chunk_audio))
+
+
+def _streaming_debug_enabled() -> bool:
+    raw = os.getenv("PARAKEET_STREAMING_DEBUG", "")
+    return raw.strip().casefold() in {"1", "true", "yes", "on"}
+
+
+def _longest_casefold_suffix_prefix_overlap(existing: list[str], current: list[str]) -> int:
+    max_overlap = min(len(existing), len(current))
+    for overlap in range(max_overlap, 0, -1):
+        if all(
+            existing[len(existing) - overlap + index].casefold() == current[index].casefold()
+            for index in range(overlap)
+        ):
+            return overlap
+    return 0
+
+
+__all__ = [
+    "OverlayInterimTranscriptContext",
+    "OverlayInterimTranscriptStabilizer",
+    "StabilizedInterimText",
+    "append_overlay_interim_context",
+]

--- a/parakeet-stt-daemon/src/parakeet_stt_daemon/server.py
+++ b/parakeet-stt-daemon/src/parakeet_stt_daemon/server.py
@@ -3,12 +3,9 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import math
-import os
 import time
 from contextlib import asynccontextmanager
-from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from functools import partial
 from typing import Literal
@@ -47,6 +44,11 @@ from .model import (
     _release_cuda_cache,
     load_parakeet_model,
 )
+from .overlay_interim import (
+    OverlayInterimTranscriptContext,
+    OverlayInterimTranscriptStabilizer,
+    append_overlay_interim_context,
+)
 from .session import Session, SessionBusyError, SessionManager, SessionNotFoundError, SessionState
 
 ErrorCode = Literal[
@@ -62,28 +64,6 @@ OVERLAY_SESSION_STATE_CACHE_LIMIT = 128
 SESSION_GUARD_POLL_SECS = 0.1
 SESSION_GUARD_WARNING_FRACTION = 0.8  # emit warning at 80% of limit
 _REAL_ASYNCIO_SLEEP = asyncio.sleep
-
-
-@dataclass
-class OverlayInterimTranscriptState:
-    committed_tokens: list[str] = field(default_factory=list)
-    draft_tokens: list[str] = field(default_factory=list)
-
-
-def _streaming_debug_enabled() -> bool:
-    raw = os.getenv("PARAKEET_STREAMING_DEBUG", "")
-    return raw.strip().casefold() in {"1", "true", "yes", "on"}
-
-
-def _longest_casefold_suffix_prefix_overlap(existing: list[str], current: list[str]) -> int:
-    max_overlap = min(len(existing), len(current))
-    for overlap in range(max_overlap, 0, -1):
-        if all(
-            existing[len(existing) - overlap + index].casefold() == current[index].casefold()
-            for index in range(overlap)
-        ):
-            return overlap
-    return 0
 
 
 class DaemonServer:
@@ -148,8 +128,9 @@ class DaemonServer:
             self.audio.configure_stream_chunk_size(chunk_samples)
         self._overlay_event_seq_by_session: dict[UUID, int] = {}
         self._overlay_last_interim_text_by_session: dict[UUID, str] = {}
-        self._overlay_interim_transcript_by_session: dict[UUID, OverlayInterimTranscriptState] = {}
-        self._overlay_interim_source_seq_by_session: dict[UUID, dict[str, int]] = {}
+        self._overlay_interim_stabilizer_by_session: dict[
+            UUID, OverlayInterimTranscriptStabilizer
+        ] = {}
         self._overlay_state_by_session: dict[UUID, str] = {}
         self._overlay_events_emitted = 0
         self._overlay_events_dropped = 0
@@ -348,9 +329,11 @@ class DaemonServer:
                     session.session_id,
                     ready_chunks,
                 )
-                flushed_interim = self._flush_overlay_interim_pending_tail(session.session_id)
+                flushed_interim = self._overlay_interim_stabilizer(
+                    session.session_id
+                ).flush_pending_tail()
                 if flushed_interim is not None:
-                    interim_updates.append(flushed_interim)
+                    interim_updates.append(flushed_interim.text)
                 if interim_updates:
                     await self._emit_interim_state(
                         websocket,
@@ -672,15 +655,6 @@ class DaemonServer:
     def _owner_token_for_websocket(self, websocket: WebSocket) -> int:
         return id(websocket)
 
-    @staticmethod
-    def _append_overlay_interim_context(
-        existing: np.ndarray,
-        chunk_audio: np.ndarray,
-    ) -> np.ndarray:
-        if existing.size == 0:
-            return np.array(chunk_audio, copy=True)
-        return np.concatenate((existing, chunk_audio))
-
     async def _send_error(
         self, websocket: WebSocket, session_id: UUID | None, code: ErrorCode, message: str
     ) -> None:
@@ -763,12 +737,34 @@ class DaemonServer:
         overlay_last_text = getattr(self, "_overlay_last_interim_text_by_session", None)
         if isinstance(overlay_last_text, dict):
             overlay_last_text.pop(session_id, None)
-        overlay_transcripts = getattr(self, "_overlay_interim_transcript_by_session", None)
-        if isinstance(overlay_transcripts, dict):
-            overlay_transcripts.pop(session_id, None)
-        overlay_source_seqs = getattr(self, "_overlay_interim_source_seq_by_session", None)
-        if isinstance(overlay_source_seqs, dict):
-            overlay_source_seqs.pop(session_id, None)
+        overlay_stabilizers = getattr(self, "_overlay_interim_stabilizer_by_session", None)
+        if isinstance(overlay_stabilizers, dict):
+            overlay_stabilizers.pop(session_id, None)
+
+    def _overlay_interim_stabilizer(
+        self,
+        session_id: UUID,
+    ) -> OverlayInterimTranscriptStabilizer:
+        overlay_stabilizers = getattr(self, "_overlay_interim_stabilizer_by_session", None)
+        if not isinstance(overlay_stabilizers, dict):
+            overlay_stabilizers = {}
+            self._overlay_interim_stabilizer_by_session = overlay_stabilizers
+        stabilizer = overlay_stabilizers.get(session_id)
+        if stabilizer is None:
+            stabilizer = OverlayInterimTranscriptStabilizer()
+            overlay_stabilizers[session_id] = stabilizer
+        return stabilizer
+
+    def _overlay_interim_context(
+        self,
+        session_id: UUID,
+        context_samples: int,
+    ) -> OverlayInterimTranscriptContext:
+        return OverlayInterimTranscriptContext(
+            session_id=session_id,
+            context_samples=context_samples,
+            sample_rate=int(self.audio.sample_rate),
+        )
 
     def _next_overlay_seq(self, session_id: UUID) -> int:
         overlay_seq_by_session = getattr(self, "_overlay_event_seq_by_session", None)
@@ -847,212 +843,6 @@ class DaemonServer:
         message = AudioLevelMessage(session_id=session_id, level_db=level_db)
         await self._send_overlay_message(websocket, session_id, message.model_dump(mode="json"))
 
-    def _overlay_interim_transcript_state(
-        self,
-        session_id: UUID,
-    ) -> OverlayInterimTranscriptState:
-        overlay_transcripts = getattr(self, "_overlay_interim_transcript_by_session", None)
-        if not isinstance(overlay_transcripts, dict):
-            overlay_transcripts = {}
-            self._overlay_interim_transcript_by_session = overlay_transcripts
-        state = overlay_transcripts.get(session_id)
-        if state is None:
-            state = OverlayInterimTranscriptState()
-            overlay_transcripts[session_id] = state
-        return state
-
-    def _overlay_interim_display_tokens(self, session_id: UUID) -> list[str]:
-        state = self._overlay_interim_transcript_state(session_id)
-        return [*state.committed_tokens, *state.draft_tokens]
-
-    def _overlay_interim_display_text(self, session_id: UUID) -> str | None:
-        display_tokens = self._overlay_interim_display_tokens(session_id)
-        if not display_tokens:
-            return None
-        return " ".join(display_tokens)
-
-    def _overlay_stabilizer_debug_enabled(self) -> bool:
-        return self.settings.overlay_events_enabled and _streaming_debug_enabled()
-
-    def _next_overlay_interim_source_seq(self, session_id: UUID, source: str) -> int:
-        source_seqs = getattr(self, "_overlay_interim_source_seq_by_session", None)
-        if not isinstance(source_seqs, dict):
-            source_seqs = {}
-            self._overlay_interim_source_seq_by_session = source_seqs
-        session_seqs = source_seqs.get(session_id)
-        if not isinstance(session_seqs, dict):
-            session_seqs = {}
-            source_seqs[session_id] = session_seqs
-        current = int(session_seqs.get(source, 0))
-        session_seqs[source] = current + 1
-        return current
-
-    def _log_overlay_stabilizer_event(
-        self,
-        session_id: UUID,
-        *,
-        source: str,
-        source_seq: int,
-        context_samples: int,
-        raw_text: str,
-        normalized_text: str,
-        previous_display: str,
-        committed_before: list[str],
-        draft_before: list[str],
-        raw_tokens: list[str],
-        overlap: int,
-        committed_after: list[str],
-        draft_after: list[str],
-        current_display: str,
-        action: str,
-    ) -> None:
-        if not self._overlay_stabilizer_debug_enabled():
-            return
-        context_secs = (
-            context_samples / self.audio.sample_rate if self.audio.sample_rate > 0 else 0.0
-        )
-        logger.info(
-            (
-                "overlay_stabilizer session_id={} source={} source_seq={} context_samples={} "
-                "context_secs={:.3f} action={} raw_text={} normalized_text={} "
-                "previous_display={} committed_before={} draft_before={} raw_tokens={} "
-                "overlap={} committed_after={} draft_after={} current_display={}"
-            ),
-            session_id,
-            source,
-            source_seq,
-            context_samples,
-            context_secs,
-            action,
-            json.dumps(raw_text, ensure_ascii=True),
-            json.dumps(normalized_text, ensure_ascii=True),
-            json.dumps(previous_display, ensure_ascii=True),
-            json.dumps(committed_before, ensure_ascii=True),
-            json.dumps(draft_before, ensure_ascii=True),
-            json.dumps(raw_tokens, ensure_ascii=True),
-            overlap,
-            json.dumps(committed_after, ensure_ascii=True),
-            json.dumps(draft_after, ensure_ascii=True),
-            json.dumps(current_display, ensure_ascii=True),
-        )
-
-    def _log_overlay_stabilizer_skip(
-        self,
-        session_id: UUID,
-        *,
-        source: str,
-        source_seq: int,
-        context_samples: int,
-        reason: str,
-        error_class: str | None = None,
-    ) -> None:
-        if not self._overlay_stabilizer_debug_enabled():
-            return
-        context_secs = (
-            context_samples / self.audio.sample_rate if self.audio.sample_rate > 0 else 0.0
-        )
-        logger.info(
-            (
-                "overlay_stabilizer_skip session_id={} source={} source_seq={} "
-                "context_samples={} context_secs={:.3f} reason={} error_class={}"
-            ),
-            session_id,
-            source,
-            source_seq,
-            context_samples,
-            context_secs,
-            reason,
-            error_class,
-        )
-
-    def _stabilize_overlay_interim_text(
-        self,
-        session_id: UUID,
-        text: str,
-        *,
-        source: str,
-        source_seq: int,
-        context_samples: int,
-    ) -> str | None:
-        state = self._overlay_interim_transcript_state(session_id)
-        committed_before = [*state.committed_tokens]
-        draft_before = [*state.draft_tokens]
-        previous_display_tokens = [*committed_before, *draft_before]
-        previous_display = " ".join(previous_display_tokens)
-        normalized = " ".join(text.split()).strip()
-        if not normalized:
-            self._log_overlay_stabilizer_event(
-                session_id,
-                source=source,
-                source_seq=source_seq,
-                context_samples=context_samples,
-                raw_text=text,
-                normalized_text=normalized,
-                previous_display=previous_display,
-                committed_before=committed_before,
-                draft_before=draft_before,
-                raw_tokens=[],
-                overlap=0,
-                committed_after=committed_before,
-                draft_after=draft_before,
-                current_display=previous_display,
-                action="empty",
-            )
-            return None
-
-        raw_tokens = normalized.split()
-        overlap = _longest_casefold_suffix_prefix_overlap(previous_display_tokens, raw_tokens)
-
-        if overlap > 0:
-            state.committed_tokens = previous_display_tokens[:-overlap]
-        state.draft_tokens = raw_tokens
-
-        committed_after = [*state.committed_tokens]
-        draft_after = [*state.draft_tokens]
-        current_display = " ".join([*committed_after, *draft_after])
-        action = "emit"
-        if current_display == previous_display:
-            action = "no_change"
-            self._log_overlay_stabilizer_event(
-                session_id,
-                source=source,
-                source_seq=source_seq,
-                context_samples=context_samples,
-                raw_text=text,
-                normalized_text=normalized,
-                previous_display=previous_display,
-                committed_before=committed_before,
-                draft_before=draft_before,
-                raw_tokens=raw_tokens,
-                overlap=overlap,
-                committed_after=committed_after,
-                draft_after=draft_after,
-                current_display=current_display,
-                action=action,
-            )
-            return None
-        self._log_overlay_stabilizer_event(
-            session_id,
-            source=source,
-            source_seq=source_seq,
-            context_samples=context_samples,
-            raw_text=text,
-            normalized_text=normalized,
-            previous_display=previous_display,
-            committed_before=committed_before,
-            draft_before=draft_before,
-            raw_tokens=raw_tokens,
-            overlap=overlap,
-            committed_after=committed_after,
-            draft_after=draft_after,
-            current_display=current_display,
-            action=action,
-        )
-        return current_display
-
-    def _flush_overlay_interim_pending_tail(self, session_id: UUID) -> str | None:
-        return self._overlay_interim_display_text(session_id)
-
     async def _collect_interim_text_updates(
         self,
         session_id: UUID,
@@ -1070,8 +860,10 @@ class DaemonServer:
             chunk_audio = np.asarray(chunk, dtype=np.float32).reshape(-1)
             if chunk_audio.size == 0:
                 continue
-            rolling_audio = self._append_overlay_interim_context(rolling_audio, chunk_audio)
-            source_seq = self._next_overlay_interim_source_seq(session_id, "stop_replay")
+            rolling_audio = append_overlay_interim_context(rolling_audio, chunk_audio)
+            stabilizer = self._overlay_interim_stabilizer(session_id)
+            source_seq = stabilizer.next_source_seq("stop_replay")
+            context = self._overlay_interim_context(session_id, int(rolling_audio.size))
             try:
                 candidate = await self._transcribe_samples_serialized(rolling_audio)
             except Exception as exc:  # noqa: BLE001
@@ -1079,24 +871,22 @@ class DaemonServer:
                     "Incremental interim source unavailable for this session: {}",
                     exc.__class__.__name__,
                 )
-                self._log_overlay_stabilizer_skip(
-                    session_id,
+                stabilizer.record_skip(
                     source="stop_replay",
                     source_seq=source_seq,
-                    context_samples=int(rolling_audio.size),
+                    context=context,
                     reason="transcribe_error",
                     error_class=exc.__class__.__name__,
                 )
                 break
-            stabilized = self._stabilize_overlay_interim_text(
-                session_id,
+            stabilized = stabilizer.accept(
+                "stop_replay",
+                source_seq,
                 candidate,
-                source="stop_replay",
-                source_seq=source_seq,
-                context_samples=int(rolling_audio.size),
+                context,
             )
             if stabilized is not None:
-                updates.append(stabilized)
+                updates.append(stabilized.text)
         return updates
 
     async def _emit_interim_text(
@@ -1188,11 +978,13 @@ class DaemonServer:
         chunk_audio = np.asarray(chunk, dtype=np.float32).reshape(-1)
         if chunk_audio.size == 0:
             return
-        self._live_interim_audio = self._append_overlay_interim_context(
+        self._live_interim_audio = append_overlay_interim_context(
             self._live_interim_audio,
             chunk_audio,
         )
-        source_seq = self._next_overlay_interim_source_seq(session_id, "live")
+        stabilizer = self._overlay_interim_stabilizer(session_id)
+        source_seq = stabilizer.next_source_seq("live")
+        context = self._overlay_interim_context(session_id, int(self._live_interim_audio.size))
         try:
             candidate = await self._transcribe_samples_serialized(self._live_interim_audio)
         except Exception as exc:  # noqa: BLE001
@@ -1200,25 +992,23 @@ class DaemonServer:
                 "Live incremental interim source unavailable for this session: {}",
                 exc.__class__.__name__,
             )
-            self._log_overlay_stabilizer_skip(
-                session_id,
+            stabilizer.record_skip(
                 source="live",
                 source_seq=source_seq,
-                context_samples=int(self._live_interim_audio.size),
+                context=context,
                 reason="transcribe_error",
                 error_class=exc.__class__.__name__,
             )
             self._live_interim_failed = True
             return
-        stabilized = self._stabilize_overlay_interim_text(
-            session_id,
+        stabilized = stabilizer.accept(
+            "live",
+            source_seq,
             candidate,
-            source="live",
-            source_seq=source_seq,
-            context_samples=int(self._live_interim_audio.size),
+            context,
         )
         if stabilized is not None:
-            await self._emit_interim_text(websocket, session_id, text=stabilized)
+            await self._emit_interim_text(websocket, session_id, text=stabilized.text)
 
     def status(self) -> StatusMessage:
         active = self.sessions.active

--- a/parakeet-stt-daemon/tests/test_messages.py
+++ b/parakeet-stt-daemon/tests/test_messages.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from uuid import uuid4
 
 import pytest
+from pydantic import ValidationError
+
 from parakeet_stt_daemon.messages import (
     InterimStateMessage,
     InterimStateValue,
@@ -12,7 +14,6 @@ from parakeet_stt_daemon.messages import (
     StatusMessage,
 )
 from parakeet_stt_daemon.session import SessionState
-from pydantic import ValidationError
 
 
 def test_interim_text_requires_text_field() -> None:

--- a/parakeet-stt-daemon/tests/test_offline_in_memory_transcription.py
+++ b/parakeet-stt-daemon/tests/test_offline_in_memory_transcription.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 from typing import Any, cast
 
 import numpy as np
+
 from parakeet_stt_daemon import server as server_module
 from parakeet_stt_daemon.config import ServerSettings
 from parakeet_stt_daemon.model import ParakeetTranscriber

--- a/parakeet-stt-daemon/tests/test_overlay_event_stream.py
+++ b/parakeet-stt-daemon/tests/test_overlay_event_stream.py
@@ -12,6 +12,7 @@ from uuid import UUID, uuid4
 
 import numpy as np
 from loguru import logger
+
 from parakeet_stt_daemon import server as server_module
 from parakeet_stt_daemon.config import ServerSettings
 from parakeet_stt_daemon.messages import (
@@ -172,8 +173,7 @@ def _build_server(
     server._live_interim_failed = False
     server._overlay_event_seq_by_session = {}
     server._overlay_last_interim_text_by_session = {}
-    server._overlay_interim_transcript_by_session = {}
-    server._overlay_interim_source_seq_by_session = {}
+    server._overlay_interim_stabilizer_by_session = {}
     server._overlay_state_by_session = {}
     server._overlay_events_emitted = 0
     server._overlay_events_dropped = 0
@@ -1056,8 +1056,6 @@ def test_phase6_daemon_reconnect_contract_recovers_with_fresh_session(monkeypatc
         )
         assert cleaned is True
         assert server.sessions.active is None
-        assert server._overlay_interim_transcript_by_session == {}
-
         await server._handle_start(cast(Any, second_socket), _start_message(second_session))
         await server._handle_stop(cast(Any, second_socket), _stop_message(second_session))
 

--- a/parakeet-stt-daemon/tests/test_overlay_interim_stabilizer.py
+++ b/parakeet-stt-daemon/tests/test_overlay_interim_stabilizer.py
@@ -1,0 +1,121 @@
+"""Direct tests for Overlay interim transcript stabilization."""
+
+from __future__ import annotations
+
+import io
+from contextlib import contextmanager
+from typing import Any
+from uuid import uuid4
+
+from loguru import logger
+
+from parakeet_stt_daemon.overlay_interim import (
+    OverlayInterimTranscriptContext,
+    OverlayInterimTranscriptStabilizer,
+    StabilizedInterimText,
+)
+
+
+def _context() -> OverlayInterimTranscriptContext:
+    return OverlayInterimTranscriptContext(
+        session_id=uuid4(),
+        context_samples=16_000,
+        sample_rate=16_000,
+    )
+
+
+def _text(stabilized: StabilizedInterimText | None) -> str | None:
+    return stabilized.text if stabilized is not None else None
+
+
+@contextmanager
+def _capture_loguru_messages() -> Any:
+    buffer = io.StringIO()
+    handler_id = logger.add(buffer, format="{message}")
+    try:
+        yield buffer
+    finally:
+        logger.remove(handler_id)
+
+
+def test_live_updates_extend_prior_overlay_text() -> None:
+    stabilizer = OverlayInterimTranscriptStabilizer()
+    context = _context()
+
+    assert _text(stabilizer.accept("live", 0, "hello", context)) == "hello"
+    assert _text(stabilizer.accept("live", 1, "hello world", context)) == "hello world"
+
+
+def test_stream_path_and_seal_path_overlap_is_reconciled() -> None:
+    stabilizer = OverlayInterimTranscriptStabilizer()
+    context = _context()
+
+    assert _text(stabilizer.accept("live", 0, "alpha beta", context)) == "alpha beta"
+    assert _text(stabilizer.accept("stop_replay", 0, "beta gamma", context)) == "alpha beta gamma"
+
+
+def test_empty_duplicate_and_no_change_inputs_are_suppressed() -> None:
+    stabilizer = OverlayInterimTranscriptStabilizer()
+    context = _context()
+
+    assert stabilizer.accept("live", 0, "   ", context) is None
+    assert _text(stabilizer.accept("live", 1, " hello   world ", context)) == "hello world"
+    assert stabilizer.accept("live", 2, "hello world", context) is None
+
+
+def test_pending_tail_flush_returns_current_overlay_text() -> None:
+    stabilizer = OverlayInterimTranscriptStabilizer()
+    context = _context()
+
+    assert stabilizer.flush_pending_tail() is None
+    stabilizer.accept("live", 0, "phase one", context)
+
+    assert _text(stabilizer.flush_pending_tail()) == "phase one"
+
+
+def test_source_sequence_tracking_is_per_source() -> None:
+    stabilizer = OverlayInterimTranscriptStabilizer()
+
+    assert stabilizer.next_source_seq("live") == 0
+    assert stabilizer.next_source_seq("live") == 1
+    assert stabilizer.next_source_seq("stop_replay") == 0
+
+
+def test_debug_log_emits_stabilizer_decisions_when_streaming_debug_enabled(monkeypatch) -> None:
+    monkeypatch.setenv("PARAKEET_STREAMING_DEBUG", "1")
+    stabilizer = OverlayInterimTranscriptStabilizer()
+    context = _context()
+
+    with _capture_loguru_messages() as log_output:
+        stabilizer.accept("live", 0, "alpha beta", context)
+        stabilizer.accept("live", 1, "beta gamma", context)
+
+    messages = log_output.getvalue()
+    assert "overlay_stabilizer" in messages
+    assert f"session_id={context.session_id}" in messages
+    assert "source=live source_seq=0" in messages
+    assert "source=live source_seq=1" in messages
+    assert 'raw_text="beta gamma"' in messages
+    assert "overlap=1" in messages
+    assert 'current_display="alpha beta gamma"' in messages
+
+
+def test_debug_log_records_skipped_transcription_source(monkeypatch) -> None:
+    monkeypatch.setenv("PARAKEET_STREAMING_DEBUG", "yes")
+    stabilizer = OverlayInterimTranscriptStabilizer()
+    context = _context()
+
+    with _capture_loguru_messages() as log_output:
+        stabilizer.record_skip(
+            "stop_replay",
+            0,
+            context,
+            reason="transcribe_error",
+            error_class="RuntimeError",
+        )
+
+    messages = log_output.getvalue()
+    assert "overlay_stabilizer_skip" in messages
+    assert "source=stop_replay source_seq=0" in messages
+    assert "reason=transcribe_error" in messages
+    assert "error_class=RuntimeError" in messages

--- a/parakeet-stt-daemon/tests/test_session_cleanup.py
+++ b/parakeet-stt-daemon/tests/test_session_cleanup.py
@@ -9,6 +9,7 @@ from uuid import UUID, uuid4
 
 import numpy as np
 from fastapi import WebSocketDisconnect
+
 from parakeet_stt_daemon import server as server_module
 from parakeet_stt_daemon.audio import AudioInput
 from parakeet_stt_daemon.config import ServerSettings

--- a/parakeet-stt-daemon/tests/test_streaming_truth.py
+++ b/parakeet-stt-daemon/tests/test_streaming_truth.py
@@ -7,6 +7,7 @@ from typing import Any, cast
 from uuid import uuid4
 
 import numpy as np
+
 from parakeet_stt_daemon.config import ServerSettings
 from parakeet_stt_daemon.server import DaemonServer
 from parakeet_stt_daemon.session import SessionManager


### PR DESCRIPTION
## Summary

Refs #58.

Extracts `OverlayInterimTranscriptStabilizer` as a deep in-process module for Overlay interim text reconciliation across the Stream path and stop-replay Seal path. `DaemonServer` now acts as the adapter that feeds raw candidates into the stabilizer and emits the unchanged `interim_text` / `interim_state` WebSocket payloads.

`server.py` line count: 1558 -> 1348.

## Acceptance Evidence

- New module: `parakeet_stt_daemon.overlay_interim.OverlayInterimTranscriptStabilizer` owns token reconciliation, source-seq handling, pending-tail flush behavior, longest casefold suffix/prefix overlap, and debug logging.
- Removed from `DaemonServer`: `OverlayInterimTranscriptState`, `_overlay_interim_transcript_state`, `_overlay_interim_display_tokens`, `_overlay_interim_display_text`, `_stabilize_overlay_interim_text`, `_flush_overlay_interim_pending_tail`, `_next_overlay_interim_source_seq`, `_log_overlay_stabilizer_event`, `_log_overlay_stabilizer_skip`, `_append_overlay_interim_context`, `_longest_casefold_suffix_prefix_overlap`.
- Direct unit tests added in `parakeet-stt-daemon/tests/test_overlay_interim_stabilizer.py` for live extension, Stream path / Seal path overlap, empty/duplicate/no-change inputs, pending-tail flush, source sequence tracking, and debug logging when `PARAKEET_STREAMING_DEBUG` is set.
- The WebSocket-heavy assertion that inspected `DaemonServer._overlay_interim_transcript_by_session` after reconnect was deleted from `tests/test_overlay_event_stream.py`; the new direct unit tests cover stabilizer state cleanup/reconciliation behavior through the module interface instead of private DaemonServer internals.
- Surviving Overlay event WebSocket tests still validate `interim_text` / `interim_state` wire format and sequencing.
- Module docstring uses Daemon, Overlay, Stream path, Seal path, and Session vocabulary.

## Verification (#58)

- targeted: `cd parakeet-stt-daemon && uv run pytest tests/test_overlay_interim_stabilizer.py tests/test_overlay_event_stream.py -q` -> PASSED (33 passed)
- regression: N/A - refactor; direct interface coverage added for extracted behavior
- full suite: `cd parakeet-stt-daemon && uv run pytest -q` -> PASSED (136 passed)
- lint: `cd parakeet-stt-daemon && uv run ruff check src tests` -> PASSED
- format: `cd parakeet-stt-daemon && uv run ruff format --check src tests` -> PASSED
- types: `cd parakeet-stt-daemon && uv run ty check src` -> PASSED
- dead-code: N/A - no repo dead-code gate for this Python slice
- build: N/A - Python refactor, no package build artifact changed
- pre-commit: `prek run --all-files` -> PASSED
- pre-push: `git push -u origin issue-58-overlay-stabilizer` -> PASSED relevant hook path (`python pytest` passed; Rust hooks skipped because no Rust files changed)
- static/security: N/A - no security gate for this slice
- migrations: N/A
- CLI/script smoke: PASSED after user confirmed stable runtime was stopped. Dev helper was launched with `PARAKEET_ROOT=/home/hugo/Documents/Engineering/parakeet-stt-dev` on branch `issue-58-overlay-stabilizer`; daemon and Overlay renderer paths both resolved under the dev worktree. Two dictation sessions finalized and injected successfully: long session `50.31s` audio / `finalize_ms=206` / `text_len=620`, and second session `34.28s` audio / `finalize_ms=136` / `text_len=432`. User confirmed streaming text looked good and no stop-replay duplicate phrase was reported.
- UI render: PASS for #58 text reconciliation behavior. Residual existing Overlay renderer observations were tracked separately in #68: stale text visible when opening a frame and intermittent animation frame pacing/stagger.
- destructive/negative: N/A
- review: `coderabbit_review_watch.py gate --pr 66` -> PASSED; local review completed with 0 findings, remote check passed, no actionable PR feedback; summary at `.git/worktrees/parakeet-stt-dev/coderabbit-review/20260518T124626Z/gate-summary.json`
- tests added/expanded: `parakeet-stt-daemon/tests/test_overlay_interim_stabilizer.py`
- preexisting failures left: `prek run --stage pre-push --all-files` exposes unrelated Rust `clippy::collapsible_match` in `parakeet-ptt/src/overlay_renderer.rs:1819`; not part of this Python issue branch

## Residual Follow-up

- #68 tracks the existing stale Overlay text / frame pacing observations found during manual smoke. It is outside this PR's extracted text reconciliation interface.
