### PR TITLE
refactor(daemon): introduce SessionEvent/EventSink seam (#60)

### DIFF
--- a/parakeet-stt-daemon/src/parakeet_stt_daemon/events.py
+++ b/parakeet-stt-daemon/src/parakeet_stt_daemon/events.py
@@ -1,0 +1,321 @@
+"""Session event vocabulary for the Daemon, Session lifecycle, and Overlay adapters."""
+
+from __future__ import annotations
+
+import asyncio
+import math
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Literal, Protocol, TypeAlias
+from uuid import UUID
+
+from loguru import logger
+
+from .messages import (
+    AudioLevelMessage,
+    ErrorMessage,
+    FinalResult,
+    InterimStateMessage,
+    InterimStateValue,
+    InterimTextMessage,
+    SessionEndedMessage,
+    SessionEndReason,
+    SessionStarted,
+    SessionWarningMessage,
+)
+
+ErrorCode: TypeAlias = Literal[
+    "SESSION_BUSY",
+    "SESSION_NOT_FOUND",
+    "SESSION_ABORTED",
+    "AUDIO_DEVICE",
+    "MODEL",
+    "INVALID_REQUEST",
+    "UNEXPECTED",
+]
+
+
+class JsonWebSocket(Protocol):
+    async def send_json(self, data: dict[str, Any]) -> None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class SessionStartedEvent:
+    session_id: UUID
+    ts: datetime
+    mic_device: str | None
+    lang: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class InterimStateEvent:
+    session_id: UUID
+    state: InterimStateValue
+
+
+@dataclass(frozen=True, slots=True)
+class InterimTextEvent:
+    session_id: UUID
+    text: str
+
+
+@dataclass(frozen=True, slots=True)
+class AudioLevelEvent:
+    session_id: UUID
+    rms: float
+
+
+@dataclass(frozen=True, slots=True)
+class FinalResultEvent:
+    session_id: UUID
+    text: str
+    latency_ms: int
+    audio_ms: int
+    lang: str | None
+    confidence: float | None
+    tail_trim_mode: Literal["rms", "vad"] | None
+    vad_active: bool | None
+    vad_fallback_reason: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class SessionEndedEvent:
+    session_id: UUID
+    reason: SessionEndReason
+
+
+@dataclass(frozen=True, slots=True)
+class SessionWarningEvent:
+    session_id: UUID
+    remaining_seconds: float
+    limit_seconds: float
+    warning: Literal["approaching_limit"] = "approaching_limit"
+
+
+@dataclass(frozen=True, slots=True)
+class SessionErrorEvent:
+    session_id: UUID | None
+    code: ErrorCode
+    message: str
+
+
+SessionEvent: TypeAlias = (
+    SessionStartedEvent
+    | InterimStateEvent
+    | InterimTextEvent
+    | AudioLevelEvent
+    | FinalResultEvent
+    | SessionEndedEvent
+    | SessionWarningEvent
+    | SessionErrorEvent
+)
+
+
+class EventSink(Protocol):
+    async def emit(self, event: SessionEvent) -> None: ...
+
+
+@dataclass
+class RecordingEventSink:
+    events: list[SessionEvent] = field(default_factory=list)
+
+    async def emit(self, event: SessionEvent) -> None:
+        self.events.append(event)
+
+
+class WebSocketEventSink:
+    """Serialize Session events to the existing WebSocket protocol."""
+
+    def __init__(
+        self,
+        *,
+        websocket: JsonWebSocket,
+        send_lock: Callable[[], asyncio.Lock],
+        overlay_events_enabled: bool,
+        next_overlay_seq: Callable[[UUID], int],
+        overlay_session_state: Callable[[UUID], str | None],
+        set_overlay_session_state: Callable[[UUID, str], None],
+        last_interim_text: Callable[[UUID], str | None],
+        record_interim_text: Callable[[UUID, str], None],
+        clear_interim_text: Callable[[UUID], None],
+        increment_overlay_events_emitted: Callable[[], None],
+        increment_overlay_events_dropped: Callable[[], None],
+    ) -> None:
+        self._websocket = websocket
+        self._send_lock = send_lock
+        self._overlay_events_enabled = overlay_events_enabled
+        self._next_overlay_seq = next_overlay_seq
+        self._overlay_session_state = overlay_session_state
+        self._set_overlay_session_state = set_overlay_session_state
+        self._last_interim_text = last_interim_text
+        self._record_interim_text = record_interim_text
+        self._clear_interim_text = clear_interim_text
+        self._increment_overlay_events_emitted = increment_overlay_events_emitted
+        self._increment_overlay_events_dropped = increment_overlay_events_dropped
+
+    async def emit(self, event: SessionEvent) -> None:
+        if isinstance(event, SessionStartedEvent):
+            await self._emit_session_started(event)
+        elif isinstance(event, InterimStateEvent):
+            await self._emit_interim_state(event)
+        elif isinstance(event, InterimTextEvent):
+            await self._emit_interim_text(event)
+        elif isinstance(event, AudioLevelEvent):
+            await self._emit_audio_level(event)
+        elif isinstance(event, FinalResultEvent):
+            await self._emit_final_result(event)
+        elif isinstance(event, SessionEndedEvent):
+            await self._emit_session_ended(event)
+        elif isinstance(event, SessionWarningEvent):
+            await self._emit_session_warning(event)
+        elif isinstance(event, SessionErrorEvent):
+            await self._emit_session_error(event)
+
+    async def _send_direct(self, payload: dict[str, Any]) -> None:
+        async with self._send_lock():
+            await self._websocket.send_json(payload)
+
+    async def _send_overlay(
+        self,
+        session_id: UUID,
+        payload: dict[str, Any],
+        *,
+        allow_terminal: bool = False,
+        next_state: str | None = None,
+    ) -> bool:
+        if not self._overlay_events_enabled:
+            return False
+        try:
+            async with self._send_lock():
+                current_state = self._overlay_session_state(session_id)
+                if current_state == "ended" or (current_state == "terminal" and not allow_terminal):
+                    self._increment_overlay_events_dropped()
+                    logger.debug(
+                        "Dropping overlay event {} for session {} after terminal transition",
+                        payload.get("type"),
+                        session_id,
+                    )
+                    return False
+                await self._websocket.send_json(payload)
+            if next_state is not None:
+                self._set_overlay_session_state(session_id, next_state)
+            self._increment_overlay_events_emitted()
+            return True
+        except Exception as exc:  # noqa: BLE001
+            self._increment_overlay_events_dropped()
+            logger.debug("Dropping overlay event after send failure: {}", exc)
+            return False
+
+    async def _emit_session_started(self, event: SessionStartedEvent) -> None:
+        message = SessionStarted(
+            session_id=event.session_id,
+            ts=event.ts,
+            mic_device=event.mic_device,
+            lang=event.lang,
+        )
+        await self._send_direct(message.model_dump(mode="json"))
+
+    async def _emit_interim_state(self, event: InterimStateEvent) -> None:
+        if not self._overlay_events_enabled:
+            return
+        message = InterimStateMessage(
+            session_id=event.session_id,
+            seq=self._next_overlay_seq(event.session_id),
+            state=event.state,
+        )
+        await self._send_overlay(event.session_id, message.model_dump(mode="json"))
+
+    async def _emit_interim_text(self, event: InterimTextEvent) -> None:
+        if not self._overlay_events_enabled:
+            return
+        normalized = " ".join(event.text.split()).strip()
+        if not normalized:
+            return
+        if self._last_interim_text(event.session_id) == normalized:
+            return
+        message = InterimTextMessage(
+            session_id=event.session_id,
+            seq=self._next_overlay_seq(event.session_id),
+            text=normalized,
+        )
+        if await self._send_overlay(event.session_id, message.model_dump(mode="json")):
+            self._record_interim_text(event.session_id, normalized)
+
+    async def _emit_audio_level(self, event: AudioLevelEvent) -> None:
+        if not self._overlay_events_enabled:
+            return
+        if not math.isfinite(event.rms):
+            return
+        level_db = 20.0 * math.log10(max(event.rms, 1e-6))
+        if not math.isfinite(level_db):
+            return
+        message = AudioLevelMessage(session_id=event.session_id, level_db=level_db)
+        await self._send_overlay(event.session_id, message.model_dump(mode="json"))
+
+    async def _emit_final_result(self, event: FinalResultEvent) -> None:
+        message = FinalResult(
+            session_id=event.session_id,
+            text=event.text,
+            latency_ms=event.latency_ms,
+            audio_ms=event.audio_ms,
+            lang=event.lang,
+            confidence=event.confidence,
+        )
+        await self._send_direct(message.model_dump(mode="json"))
+
+    async def _emit_session_ended(self, event: SessionEndedEvent) -> None:
+        if not self._overlay_events_enabled:
+            self._clear_interim_text(event.session_id)
+            return
+        message = SessionEndedMessage(session_id=event.session_id, reason=event.reason)
+        await self._send_overlay(
+            event.session_id,
+            message.model_dump(mode="json"),
+            allow_terminal=True,
+            next_state="ended",
+        )
+        self._clear_interim_text(event.session_id)
+
+    async def _emit_session_warning(self, event: SessionWarningEvent) -> None:
+        logger.info(
+            "Session {} warning: {:.0f}s remaining of {:.0f}s limit",
+            event.session_id,
+            event.remaining_seconds,
+            event.limit_seconds,
+        )
+        message = SessionWarningMessage(
+            session_id=event.session_id,
+            warning=event.warning,
+            remaining_seconds=round(event.remaining_seconds, 1),
+            limit_seconds=event.limit_seconds,
+        )
+        try:
+            await self._send_direct(message.model_dump(mode="json"))
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Failed to send session warning for {}: {}", event.session_id, exc)
+
+    async def _emit_session_error(self, event: SessionErrorEvent) -> None:
+        message = ErrorMessage(
+            session_id=event.session_id,
+            code=event.code,
+            message=event.message,
+        )
+        await self._send_direct(message.model_dump(mode="json"))
+
+
+__all__ = [
+    "AudioLevelEvent",
+    "ErrorCode",
+    "EventSink",
+    "FinalResultEvent",
+    "InterimStateEvent",
+    "InterimTextEvent",
+    "RecordingEventSink",
+    "SessionEndedEvent",
+    "SessionErrorEvent",
+    "SessionEvent",
+    "SessionStartedEvent",
+    "SessionWarningEvent",
+    "WebSocketEventSink",
+]

--- a/parakeet-stt-daemon/src/parakeet_stt_daemon/server.py
+++ b/parakeet-stt-daemon/src/parakeet_stt_daemon/server.py
@@ -18,20 +18,24 @@ from loguru import logger
 
 from .audio import AudioInput
 from .config import ServerSettings
+from .events import (
+    AudioLevelEvent,
+    ErrorCode,
+    FinalResultEvent,
+    InterimStateEvent,
+    InterimTextEvent,
+    SessionEndedEvent,
+    SessionErrorEvent,
+    SessionStartedEvent,
+    SessionWarningEvent,
+    WebSocketEventSink,
+)
 from .messages import (
     AbortSession,
-    AudioLevelMessage,
     ClientMessageType,
-    ErrorMessage,
-    FinalResult,
-    InterimStateMessage,
     InterimStateValue,
-    InterimTextMessage,
     ParsedMessage,
-    SessionEndedMessage,
     SessionEndReason,
-    SessionStarted,
-    SessionWarningMessage,
     StartSession,
     StatusMessage,
     StopSession,
@@ -52,15 +56,6 @@ from .overlay_interim import (
 from .session import Session, SessionBusyError, SessionManager, SessionNotFoundError, SessionState
 from .tail_trim import SealPathTailTrimmer
 
-ErrorCode = Literal[
-    "SESSION_BUSY",
-    "SESSION_NOT_FOUND",
-    "SESSION_ABORTED",
-    "AUDIO_DEVICE",
-    "MODEL",
-    "INVALID_REQUEST",
-    "UNEXPECTED",
-]
 OVERLAY_SESSION_STATE_CACHE_LIMIT = 128
 SESSION_GUARD_POLL_SECS = 0.1
 SESSION_GUARD_WARNING_FRACTION = 0.8  # emit warning at 80% of limit
@@ -223,13 +218,14 @@ class DaemonServer:
                 self._start_stream_drain_loop(websocket, message.session_id)
             self._start_session_guard_loop(websocket, message.session_id)
 
-            response = SessionStarted(
-                session_id=message.session_id,
-                ts=datetime.now(tz=UTC),
-                mic_device=str(self.settings.mic_device) if self.settings.mic_device else None,
-                lang=message.preferred_lang,
+            await self._event_sink(websocket).emit(
+                SessionStartedEvent(
+                    session_id=message.session_id,
+                    ts=datetime.now(tz=UTC),
+                    mic_device=str(self.settings.mic_device) if self.settings.mic_device else None,
+                    lang=message.preferred_lang,
+                )
             )
-            await self._send_message(websocket, response.model_dump(mode="json"))
             await self._emit_interim_state(
                 websocket,
                 message.session_id,
@@ -373,17 +369,21 @@ class DaemonServer:
                 return
 
             latency_ms = int((datetime.now(tz=UTC) - session.last_updated).total_seconds() * 1000)
-            completion = FinalResult(
-                session_id=session.session_id,
-                text=text,
-                latency_ms=latency_ms,
-                audio_ms=audio_ms,
-                lang=self.settings.language,
-                confidence=None,
-            )
             self._set_overlay_session_state(session.session_id, "terminal")
             send_started = datetime.now(tz=UTC)
-            await self._send_message(websocket, completion.model_dump(mode="json"))
+            await self._event_sink(websocket).emit(
+                FinalResultEvent(
+                    session_id=session.session_id,
+                    text=text,
+                    latency_ms=latency_ms,
+                    audio_ms=audio_ms,
+                    lang=self.settings.language,
+                    confidence=None,
+                    tail_trim_mode=self._tail_trim_mode(),
+                    vad_active=self._vad_active(),
+                    vad_fallback_reason=self._vad_fallback_reason(),
+                )
+            )
             send_ms = int((datetime.now(tz=UTC) - send_started).total_seconds() * 1000)
             await self._emit_session_ended(
                 websocket, session.session_id, reason=SessionEndReason.FINAL
@@ -661,8 +661,9 @@ class DaemonServer:
     async def _send_error(
         self, websocket: WebSocket, session_id: UUID | None, code: ErrorCode, message: str
     ) -> None:
-        err = ErrorMessage(session_id=session_id, code=code, message=message)
-        await self._send_message(websocket, err.model_dump(mode="json"))
+        await self._event_sink(websocket).emit(
+            SessionErrorEvent(session_id=session_id, code=code, message=message)
+        )
 
     def _send_lock_for_websocket(self, websocket: WebSocket) -> asyncio.Lock:
         websocket_send_locks = getattr(self, "_websocket_send_locks", None)
@@ -675,9 +676,20 @@ class DaemonServer:
             websocket_send_locks[id(websocket)] = lock
         return lock
 
-    async def _send_message(self, websocket: WebSocket, payload: dict) -> None:
-        async with self._send_lock_for_websocket(websocket):
-            await websocket.send_json(payload)
+    def _event_sink(self, websocket: WebSocket) -> WebSocketEventSink:
+        return WebSocketEventSink(
+            websocket=websocket,
+            send_lock=lambda: self._send_lock_for_websocket(websocket),
+            overlay_events_enabled=self.settings.overlay_events_enabled,
+            next_overlay_seq=self._next_overlay_seq,
+            overlay_session_state=self._overlay_session_state,
+            set_overlay_session_state=self._set_overlay_session_state,
+            last_interim_text=self._overlay_last_interim_text,
+            record_interim_text=self._record_overlay_interim_text,
+            clear_interim_text=self._clear_overlay_interim_text,
+            increment_overlay_events_emitted=self._increment_overlay_events_emitted,
+            increment_overlay_events_dropped=self._increment_overlay_events_dropped,
+        )
 
     def _session_lock_for_runtime(self) -> asyncio.Lock:
         lock = getattr(self, "_session_lock", None)
@@ -737,12 +749,28 @@ class DaemonServer:
         overlay_seq_by_session = getattr(self, "_overlay_event_seq_by_session", None)
         if isinstance(overlay_seq_by_session, dict):
             overlay_seq_by_session.pop(session_id, None)
-        overlay_last_text = getattr(self, "_overlay_last_interim_text_by_session", None)
-        if isinstance(overlay_last_text, dict):
-            overlay_last_text.pop(session_id, None)
+        self._clear_overlay_interim_text(session_id)
         overlay_stabilizers = getattr(self, "_overlay_interim_stabilizer_by_session", None)
         if isinstance(overlay_stabilizers, dict):
             overlay_stabilizers.pop(session_id, None)
+
+    def _overlay_last_interim_text(self, session_id: UUID) -> str | None:
+        overlay_last_text = getattr(self, "_overlay_last_interim_text_by_session", None)
+        if not isinstance(overlay_last_text, dict):
+            return None
+        return overlay_last_text.get(session_id)
+
+    def _record_overlay_interim_text(self, session_id: UUID, text: str) -> None:
+        overlay_last_text = getattr(self, "_overlay_last_interim_text_by_session", None)
+        if not isinstance(overlay_last_text, dict):
+            overlay_last_text = {}
+            self._overlay_last_interim_text_by_session = overlay_last_text
+        overlay_last_text[session_id] = text
+
+    def _clear_overlay_interim_text(self, session_id: UUID) -> None:
+        overlay_last_text = getattr(self, "_overlay_last_interim_text_by_session", None)
+        if isinstance(overlay_last_text, dict):
+            overlay_last_text.pop(session_id, None)
 
     def _overlay_interim_stabilizer(
         self,
@@ -778,41 +806,11 @@ class DaemonServer:
         overlay_seq_by_session[session_id] = current + 1
         return current
 
-    async def _send_overlay_message(
-        self,
-        websocket: WebSocket,
-        session_id: UUID,
-        payload: dict,
-        *,
-        allow_terminal: bool = False,
-        next_state: str | None = None,
-    ) -> bool:
-        if not self.settings.overlay_events_enabled:
-            return False
-        try:
-            async with self._send_lock_for_websocket(websocket):
-                current_state = self._overlay_session_state(session_id)
-                if current_state == "ended" or (current_state == "terminal" and not allow_terminal):
-                    self._overlay_events_dropped = (
-                        int(getattr(self, "_overlay_events_dropped", 0)) + 1
-                    )
-                    logger.debug(
-                        "Dropping overlay event {} for session {} after terminal transition",
-                        payload.get("type"),
-                        session_id,
-                    )
-                    return False
-                await websocket.send_json(payload)
-            if next_state is not None:
-                self._set_overlay_session_state(session_id, next_state)
-            self._overlay_events_emitted = int(getattr(self, "_overlay_events_emitted", 0)) + 1
-            return True
-        except Exception as exc:  # noqa: BLE001
-            # Overlay events are display-only signals and must never break
-            # transcription/injection flow.
-            self._overlay_events_dropped = int(getattr(self, "_overlay_events_dropped", 0)) + 1
-            logger.debug("Dropping overlay event after send failure: {}", exc)
-            return False
+    def _increment_overlay_events_emitted(self) -> None:
+        self._overlay_events_emitted = int(getattr(self, "_overlay_events_emitted", 0)) + 1
+
+    def _increment_overlay_events_dropped(self) -> None:
+        self._overlay_events_dropped = int(getattr(self, "_overlay_events_dropped", 0)) + 1
 
     async def _emit_interim_state(
         self,
@@ -821,14 +819,9 @@ class DaemonServer:
         *,
         state: InterimStateValue,
     ) -> None:
-        if not self.settings.overlay_events_enabled:
-            return
-        message = InterimStateMessage(
-            session_id=session_id,
-            seq=self._next_overlay_seq(session_id),
-            state=state,
+        await self._event_sink(websocket).emit(
+            InterimStateEvent(session_id=session_id, state=state)
         )
-        await self._send_overlay_message(websocket, session_id, message.model_dump(mode="json"))
 
     async def _emit_audio_level(
         self,
@@ -836,15 +829,7 @@ class DaemonServer:
         session_id: UUID,
         rms: float,
     ) -> None:
-        if not self.settings.overlay_events_enabled:
-            return
-        if not np.isfinite(rms):
-            return
-        level_db = 20.0 * np.log10(max(rms, 1e-6))
-        if not np.isfinite(level_db):
-            return
-        message = AudioLevelMessage(session_id=session_id, level_db=level_db)
-        await self._send_overlay_message(websocket, session_id, message.model_dump(mode="json"))
+        await self._event_sink(websocket).emit(AudioLevelEvent(session_id=session_id, rms=rms))
 
     async def _collect_interim_text_updates(
         self,
@@ -899,26 +884,7 @@ class DaemonServer:
         *,
         text: str,
     ) -> None:
-        if not self.settings.overlay_events_enabled:
-            return
-        normalized = " ".join(text.split()).strip()
-        if not normalized:
-            return
-        last_by_session = getattr(self, "_overlay_last_interim_text_by_session", None)
-        if isinstance(last_by_session, dict):
-            prev = last_by_session.get(session_id)
-            if prev == normalized:
-                return
-        message = InterimTextMessage(
-            session_id=session_id,
-            seq=self._next_overlay_seq(session_id),
-            text=normalized,
-        )
-        if await self._send_overlay_message(websocket, session_id, message.model_dump(mode="json")):
-            if not isinstance(last_by_session, dict):
-                self._overlay_last_interim_text_by_session = {}
-                last_by_session = self._overlay_last_interim_text_by_session
-            last_by_session[session_id] = normalized
+        await self._event_sink(websocket).emit(InterimTextEvent(session_id=session_id, text=text))
 
     async def _emit_session_ended(
         self,
@@ -927,19 +893,9 @@ class DaemonServer:
         *,
         reason: SessionEndReason,
     ) -> None:
-        if not self.settings.overlay_events_enabled:
-            return
-        message = SessionEndedMessage(session_id=session_id, reason=reason)
-        await self._send_overlay_message(
-            websocket,
-            session_id,
-            message.model_dump(mode="json"),
-            allow_terminal=True,
-            next_state="ended",
+        await self._event_sink(websocket).emit(
+            SessionEndedEvent(session_id=session_id, reason=reason)
         )
-        overlay_last_text = getattr(self, "_overlay_last_interim_text_by_session", None)
-        if isinstance(overlay_last_text, dict):
-            overlay_last_text.pop(session_id, None)
 
     async def _emit_session_warning(
         self,
@@ -949,24 +905,13 @@ class DaemonServer:
     ) -> None:
         remaining = self._session_remaining_seconds(session)
         limit = self._effective_session_limit_seconds()
-        logger.info(
-            "Session {} warning: {:.0f}s remaining of {:.0f}s limit",
-            session_id,
-            remaining,
-            limit,
+        await self._event_sink(websocket).emit(
+            SessionWarningEvent(
+                session_id=session_id,
+                remaining_seconds=remaining,
+                limit_seconds=limit,
+            )
         )
-        message = SessionWarningMessage(
-            session_id=session_id,
-            warning="approaching_limit",
-            remaining_seconds=round(remaining, 1),
-            limit_seconds=limit,
-        )
-        # Session warning is sent on the main websocket, not the overlay channel,
-        # so the client can forward it to the overlay.
-        try:
-            await self._send_message(websocket, message.model_dump(mode="json"))
-        except Exception as exc:  # noqa: BLE001
-            logger.debug("Failed to send session warning for {}: {}", session_id, exc)
 
     async def _emit_live_interim_from_chunk(
         self,

--- a/parakeet-stt-daemon/tests/test_events.py
+++ b/parakeet-stt-daemon/tests/test_events.py
@@ -1,0 +1,182 @@
+"""Session event seam tests."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID, uuid4
+
+from parakeet_stt_daemon.events import (
+    AudioLevelEvent,
+    FinalResultEvent,
+    InterimStateEvent,
+    InterimTextEvent,
+    RecordingEventSink,
+    SessionEndedEvent,
+    SessionStartedEvent,
+    WebSocketEventSink,
+)
+from parakeet_stt_daemon.messages import InterimStateValue, SessionEndReason
+
+
+class FakeWebSocket:
+    def __init__(self) -> None:
+        self.sent_json: list[dict[str, Any]] = []
+
+    async def send_json(self, data: dict[str, Any]) -> None:
+        self.sent_json.append(data)
+
+
+def test_recording_event_sink_preserves_session_flow_order() -> None:
+    async def scenario() -> None:
+        sink = RecordingEventSink()
+        session_id = uuid4()
+
+        await sink.emit(
+            SessionStartedEvent(
+                session_id=session_id,
+                ts=datetime.now(tz=UTC),
+                mic_device="test mic",
+                lang="auto",
+            )
+        )
+        await sink.emit(
+            InterimTextEvent(
+                session_id=session_id,
+                text="partial text",
+            )
+        )
+        await sink.emit(
+            FinalResultEvent(
+                session_id=session_id,
+                text="final text",
+                latency_ms=10,
+                audio_ms=100,
+                lang="auto",
+                confidence=None,
+                tail_trim_mode="rms",
+                vad_active=False,
+                vad_fallback_reason=None,
+            )
+        )
+        await sink.emit(SessionEndedEvent(session_id=session_id, reason=SessionEndReason.FINAL))
+
+        assert [type(event).__name__ for event in sink.events] == [
+            "SessionStartedEvent",
+            "InterimTextEvent",
+            "FinalResultEvent",
+            "SessionEndedEvent",
+        ]
+
+    asyncio.run(scenario())
+
+
+def test_websocket_event_sink_serializes_existing_wire_messages() -> None:
+    async def scenario() -> None:
+        websocket = FakeWebSocket()
+        send_lock = asyncio.Lock()
+        overlay_seq_by_session: dict[UUID, int] = {}
+        overlay_state_by_session: dict[UUID, str] = {}
+        last_interim_text_by_session: dict[UUID, str] = {}
+        counters = {"emitted": 0, "dropped": 0}
+
+        def next_overlay_seq(session_id: UUID) -> int:
+            current = overlay_seq_by_session.get(session_id, 0)
+            overlay_seq_by_session[session_id] = current + 1
+            return current
+
+        def overlay_session_state(session_id: UUID) -> str | None:
+            return overlay_state_by_session.get(session_id)
+
+        def set_overlay_session_state(session_id: UUID, state: str) -> None:
+            overlay_state_by_session[session_id] = state
+
+        def last_interim_text(session_id: UUID) -> str | None:
+            return last_interim_text_by_session.get(session_id)
+
+        def record_interim_text(session_id: UUID, text: str) -> None:
+            last_interim_text_by_session[session_id] = text
+
+        def clear_interim_text(session_id: UUID) -> None:
+            last_interim_text_by_session.pop(session_id, None)
+
+        def increment_emitted() -> None:
+            counters["emitted"] += 1
+
+        def increment_dropped() -> None:
+            counters["dropped"] += 1
+
+        sink = WebSocketEventSink(
+            websocket=websocket,
+            send_lock=lambda: send_lock,
+            overlay_events_enabled=True,
+            next_overlay_seq=next_overlay_seq,
+            overlay_session_state=overlay_session_state,
+            set_overlay_session_state=set_overlay_session_state,
+            last_interim_text=last_interim_text,
+            record_interim_text=record_interim_text,
+            clear_interim_text=clear_interim_text,
+            increment_overlay_events_emitted=increment_emitted,
+            increment_overlay_events_dropped=increment_dropped,
+        )
+        session_id = uuid4()
+
+        await sink.emit(
+            SessionStartedEvent(
+                session_id=session_id,
+                ts=datetime(2026, 5, 18, tzinfo=UTC),
+                mic_device=None,
+                lang="auto",
+            )
+        )
+        await sink.emit(InterimStateEvent(session_id=session_id, state=InterimStateValue.LISTENING))
+        await sink.emit(InterimTextEvent(session_id=session_id, text=" hello   world "))
+        await sink.emit(InterimTextEvent(session_id=session_id, text="hello world"))
+        await sink.emit(AudioLevelEvent(session_id=session_id, rms=0.1))
+        set_overlay_session_state(session_id, "terminal")
+        await sink.emit(
+            FinalResultEvent(
+                session_id=session_id,
+                text="final text",
+                latency_ms=12,
+                audio_ms=345,
+                lang="auto",
+                confidence=None,
+                tail_trim_mode="vad",
+                vad_active=True,
+                vad_fallback_reason=None,
+            )
+        )
+        await sink.emit(SessionEndedEvent(session_id=session_id, reason=SessionEndReason.FINAL))
+
+        sent_types = [payload["type"] for payload in websocket.sent_json]
+        assert sent_types == [
+            "session_started",
+            "interim_state",
+            "interim_text",
+            "audio_level",
+            "final_result",
+            "session_ended",
+        ]
+
+        overlay_payloads = [
+            payload
+            for payload in websocket.sent_json
+            if payload["type"] in {"interim_state", "interim_text"}
+        ]
+        assert [payload["seq"] for payload in overlay_payloads] == [0, 1]
+        assert websocket.sent_json[2]["text"] == "hello world"
+        assert websocket.sent_json[4] == {
+            "type": "final_result",
+            "session_id": str(session_id),
+            "text": "final text",
+            "latency_ms": 12,
+            "audio_ms": 345,
+            "lang": "auto",
+            "confidence": None,
+        }
+        assert last_interim_text_by_session == {}
+        assert counters == {"emitted": 4, "dropped": 0}
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## Summary
- Add `parakeet_stt_daemon.events` with frozen `SessionEvent` dataclasses, an `EventSink` port, production `WebSocketEventSink`, and in-memory `RecordingEventSink`.
- Move WebSocket wire-message construction for session started, interim state/text, audio level, final result, session ended, session warning, and errors into `WebSocketEventSink`.
- Keep `DaemonServer._emit_*` methods thin: they build domain events and emit through the sink while preserving existing Overlay `seq`, terminal-state filtering, counters, and direct WebSocket send locking.
- Add direct event tests for recording-sink ordering and adapter serialization/Overlay sequence assignment.

## Acceptance Notes
- `SessionEvent` cases carry no Overlay `seq`; the adapter assigns `seq` only when serializing Overlay wire messages.
- `FinalResultEvent` carries Runtime truth facts from the tail trimmer (`tail_trim_mode`, `vad_active`, `vad_fallback_reason`) even though the existing `final_result` wire payload remains unchanged.
- `CONTEXT.md` is referenced by the issue/AGENTS instructions but is not present on the fresh `origin/main` branch; the new module docstring uses the Daemon, Session, and Overlay vocabulary from the issue text and `docs/SPEC.md`.

## Verification
- `cd parakeet-stt-daemon && uv run pytest tests/test_events.py tests/test_overlay_event_stream.py tests/test_session_cleanup.py -q` -> PASSED (50 passed)
- `cd parakeet-stt-daemon && uv run pytest -q` -> PASSED (140 passed)
- `cd parakeet-stt-daemon && uv run ruff check src tests check_model_lib` -> PASSED
- `cd parakeet-stt-daemon && uv run ruff format --check src tests check_model_lib` -> PASSED
- `cd parakeet-stt-daemon && uv run ty check src` -> PASSED
- `prek run --all-files` -> PASSED
- `git push -u origin issue-60-event-sink` pre-push hook -> PASSED (`python pytest`; Rust hooks skipped because no Rust files changed)
- `coderabbit_review_watch.py gate --pr 70` -> PASSED on head `458a992d3d2d4ab6beaa195be2dd14a4a9919367`; local review completed, remote check passed, no actionable PR feedback; summary at `/home/hugo/Documents/Engineering/parakeet-stt/.git/worktrees/parakeet-stt-dev/coderabbit-review/20260518T144841Z/gate-summary.json`
- Dev helper smoke -> PASSED with `PARAKEET_ROOT=/home/hugo/Documents/Engineering/parakeet-stt-dev` pinned. Daemon and client resolved under the dev worktree. Because the tester was AFK, smoke used a synthetic WebSocket `start_session`/`stop_session` instead of a Right-Ctrl dictation. Session `4f63b600-329a-4ab3-8c74-460ddb51ee57` emitted `session_started`, Overlay interim/audio-level events, `final_result`, and `session_ended` with no `error`; final payload remained byte-compatible (`text=""`, `audio_ms=3500`, `lang="auto"`, `confidence=null`) and logs show the offline Seal path completed normally.
- `/status` after smoke -> `state="idle"`, `sessions_active=0`, `streaming_enabled=true`, `finalization_mode="offline_seal"`, `final_audio_source="canonical_session_audio"`, `tail_trim_mode="rms"`, `vad_enabled=false`, `vad_active=false`, `vad_fallback_reason=null`, `overlay_events_enabled=true`, `overlay_events_dropped=0`.
- Dev helper was stopped after smoke; daemon/client no longer running.

## Known non-blocking issue
- `prek run --stage pre-push --all-files` still fails on a pre-existing unrelated Rust Clippy warning in `parakeet-ptt/src/overlay_renderer.rs:1819` (`clippy::collapsible_match`). This PR does not touch Rust files; that command's Python pytest and Rust tests passed.

Fixes #60
