### PR TITLE
refactor(daemon): carve SessionOrchestrator out of DaemonServer

### DIFF
--- a/parakeet-stt-daemon/src/parakeet_stt_daemon/__main__.py
+++ b/parakeet-stt-daemon/src/parakeet_stt_daemon/__main__.py
@@ -165,20 +165,21 @@ def run_checks(settings: ServerSettings) -> None:
         logger.error("Failed to initialise server components: {}", exc)
         raise
 
+    orchestrator = server.orchestrator
     try:
-        server.audio.start()
+        orchestrator.audio.start()
         logger.info("Audio stream opened successfully (device={})", settings.mic_device)
-        server.audio.stop()
+        orchestrator.audio.stop()
     except Exception as exc:  # noqa: BLE001
         logger.error("Audio stream check failed: {}", exc)
 
     try:
-        server.transcriber.warmup()
+        orchestrator.transcriber.warmup()
         logger.info("Model warmup completed")
     except Exception as exc:  # noqa: BLE001
         logger.warning("Model warmup skipped/failed: {}", exc)
     if settings.vad_enabled:
-        server.prepare_vad()
+        orchestrator.prepare_vad()
 
     try:
         # sounddevice returns DeviceList; cast for static typing.
@@ -211,34 +212,34 @@ def run_checks(settings: ServerSettings) -> None:
         settings.max_session_samples,
     )
     if settings.streaming_enabled:
-        helper_active = server._stream_helper_active()
-        fallback_reason = server._stream_fallback_reason()
-        helper_class = getattr(server.streaming_transcriber, "_helper_class_name", None)
+        helper_active = orchestrator._stream_helper_active()
+        fallback_reason = orchestrator._stream_fallback_reason()
+        helper_class = getattr(orchestrator.streaming_transcriber, "_helper_class_name", None)
         if helper_active:
             logger.info(
                 "Live session helper: ACTIVE (class={}, scope={})",
                 helper_class,
-                server._stream_helper_scope(),
+                orchestrator._stream_helper_scope(),
             )
         else:
             logger.warning(
                 "Live session helper: INACTIVE (scope={}, reason={})",
-                server._stream_helper_scope(),
+                orchestrator._stream_helper_scope(),
                 fallback_reason,
             )
     logger.info(
         "Final transcript path: {} (audio_source={}, tail_trim_mode={})",
-        server._finalization_mode(),
-        server._final_audio_source(),
-        server._tail_trim_mode(),
+        orchestrator._finalization_mode(),
+        orchestrator._final_audio_source(),
+        orchestrator._tail_trim_mode(),
     )
     if settings.vad_enabled:
-        if server._vad_active():
+        if orchestrator._vad_active():
             logger.info("VAD trim: ACTIVE (backend=silero_onnx)")
         else:
             logger.warning(
                 "VAD trim: INACTIVE (reason={}). Tail trim will fall back to RMS.",
-                server._vad_fallback_reason(),
+                orchestrator._vad_fallback_reason(),
             )
     else:
         logger.info("VAD trim: DISABLED")

--- a/parakeet-stt-daemon/src/parakeet_stt_daemon/events.py
+++ b/parakeet-stt-daemon/src/parakeet_stt_daemon/events.py
@@ -25,6 +25,8 @@ from .messages import (
     SessionWarningMessage,
 )
 
+OVERLAY_SESSION_STATE_CACHE_LIMIT = 128
+
 ErrorCode: TypeAlias = Literal[
     "SESSION_BUSY",
     "SESSION_NOT_FOUND",
@@ -116,12 +118,96 @@ class EventSink(Protocol):
     async def emit(self, event: SessionEvent) -> None: ...
 
 
+class EventSinkClosed(RuntimeError):
+    """Raised when a transport-backed event sink is no longer writable."""
+
+
 @dataclass
 class RecordingEventSink:
     events: list[SessionEvent] = field(default_factory=list)
 
     async def emit(self, event: SessionEvent) -> None:
         self.events.append(event)
+
+
+class WebSocketEventSinkState:
+    """Own overlay wire sequencing and counters for WebSocket event sinks."""
+
+    def __init__(self, *, overlay_events_enabled: bool) -> None:
+        self.overlay_events_enabled = overlay_events_enabled
+        self._overlay_event_seq_by_session: dict[UUID, int] = {}
+        self._overlay_last_interim_text_by_session: dict[UUID, str] = {}
+        self._overlay_state_by_session: dict[UUID, str] = {}
+        self._overlay_events_emitted = 0
+        self._overlay_events_dropped = 0
+
+    @property
+    def overlay_events_emitted(self) -> int:
+        return self._overlay_events_emitted
+
+    @property
+    def overlay_events_dropped(self) -> int:
+        return self._overlay_events_dropped
+
+    def sink(
+        self,
+        *,
+        websocket: JsonWebSocket,
+        send_lock: Callable[[], asyncio.Lock],
+    ) -> WebSocketEventSink:
+        return WebSocketEventSink(
+            websocket=websocket,
+            send_lock=send_lock,
+            overlay_events_enabled=self.overlay_events_enabled,
+            next_overlay_seq=self._next_overlay_seq,
+            overlay_session_state=self._overlay_session_state,
+            set_overlay_session_state=self._set_overlay_session_state,
+            last_interim_text=self._overlay_last_interim_text,
+            record_interim_text=self._record_overlay_interim_text,
+            clear_interim_text=self._clear_overlay_interim_text,
+            increment_overlay_events_emitted=self._increment_overlay_events_emitted,
+            increment_overlay_events_dropped=self._increment_overlay_events_dropped,
+            clear_session_runtime=self._clear_overlay_session_runtime,
+            mark_session_terminal=self._mark_overlay_session_terminal,
+        )
+
+    def _next_overlay_seq(self, session_id: UUID) -> int:
+        current = self._overlay_event_seq_by_session.get(session_id, 0)
+        self._overlay_event_seq_by_session[session_id] = current + 1
+        return current
+
+    def _overlay_session_state(self, session_id: UUID) -> str | None:
+        return self._overlay_state_by_session.get(session_id)
+
+    def _set_overlay_session_state(self, session_id: UUID, state: str) -> None:
+        self._overlay_state_by_session.pop(session_id, None)
+        self._overlay_state_by_session[session_id] = state
+        while len(self._overlay_state_by_session) > OVERLAY_SESSION_STATE_CACHE_LIMIT:
+            oldest = next(iter(self._overlay_state_by_session))
+            self._overlay_state_by_session.pop(oldest)
+
+    def _clear_overlay_session_runtime(self, session_id: UUID) -> None:
+        self._overlay_event_seq_by_session.pop(session_id, None)
+        self._overlay_last_interim_text_by_session.pop(session_id, None)
+        self._set_overlay_session_state(session_id, "active")
+
+    def _mark_overlay_session_terminal(self, session_id: UUID) -> None:
+        self._set_overlay_session_state(session_id, "terminal")
+
+    def _overlay_last_interim_text(self, session_id: UUID) -> str | None:
+        return self._overlay_last_interim_text_by_session.get(session_id)
+
+    def _record_overlay_interim_text(self, session_id: UUID, text: str) -> None:
+        self._overlay_last_interim_text_by_session[session_id] = text
+
+    def _clear_overlay_interim_text(self, session_id: UUID) -> None:
+        self._overlay_last_interim_text_by_session.pop(session_id, None)
+
+    def _increment_overlay_events_emitted(self) -> None:
+        self._overlay_events_emitted += 1
+
+    def _increment_overlay_events_dropped(self) -> None:
+        self._overlay_events_dropped += 1
 
 
 class WebSocketEventSink:
@@ -141,6 +227,8 @@ class WebSocketEventSink:
         clear_interim_text: Callable[[UUID], None],
         increment_overlay_events_emitted: Callable[[], None],
         increment_overlay_events_dropped: Callable[[], None],
+        clear_session_runtime: Callable[[UUID], None] | None = None,
+        mark_session_terminal: Callable[[UUID], None] | None = None,
     ) -> None:
         self._websocket = websocket
         self._send_lock = send_lock
@@ -153,6 +241,8 @@ class WebSocketEventSink:
         self._clear_interim_text = clear_interim_text
         self._increment_overlay_events_emitted = increment_overlay_events_emitted
         self._increment_overlay_events_dropped = increment_overlay_events_dropped
+        self._clear_session_runtime = clear_session_runtime
+        self._mark_session_terminal = mark_session_terminal
 
     async def emit(self, event: SessionEvent) -> None:
         if isinstance(event, SessionStartedEvent):
@@ -173,8 +263,13 @@ class WebSocketEventSink:
             await self._emit_session_error(event)
 
     async def _send_direct(self, payload: dict[str, Any]) -> None:
-        async with self._send_lock():
-            await self._websocket.send_json(payload)
+        try:
+            async with self._send_lock():
+                await self._websocket.send_json(payload)
+        except Exception as exc:  # noqa: BLE001
+            if exc.__class__.__name__ == "WebSocketDisconnect":
+                raise EventSinkClosed("event sink transport disconnected") from exc
+            raise
 
     async def _send_overlay(
         self,
@@ -208,6 +303,8 @@ class WebSocketEventSink:
             return False
 
     async def _emit_session_started(self, event: SessionStartedEvent) -> None:
+        if self._clear_session_runtime is not None:
+            self._clear_session_runtime(event.session_id)
         message = SessionStarted(
             session_id=event.session_id,
             ts=event.ts,
@@ -254,6 +351,8 @@ class WebSocketEventSink:
         await self._send_overlay(event.session_id, message.model_dump(mode="json"))
 
     async def _emit_final_result(self, event: FinalResultEvent) -> None:
+        if self._mark_session_terminal is not None:
+            self._mark_session_terminal(event.session_id)
         message = FinalResult(
             session_id=event.session_id,
             text=event.text,
@@ -307,6 +406,7 @@ class WebSocketEventSink:
 __all__ = [
     "AudioLevelEvent",
     "ErrorCode",
+    "EventSinkClosed",
     "EventSink",
     "FinalResultEvent",
     "InterimStateEvent",
@@ -318,4 +418,5 @@ __all__ = [
     "SessionStartedEvent",
     "SessionWarningEvent",
     "WebSocketEventSink",
+    "WebSocketEventSinkState",
 ]

--- a/parakeet-stt-daemon/src/parakeet_stt_daemon/server.py
+++ b/parakeet-stt-daemon/src/parakeet_stt_daemon/server.py
@@ -1,39 +1,26 @@
-"""FastAPI-based WebSocket server wrapping the Parakeet audio pipeline."""
+"""FastAPI WebSocket adapter for the Parakeet Session orchestrator."""
 
 from __future__ import annotations
 
 import asyncio
-import math
-import time
 from contextlib import asynccontextmanager
-from datetime import UTC, datetime
-from functools import partial
-from typing import Literal
 from uuid import UUID
 
-import numpy as np
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.responses import JSONResponse
 from loguru import logger
 
-from .audio import AudioInput
 from .config import ServerSettings
 from .events import (
-    AudioLevelEvent,
     ErrorCode,
-    FinalResultEvent,
-    InterimStateEvent,
-    InterimTextEvent,
-    SessionEndedEvent,
+    EventSinkClosed,
     SessionErrorEvent,
-    SessionStartedEvent,
-    SessionWarningEvent,
     WebSocketEventSink,
+    WebSocketEventSinkState,
 )
 from .messages import (
     AbortSession,
     ClientMessageType,
-    InterimStateValue,
     ParsedMessage,
     SessionEndReason,
     StartSession,
@@ -41,97 +28,24 @@ from .messages import (
     StopSession,
     parse_client_message,
 )
-from .model import (
-    ParakeetStreamingSession,
-    ParakeetStreamingTranscriber,
-    ParakeetTranscriber,
-    _release_cuda_cache,
-    load_parakeet_model,
+from .model import _release_cuda_cache
+from .session_orchestrator import (
+    AbortSessionIntent,
+    SessionOrchestrator,
+    StartSessionIntent,
+    StopSessionIntent,
 )
-from .overlay_interim import (
-    OverlayInterimTranscriptContext,
-    OverlayInterimTranscriptStabilizer,
-    append_overlay_interim_context,
-)
-from .session import Session, SessionBusyError, SessionManager, SessionNotFoundError, SessionState
-from .tail_trim import SealPathTailTrimmer
-
-OVERLAY_SESSION_STATE_CACHE_LIMIT = 128
-SESSION_GUARD_POLL_SECS = 0.1
-SESSION_GUARD_WARNING_FRACTION = 0.8  # emit warning at 80% of limit
-_REAL_ASYNCIO_SLEEP = asyncio.sleep
 
 
 class DaemonServer:
-    """Coordinate session state and translate WebSocket messages into actions."""
+    """Adapt WebSocket messages to the in-process SessionOrchestrator."""
 
     def __init__(self, settings: ServerSettings) -> None:
         self.settings = settings
-        self.sessions = SessionManager()
-        sample_rate = 16_000
-        duration_limit_samples = max(1, int(settings.max_session_seconds * sample_rate))
-        explicit_sample_limit = (
-            int(settings.max_session_samples)
-            if settings.max_session_samples is not None
-            else duration_limit_samples
+        self.orchestrator = SessionOrchestrator(settings)
+        self.event_sinks = WebSocketEventSinkState(
+            overlay_events_enabled=settings.overlay_events_enabled
         )
-        self._session_sample_limit = max(1, min(duration_limit_samples, explicit_sample_limit))
-        self._session_age_limit_ms = max(1, int(settings.max_session_seconds * 1000))
-        self.audio = AudioInput(
-            sample_rate=sample_rate,
-            channels=1,
-            dtype="float32",
-            device=settings.mic_device,
-            max_session_samples=self._session_sample_limit,
-        )
-        self.model = load_parakeet_model(device=settings.device)
-        self.transcriber = ParakeetTranscriber(self.model)
-        self._requested_device = str(settings.device)
-        self._effective_device = str(
-            getattr(self.model, "_parakeet_effective_device", self._requested_device)
-        )
-        self._session_lock = asyncio.Lock()
-        self._inference_lock = asyncio.Lock()
-        self.streaming_transcriber: ParakeetStreamingTranscriber | None = (
-            ParakeetStreamingTranscriber(
-                self.model,
-                chunk_secs=settings.chunk_secs,
-                right_context_secs=settings.right_context_secs,
-                left_context_secs=settings.left_context_secs,
-                batch_size=settings.batch_size,
-            )
-            if settings.streaming_enabled
-            else None
-        )
-        self._active_stream: ParakeetStreamingSession | None = None
-        self._stream_drain_task: asyncio.Task | None = None
-        self._stream_drain_running = False
-        self._session_guard_task: asyncio.Task | None = None
-        self._session_guard_running = False
-        self._last_audio_ms: int | None = None
-        self._last_audio_stop_ms: int | None = None
-        self._last_finalize_ms: int | None = None
-        self._last_infer_ms: int | None = None
-        self._last_send_ms: int | None = None
-        self._live_interim_audio = np.zeros((0,), dtype=np.float32)
-        self._live_interim_failed = False
-        self._vad_enabled = bool(settings.vad_enabled)
-        self.tail_trimmer = SealPathTailTrimmer(
-            vad_enabled=self._vad_enabled,
-            silence_floor_db=float(settings.silence_floor_db),
-            warmup_sample_rate=sample_rate,
-        )
-        if settings.streaming_enabled:
-            chunk_samples = int(settings.chunk_secs * self.audio.sample_rate)
-            self.audio.configure_stream_chunk_size(chunk_samples)
-        self._overlay_event_seq_by_session: dict[UUID, int] = {}
-        self._overlay_last_interim_text_by_session: dict[UUID, str] = {}
-        self._overlay_interim_stabilizer_by_session: dict[
-            UUID, OverlayInterimTranscriptStabilizer
-        ] = {}
-        self._overlay_state_by_session: dict[UUID, str] = {}
-        self._overlay_events_emitted = 0
-        self._overlay_events_dropped = 0
         self._websocket_send_locks: dict[int, asyncio.Lock] = {}
 
     async def handle_websocket(self, websocket: WebSocket) -> None:
@@ -155,508 +69,86 @@ class DaemonServer:
                     continue
 
                 await self._dispatch(websocket, parsed)
-        except WebSocketDisconnect:
+        except (WebSocketDisconnect, EventSinkClosed):
             logger.info("WebSocket client disconnected: {}", websocket.client)
-            active = self.sessions.active
+            active = self.orchestrator.sessions.active
             expected_session_id = active.session_id if active else None
-            await self._cleanup_active_session(
+            await self.orchestrator._cleanup_active_session(
                 "websocket disconnected",
                 expected_session_id=expected_session_id,
                 expected_owner_token=owner_token,
                 require_session_match=True,
                 require_owner_match=True,
+                event_sink=self._event_sink(websocket),
+                session_end_reason=SessionEndReason.ABORT,
             )
         except Exception as exc:  # noqa: BLE001
             logger.exception("Unhandled error in WebSocket handler: {}", exc)
-            await self._cleanup_active_session(
+            await self.orchestrator._cleanup_active_session(
                 f"websocket handler exception: {exc.__class__.__name__}",
                 expected_owner_token=owner_token,
                 require_owner_match=True,
+                event_sink=self._event_sink(websocket),
+                session_end_reason=SessionEndReason.ABORT,
             )
             try:
                 await self._send_error(websocket, None, "UNEXPECTED", str(exc))
             except Exception as send_exc:  # noqa: BLE001
                 logger.debug("Failed to send error after websocket handler exception: {}", send_exc)
         finally:
-            websocket_send_locks = getattr(self, "_websocket_send_locks", None)
-            if isinstance(websocket_send_locks, dict):
-                websocket_send_locks.pop(id(websocket), None)
+            self._websocket_send_locks.pop(id(websocket), None)
 
     async def _dispatch(self, websocket: WebSocket, parsed: ParsedMessage) -> None:
+        owner_token = self._owner_token_for_websocket(websocket)
+        event_sink = self._event_sink(websocket)
         if parsed.kind is ClientMessageType.START_SESSION:
             assert isinstance(parsed.model, StartSession)
-            await self._handle_start(websocket, parsed.model)
+            await self.orchestrator.start(
+                StartSessionIntent(
+                    session_id=parsed.model.session_id,
+                    owner_token=owner_token,
+                    event_sink=event_sink,
+                    preferred_lang=parsed.model.preferred_lang,
+                )
+            )
         elif parsed.kind is ClientMessageType.STOP_SESSION:
             assert isinstance(parsed.model, StopSession)
-            await self._handle_stop(websocket, parsed.model)
+            await self.orchestrator.stop(
+                StopSessionIntent(
+                    session_id=parsed.model.session_id,
+                    owner_token=owner_token,
+                    event_sink=event_sink,
+                    post_roll_secs=0.25,
+                )
+            )
         elif parsed.kind is ClientMessageType.ABORT_SESSION:
             assert isinstance(parsed.model, AbortSession)
-            await self._handle_abort(websocket, parsed.model)
+            await self.orchestrator.abort(
+                AbortSessionIntent(
+                    session_id=parsed.model.session_id,
+                    owner_token=owner_token,
+                    event_sink=event_sink,
+                    reason=parsed.model.reason,
+                )
+            )
         else:  # pragma: no cover
             await self._send_error(websocket, None, "INVALID_REQUEST", "Unsupported message")
 
-    async def _handle_start(self, websocket: WebSocket, message: StartSession) -> None:
-        logger.debug("start_session received: {}", message)
-        owner_token = self._owner_token_for_websocket(websocket)
-        try:
-            session = await self.sessions.start_session(message.session_id, owner_token=owner_token)
-        except SessionBusyError:
-            await self._send_error(
-                websocket, message.session_id, "SESSION_BUSY", "A session is already active"
-            )
-            return
-        try:
-            self._live_interim_audio = np.zeros((0,), dtype=np.float32)
-            self._live_interim_failed = False
-            self._clear_overlay_session_runtime(message.session_id)
-            self._set_overlay_session_state(message.session_id, "active")
-            self.audio.start_session()
-            if self.streaming_transcriber:
-                self._active_stream = self.streaming_transcriber.start_session(
-                    self.audio.sample_rate
-                )
-                self._start_stream_drain_loop(websocket, message.session_id)
-            self._start_session_guard_loop(websocket, message.session_id)
-
-            await self._event_sink(websocket).emit(
-                SessionStartedEvent(
-                    session_id=message.session_id,
-                    ts=datetime.now(tz=UTC),
-                    mic_device=str(self.settings.mic_device) if self.settings.mic_device else None,
-                    lang=message.preferred_lang,
-                )
-            )
-            await self._emit_interim_state(
-                websocket,
-                message.session_id,
-                state=InterimStateValue.LISTENING,
-            )
-        except WebSocketDisconnect:
-            await self._cleanup_active_session(
-                "start_session websocket disconnected",
-                expected_session_id=message.session_id,
-                expected_owner_token=owner_token,
-                require_session_match=True,
-                require_owner_match=True,
-            )
-            raise
-        except Exception as exc:  # noqa: BLE001
-            logger.exception("Failed to start session {}: {}", message.session_id, exc)
-            await self._cleanup_active_session(
-                f"start_session rollback: {exc.__class__.__name__}",
-                expected_session_id=message.session_id,
-                expected_owner_token=owner_token,
-                require_session_match=True,
-                require_owner_match=True,
-            )
-            try:
-                await self._send_error(
-                    websocket,
-                    message.session_id,
-                    "UNEXPECTED",
-                    "Failed to start session",
-                )
-            except Exception as send_exc:  # noqa: BLE001
-                logger.debug("Failed to send start_session error response: {}", send_exc)
-            return
-        logger.info("Session {} started", session.session_id)
-
-    async def _handle_stop(self, websocket: WebSocket, message: StopSession) -> None:
-        logger.debug("stop_session received: {}", message)
-        await self._stop_active_session(
-            websocket,
-            message.session_id,
-            owner_token=self._owner_token_for_websocket(websocket),
-            post_roll_secs=0.25,
-        )
-
-    async def _stop_active_session(
-        self,
-        websocket: WebSocket,
-        session_id: UUID,
-        *,
-        owner_token: int,
-        post_roll_secs: float,
-    ) -> None:
-        if post_roll_secs > 0:
-            await asyncio.sleep(post_roll_secs)  # brief post-roll to capture tail audio
-        async with self._session_lock_for_runtime():
-            try:
-                session = await self.sessions.stop_session(session_id, owner_token=owner_token)
-            except SessionNotFoundError:
-                await self._send_error(
-                    websocket, session_id, "SESSION_NOT_FOUND", "No matching active session"
-                )
-                return
-            self._stop_session_guard_loop()
-            await self._emit_interim_state(
-                websocket,
-                session.session_id,
-                state=InterimStateValue.PROCESSING,
-            )
-            audio_stop_started = time.perf_counter()
-            audio_samples, ready_chunks, _tail = self.audio.stop_session_with_streaming()
-            await self._stop_stream_drain_loop()
-            # Final correctness must come from the capture layer's canonical buffer,
-            # not whatever the drain task managed to mirror into `_active_stream`.
-            self._active_stream = None
-            audio_stop_ms = int((time.perf_counter() - audio_stop_started) * 1000)
-            audio_duration_raw = len(audio_samples) / self.audio.sample_rate
-            audio_ms = int(audio_duration_raw * 1000)
-
-            if audio_samples.size == 0:
-                self._set_overlay_session_state(session.session_id, "terminal")
-                await self._send_error(
-                    websocket,
-                    session.session_id,
-                    "AUDIO_DEVICE",
-                    "No audio captured for session",
-                )
-                await self._emit_session_ended(
-                    websocket, session.session_id, reason=SessionEndReason.ERROR
-                )
-                await self.sessions.clear(session.session_id, owner_token=owner_token)
-                self._clear_overlay_session_runtime(session.session_id)
-                self._live_interim_audio = np.zeros((0,), dtype=np.float32)
-                self._live_interim_failed = False
-                return
-
-            finalize_ms: int | None = None
-            infer_ms: int | None = None
-            try:
-                interim_updates = await self._collect_interim_text_updates(
-                    session.session_id,
-                    ready_chunks,
-                )
-                flushed_interim = self._overlay_interim_stabilizer(
-                    session.session_id
-                ).flush_pending_tail()
-                if flushed_interim is not None:
-                    interim_updates.append(flushed_interim.text)
-                if interim_updates:
-                    await self._emit_interim_state(
-                        websocket,
-                        session.session_id,
-                        state=InterimStateValue.INTERIM,
-                    )
-                    for interim_text in interim_updates:
-                        await self._emit_interim_text(
-                            websocket,
-                            session.session_id,
-                            text=interim_text,
-                        )
-                await self._emit_interim_state(
-                    websocket,
-                    session.session_id,
-                    state=InterimStateValue.FINALIZING,
-                )
-                finalize_started = time.perf_counter()
-                text, infer_ms = await self._finalise_transcription(audio_samples)
-                finalize_ms = int((time.perf_counter() - finalize_started) * 1000)
-            except Exception as exc:  # noqa: BLE001
-                logger.exception("Failed to transcribe session {}: {}", session.session_id, exc)
-                self._set_overlay_session_state(session.session_id, "terminal")
-                await self._send_error(
-                    websocket, session.session_id, "MODEL", "Transcription failed"
-                )
-                await self._emit_session_ended(
-                    websocket, session.session_id, reason=SessionEndReason.ERROR
-                )
-                await self.sessions.clear(session.session_id, owner_token=owner_token)
-                self._clear_overlay_session_runtime(session.session_id)
-                self._live_interim_audio = np.zeros((0,), dtype=np.float32)
-                self._live_interim_failed = False
-                return
-
-            latency_ms = int((datetime.now(tz=UTC) - session.last_updated).total_seconds() * 1000)
-            self._set_overlay_session_state(session.session_id, "terminal")
-            send_started = datetime.now(tz=UTC)
-            await self._event_sink(websocket).emit(
-                FinalResultEvent(
-                    session_id=session.session_id,
-                    text=text,
-                    latency_ms=latency_ms,
-                    audio_ms=audio_ms,
-                    lang=self.settings.language,
-                    confidence=None,
-                    tail_trim_mode=self._tail_trim_mode(),
-                    vad_active=self._vad_active(),
-                    vad_fallback_reason=self._vad_fallback_reason(),
-                )
-            )
-            send_ms = int((datetime.now(tz=UTC) - send_started).total_seconds() * 1000)
-            await self._emit_session_ended(
-                websocket, session.session_id, reason=SessionEndReason.FINAL
-            )
-            await self.sessions.clear(session.session_id, owner_token=owner_token)
-            self._clear_overlay_session_runtime(session.session_id)
-            self._live_interim_audio = np.zeros((0,), dtype=np.float32)
-            self._live_interim_failed = False
-            self._last_audio_ms = audio_ms
-            self._last_audio_stop_ms = audio_stop_ms
-            self._last_finalize_ms = finalize_ms
-            self._last_infer_ms = infer_ms
-            self._last_send_ms = send_ms
-
-            # Diagnostic logging for truncation investigation
-            text_len = len(text)
-            chars_per_sec = text_len / audio_duration_raw if audio_duration_raw > 0 else 0
-            logger.info(
-                "Session {} completed: audio_raw={:.2f}s, audio_ms={}, audio_stop_ms={}, "
-                "latency_ms={}, finalize_ms={}, infer_ms={}, send_ms={}, text_len={}, "
-                "chars_per_sec={:.1f}, live_session_helper_active={}, "
-                "live_session_helper_scope={}, stream_fallback_reason={}, "
-                "finalization_mode={}, final_audio_source={}, tail_trim_mode={}, "
-                "vad_enabled={}, vad_active={}, vad_fallback_reason={}",
-                session.session_id,
-                audio_duration_raw,
-                audio_ms,
-                audio_stop_ms,
-                latency_ms,
-                finalize_ms,
-                infer_ms,
-                send_ms,
-                text_len,
-                chars_per_sec,
-                self._stream_helper_active(),
-                self._stream_helper_scope(),
-                self._stream_fallback_reason(),
-                self._finalization_mode(),
-                self._final_audio_source(),
-                self._tail_trim_mode(),
-                bool(getattr(self, "_vad_enabled", False)),
-                self._vad_active(),
-                self._vad_fallback_reason(),
-            )
-
-    async def _handle_abort(self, websocket: WebSocket, message: AbortSession) -> None:
-        logger.debug("abort_session received: {}", message)
-        cleaned = await self._cleanup_active_session(
-            f"abort_session requested ({message.reason})",
-            expected_session_id=message.session_id,
-            expected_owner_token=self._owner_token_for_websocket(websocket),
-            require_session_match=True,
-            require_owner_match=True,
-        )
-        if cleaned:
-            await self._emit_session_ended(
-                websocket, message.session_id, reason=SessionEndReason.ABORT
-            )
-            code = "SESSION_ABORTED"
-            error_message = f"Session aborted: {message.reason}"
-        else:
-            code = "SESSION_NOT_FOUND"
-            error_message = "No matching active session"
-        await self._send_error(websocket, message.session_id, code, error_message)
-
-    async def _cleanup_active_session(
-        self,
-        reason: str,
-        expected_session_id: UUID | None = None,
-        expected_owner_token: int | None = None,
-        *,
-        require_session_match: bool = False,
-        require_owner_match: bool = False,
-    ) -> bool:
-        """Reset all runtime state tied to an active session."""
-        async with self._session_lock_for_runtime():
-            active = self.sessions.active
-            if require_session_match:
-                if expected_session_id is None and active is not None:
-                    logger.debug(
-                        "Skipping cleanup with no expected session (active session is {})",
-                        active.session_id,
-                    )
-                    return False
-                if expected_session_id is not None and (
-                    active is None or active.session_id != expected_session_id
-                ):
-                    logger.debug(
-                        "Skipping cleanup for session {} (active session is {})",
-                        expected_session_id,
-                        active.session_id if active else None,
-                    )
-                    return False
-            if require_owner_match:
-                if expected_owner_token is None and active is not None:
-                    logger.debug(
-                        "Skipping cleanup with no expected owner (active owner is {})",
-                        active.owner_token,
-                    )
-                    return False
-                if expected_owner_token is not None and (
-                    active is None or active.owner_token != expected_owner_token
-                ):
-                    logger.debug(
-                        "Skipping cleanup for owner {} (active owner is {})",
-                        expected_owner_token,
-                        active.owner_token if active else None,
-                    )
-                    return False
-            if (
-                active is not None
-                and expected_session_id is not None
-                and active.session_id != expected_session_id
-            ):
-                logger.debug(
-                    "Skipping cleanup for session {} (active session is {})",
-                    expected_session_id,
-                    active.session_id,
-                )
-                return False
-            if (
-                active is not None
-                and expected_owner_token is not None
-                and active.owner_token != expected_owner_token
-            ):
-                logger.debug(
-                    "Skipping cleanup for owner {} (active owner is {})",
-                    expected_owner_token,
-                    active.owner_token,
-                )
-                return False
-
-            active_session_id = active.session_id if active else None
-            active_owner_token = active.owner_token if active else None
-            if active_session_id is not None:
-                logger.warning("Cleaning up active session {} ({})", active_session_id, reason)
-                self._set_overlay_session_state(active_session_id, "terminal")
-            else:
-                logger.debug("Cleaning residual runtime state with no active session ({})", reason)
-            self.audio.abort_session()
-            await self._stop_stream_drain_loop()
-            self._stop_session_guard_loop()
-            if active_session_id is not None:
-                await self.sessions.clear(active_session_id, owner_token=active_owner_token)
-                self._clear_overlay_session_runtime(active_session_id)
-            self._active_stream = None
-            self._live_interim_audio = np.zeros((0,), dtype=np.float32)
-            self._live_interim_failed = False
-            return active_session_id is not None
-
-    def _audio_session_limit_exceeded(self) -> bool:
-        checker = getattr(self.audio, "session_limit_exceeded", None)
-        if not callable(checker):
-            return False
-        try:
-            return bool(checker())
-        except Exception as exc:  # noqa: BLE001
-            logger.debug("Failed checking audio session limit state: {}", exc)
-            return False
-
-    def _session_guard_warning_due(self, session: Session) -> bool:
-        """Return True when session has reached the warning threshold (80% of limit)."""
-        effective_limit_ms = self._effective_session_limit_ms()
-        if effective_limit_ms is None:
-            return False
-        threshold_ms = int(effective_limit_ms * SESSION_GUARD_WARNING_FRACTION)
-        return session.audio_duration_ms >= threshold_ms
-
-    def _session_remaining_seconds(self, session: Session) -> float:
-        effective_limit_ms = self._effective_session_limit_ms()
-        if effective_limit_ms is None:
-            return 0.0
-        return max(0.0, (effective_limit_ms - session.audio_duration_ms) / 1000.0)
-
-    def _effective_session_limit_ms(self) -> int | None:
-        limits_ms: list[int] = []
-        session_age_limit_ms = getattr(self, "_session_age_limit_ms", None)
-        if session_age_limit_ms is not None:
-            limits_ms.append(max(1, int(session_age_limit_ms)))
-
-        explicit_sample_limit = getattr(self.settings, "max_session_samples", None)
-        sample_rate = int(getattr(self.audio, "sample_rate", 0))
-        session_sample_limit = getattr(self, "_session_sample_limit", None)
-        if (
-            explicit_sample_limit is not None
-            and session_sample_limit is not None
-            and sample_rate > 0
-        ):
-            sample_limit_ms = math.ceil((int(session_sample_limit) * 1000) / sample_rate)
-            limits_ms.append(max(1, sample_limit_ms))
-
-        return min(limits_ms) if limits_ms else None
-
-    def _effective_session_limit_seconds(self) -> float:
-        effective_limit_ms = self._effective_session_limit_ms()
-        if effective_limit_ms is None:
-            return 0.0
-        return effective_limit_ms / 1000.0
-
-    def _start_session_guard_loop(self, websocket: WebSocket, session_id: UUID) -> None:
-        if getattr(self, "_session_guard_task", None) is not None:
-            return
-        self._session_guard_running = True
-        self._session_guard_warning_emitted = False
-
-        async def _guard() -> None:
-            try:
-                while bool(getattr(self, "_session_guard_running", False)):
-                    active = self.sessions.active
-                    if active is None or active.session_id != session_id:
-                        break
-
-                    if self._audio_session_limit_exceeded():
-                        logger.info(
-                            "Session {} reached limit; guard stopping "
-                            "(finalization deferred to stop_session)",
-                            session_id,
-                        )
-                        if not self._session_guard_warning_emitted:
-                            self._session_guard_warning_emitted = True
-                            await self._emit_session_warning(websocket, session_id, active)
-                        break
-
-                    # The wall-clock guard remains a hard ceiling even if the audio
-                    # callback has not yet accumulated the equivalent sample cap.
-                    session_age_limit_ms = getattr(self, "_session_age_limit_ms", None)
-                    duration_limit_reached = session_age_limit_ms is not None and (
-                        active.audio_duration_ms >= int(session_age_limit_ms)
-                    )
-                    if duration_limit_reached:
-                        if not self._session_guard_warning_emitted:
-                            self._session_guard_warning_emitted = True
-                            await self._emit_session_warning(websocket, session_id, active)
-                        logger.info(
-                            "Session {} reached wall-clock limit; auto-stopping",
-                            session_id,
-                        )
-                        await self._stop_active_session(
-                            websocket,
-                            session_id,
-                            owner_token=self._owner_token_for_websocket(websocket),
-                            post_roll_secs=0.0,
-                        )
-                        break
-
-                    # At 80%: emit warning so overlay turns amber.
-                    if not self._session_guard_warning_emitted and self._session_guard_warning_due(
-                        active
-                    ):
-                        self._session_guard_warning_emitted = True
-                        await self._emit_session_warning(websocket, session_id, active)
-
-                    await _REAL_ASYNCIO_SLEEP(SESSION_GUARD_POLL_SECS)
-            except asyncio.CancelledError:
-                raise
-            finally:
-                if getattr(self, "_session_guard_task", None) is asyncio.current_task():
-                    self._session_guard_task = None
-                self._session_guard_running = False
-
-        self._session_guard_task = asyncio.create_task(_guard())
-
-    def _stop_session_guard_loop(self) -> None:
-        task = getattr(self, "_session_guard_task", None)
-        if task is None:
-            return
-        self._session_guard_running = False
-        self._session_guard_task = None
-        if not task.done() and task is not asyncio.current_task():
-            task.cancel()
-
     def _owner_token_for_websocket(self, websocket: WebSocket) -> int:
         return id(websocket)
+
+    def _send_lock_for_websocket(self, websocket: WebSocket) -> asyncio.Lock:
+        lock = self._websocket_send_locks.get(id(websocket))
+        if lock is None:
+            lock = asyncio.Lock()
+            self._websocket_send_locks[id(websocket)] = lock
+        return lock
+
+    def _event_sink(self, websocket: WebSocket) -> WebSocketEventSink:
+        return self.event_sinks.sink(
+            websocket=websocket,
+            send_lock=lambda: self._send_lock_for_websocket(websocket),
+        )
 
     async def _send_error(
         self, websocket: WebSocket, session_id: UUID | None, code: ErrorCode, message: str
@@ -665,461 +157,12 @@ class DaemonServer:
             SessionErrorEvent(session_id=session_id, code=code, message=message)
         )
 
-    def _send_lock_for_websocket(self, websocket: WebSocket) -> asyncio.Lock:
-        websocket_send_locks = getattr(self, "_websocket_send_locks", None)
-        if not isinstance(websocket_send_locks, dict):
-            websocket_send_locks = {}
-            self._websocket_send_locks = websocket_send_locks
-        lock = websocket_send_locks.get(id(websocket))
-        if lock is None:
-            lock = asyncio.Lock()
-            websocket_send_locks[id(websocket)] = lock
-        return lock
-
-    def _event_sink(self, websocket: WebSocket) -> WebSocketEventSink:
-        return WebSocketEventSink(
-            websocket=websocket,
-            send_lock=lambda: self._send_lock_for_websocket(websocket),
-            overlay_events_enabled=self.settings.overlay_events_enabled,
-            next_overlay_seq=self._next_overlay_seq,
-            overlay_session_state=self._overlay_session_state,
-            set_overlay_session_state=self._set_overlay_session_state,
-            last_interim_text=self._overlay_last_interim_text,
-            record_interim_text=self._record_overlay_interim_text,
-            clear_interim_text=self._clear_overlay_interim_text,
-            increment_overlay_events_emitted=self._increment_overlay_events_emitted,
-            increment_overlay_events_dropped=self._increment_overlay_events_dropped,
-        )
-
-    def _session_lock_for_runtime(self) -> asyncio.Lock:
-        lock = getattr(self, "_session_lock", None)
-        if lock is None:
-            lock = asyncio.Lock()
-            self._session_lock = lock
-        return lock
-
-    def _inference_lock_for_runtime(self) -> asyncio.Lock:
-        lock = getattr(self, "_inference_lock", None)
-        if lock is None:
-            lock = asyncio.Lock()
-            self._inference_lock = lock
-        return lock
-
-    async def _transcribe_samples_serialized(self, samples: np.ndarray) -> str:
-        loop = asyncio.get_running_loop()
-        async with self._inference_lock_for_runtime():
-            inference = loop.run_in_executor(
-                None,
-                partial(
-                    self.transcriber.transcribe_samples,
-                    samples,
-                    sample_rate=self.audio.sample_rate,
-                ),
-            )
-            try:
-                return await asyncio.shield(inference)
-            except asyncio.CancelledError:
-                try:
-                    await inference
-                except Exception as exc:  # noqa: BLE001
-                    logger.debug(
-                        "Cancelled inference finished with {} before releasing gate",
-                        exc.__class__.__name__,
-                    )
-                raise
-
-    def _set_overlay_session_state(self, session_id: UUID, state: str) -> None:
-        overlay_states = getattr(self, "_overlay_state_by_session", None)
-        if not isinstance(overlay_states, dict):
-            overlay_states = {}
-            self._overlay_state_by_session = overlay_states
-        overlay_states.pop(session_id, None)
-        overlay_states[session_id] = state
-        while len(overlay_states) > OVERLAY_SESSION_STATE_CACHE_LIMIT:
-            oldest = next(iter(overlay_states))
-            overlay_states.pop(oldest)
-
-    def _overlay_session_state(self, session_id: UUID) -> str | None:
-        overlay_states = getattr(self, "_overlay_state_by_session", None)
-        if not isinstance(overlay_states, dict):
-            return None
-        return overlay_states.get(session_id)
-
-    def _clear_overlay_session_runtime(self, session_id: UUID) -> None:
-        overlay_seq_by_session = getattr(self, "_overlay_event_seq_by_session", None)
-        if isinstance(overlay_seq_by_session, dict):
-            overlay_seq_by_session.pop(session_id, None)
-        self._clear_overlay_interim_text(session_id)
-        overlay_stabilizers = getattr(self, "_overlay_interim_stabilizer_by_session", None)
-        if isinstance(overlay_stabilizers, dict):
-            overlay_stabilizers.pop(session_id, None)
-
-    def _overlay_last_interim_text(self, session_id: UUID) -> str | None:
-        overlay_last_text = getattr(self, "_overlay_last_interim_text_by_session", None)
-        if not isinstance(overlay_last_text, dict):
-            return None
-        return overlay_last_text.get(session_id)
-
-    def _record_overlay_interim_text(self, session_id: UUID, text: str) -> None:
-        overlay_last_text = getattr(self, "_overlay_last_interim_text_by_session", None)
-        if not isinstance(overlay_last_text, dict):
-            overlay_last_text = {}
-            self._overlay_last_interim_text_by_session = overlay_last_text
-        overlay_last_text[session_id] = text
-
-    def _clear_overlay_interim_text(self, session_id: UUID) -> None:
-        overlay_last_text = getattr(self, "_overlay_last_interim_text_by_session", None)
-        if isinstance(overlay_last_text, dict):
-            overlay_last_text.pop(session_id, None)
-
-    def _overlay_interim_stabilizer(
-        self,
-        session_id: UUID,
-    ) -> OverlayInterimTranscriptStabilizer:
-        overlay_stabilizers = getattr(self, "_overlay_interim_stabilizer_by_session", None)
-        if not isinstance(overlay_stabilizers, dict):
-            overlay_stabilizers = {}
-            self._overlay_interim_stabilizer_by_session = overlay_stabilizers
-        stabilizer = overlay_stabilizers.get(session_id)
-        if stabilizer is None:
-            stabilizer = OverlayInterimTranscriptStabilizer()
-            overlay_stabilizers[session_id] = stabilizer
-        return stabilizer
-
-    def _overlay_interim_context(
-        self,
-        session_id: UUID,
-        context_samples: int,
-    ) -> OverlayInterimTranscriptContext:
-        return OverlayInterimTranscriptContext(
-            session_id=session_id,
-            context_samples=context_samples,
-            sample_rate=int(self.audio.sample_rate),
-        )
-
-    def _next_overlay_seq(self, session_id: UUID) -> int:
-        overlay_seq_by_session = getattr(self, "_overlay_event_seq_by_session", None)
-        if not isinstance(overlay_seq_by_session, dict):
-            overlay_seq_by_session = {}
-            self._overlay_event_seq_by_session = overlay_seq_by_session
-        current = overlay_seq_by_session.get(session_id, 0)
-        overlay_seq_by_session[session_id] = current + 1
-        return current
-
-    def _increment_overlay_events_emitted(self) -> None:
-        self._overlay_events_emitted = int(getattr(self, "_overlay_events_emitted", 0)) + 1
-
-    def _increment_overlay_events_dropped(self) -> None:
-        self._overlay_events_dropped = int(getattr(self, "_overlay_events_dropped", 0)) + 1
-
-    async def _emit_interim_state(
-        self,
-        websocket: WebSocket,
-        session_id: UUID,
-        *,
-        state: InterimStateValue,
-    ) -> None:
-        await self._event_sink(websocket).emit(
-            InterimStateEvent(session_id=session_id, state=state)
-        )
-
-    async def _emit_audio_level(
-        self,
-        websocket: WebSocket,
-        session_id: UUID,
-        rms: float,
-    ) -> None:
-        await self._event_sink(websocket).emit(AudioLevelEvent(session_id=session_id, rms=rms))
-
-    async def _collect_interim_text_updates(
-        self,
-        session_id: UUID,
-        ready_chunks: list[np.ndarray],
-    ) -> list[str]:
-        if not self.settings.overlay_events_enabled:
-            return []
-        if not ready_chunks:
-            return []
-
-        rolling_audio = np.zeros((0,), dtype=np.float32)
-        updates: list[str] = []
-
-        for chunk in ready_chunks:
-            chunk_audio = np.asarray(chunk, dtype=np.float32).reshape(-1)
-            if chunk_audio.size == 0:
-                continue
-            rolling_audio = append_overlay_interim_context(rolling_audio, chunk_audio)
-            stabilizer = self._overlay_interim_stabilizer(session_id)
-            source_seq = stabilizer.next_source_seq("stop_replay")
-            context = self._overlay_interim_context(session_id, int(rolling_audio.size))
-            try:
-                candidate = await self._transcribe_samples_serialized(rolling_audio)
-            except Exception as exc:  # noqa: BLE001
-                logger.debug(
-                    "Incremental interim source unavailable for this session: {}",
-                    exc.__class__.__name__,
-                )
-                stabilizer.record_skip(
-                    source="stop_replay",
-                    source_seq=source_seq,
-                    context=context,
-                    reason="transcribe_error",
-                    error_class=exc.__class__.__name__,
-                )
-                break
-            stabilized = stabilizer.accept(
-                "stop_replay",
-                source_seq,
-                candidate,
-                context,
-            )
-            if stabilized is not None:
-                updates.append(stabilized.text)
-        return updates
-
-    async def _emit_interim_text(
-        self,
-        websocket: WebSocket,
-        session_id: UUID,
-        *,
-        text: str,
-    ) -> None:
-        await self._event_sink(websocket).emit(InterimTextEvent(session_id=session_id, text=text))
-
-    async def _emit_session_ended(
-        self,
-        websocket: WebSocket,
-        session_id: UUID,
-        *,
-        reason: SessionEndReason,
-    ) -> None:
-        await self._event_sink(websocket).emit(
-            SessionEndedEvent(session_id=session_id, reason=reason)
-        )
-
-    async def _emit_session_warning(
-        self,
-        websocket: WebSocket,
-        session_id: UUID,
-        session: Session,
-    ) -> None:
-        remaining = self._session_remaining_seconds(session)
-        limit = self._effective_session_limit_seconds()
-        await self._event_sink(websocket).emit(
-            SessionWarningEvent(
-                session_id=session_id,
-                remaining_seconds=remaining,
-                limit_seconds=limit,
-            )
-        )
-
-    async def _emit_live_interim_from_chunk(
-        self,
-        websocket: WebSocket,
-        session_id: UUID,
-        chunk: np.ndarray,
-    ) -> None:
-        if not self.settings.overlay_events_enabled:
-            return
-        if self._live_interim_failed:
-            return
-        chunk_audio = np.asarray(chunk, dtype=np.float32).reshape(-1)
-        if chunk_audio.size == 0:
-            return
-        self._live_interim_audio = append_overlay_interim_context(
-            self._live_interim_audio,
-            chunk_audio,
-        )
-        stabilizer = self._overlay_interim_stabilizer(session_id)
-        source_seq = stabilizer.next_source_seq("live")
-        context = self._overlay_interim_context(session_id, int(self._live_interim_audio.size))
-        try:
-            candidate = await self._transcribe_samples_serialized(self._live_interim_audio)
-        except Exception as exc:  # noqa: BLE001
-            logger.debug(
-                "Live incremental interim source unavailable for this session: {}",
-                exc.__class__.__name__,
-            )
-            stabilizer.record_skip(
-                source="live",
-                source_seq=source_seq,
-                context=context,
-                reason="transcribe_error",
-                error_class=exc.__class__.__name__,
-            )
-            self._live_interim_failed = True
-            return
-        stabilized = stabilizer.accept(
-            "live",
-            source_seq,
-            candidate,
-            context,
-        )
-        if stabilized is not None:
-            await self._emit_interim_text(websocket, session_id, text=stabilized.text)
-
     def status(self) -> StatusMessage:
-        active = self.sessions.active
-        state = active.state if active else SessionState.IDLE
-        requested_device = getattr(self, "_requested_device", str(self.settings.device))
-        effective_device = getattr(self, "_effective_device", requested_device)
-        return StatusMessage(
-            state=state,
-            sessions_active=int(active is not None),
-            gpu_mem_mb=self._gpu_mem_mb(),
-            device=requested_device,
-            effective_device=effective_device,
-            streaming_enabled=self.settings.streaming_enabled,
-            stream_helper_active=self._stream_helper_active(),
-            stream_helper_scope=self._stream_helper_scope(),
-            stream_fallback_reason=self._stream_fallback_reason(),
-            finalization_mode=self._finalization_mode(),
-            final_audio_source=self._final_audio_source(),
-            tail_trim_mode=self._tail_trim_mode(),
-            vad_enabled=bool(getattr(self, "_vad_enabled", False)),
-            vad_active=self._vad_active(),
-            vad_fallback_reason=self._vad_fallback_reason(),
-            overlay_events_enabled=self.settings.overlay_events_enabled,
-            overlay_events_emitted=getattr(self, "_overlay_events_emitted", 0),
-            overlay_events_dropped=getattr(self, "_overlay_events_dropped", 0),
-            chunk_secs=self.settings.chunk_secs if self.settings.streaming_enabled else None,
-            active_session_age_ms=active.audio_duration_ms if active else None,
-            audio_stop_ms=getattr(self, "_last_audio_stop_ms", None),
-            finalize_ms=getattr(self, "_last_finalize_ms", None),
-            infer_ms=getattr(self, "_last_infer_ms", None),
-            send_ms=getattr(self, "_last_send_ms", None),
-            last_audio_ms=getattr(self, "_last_audio_ms", None),
-            last_infer_ms=getattr(self, "_last_infer_ms", None),
-            last_send_ms=getattr(self, "_last_send_ms", None),
+        return self.orchestrator.status(
+            overlay_events_enabled=self.event_sinks.overlay_events_enabled,
+            overlay_events_emitted=self.event_sinks.overlay_events_emitted,
+            overlay_events_dropped=self.event_sinks.overlay_events_dropped,
         )
-
-    def _stream_helper_active(self) -> bool:
-        if not self.settings.streaming_enabled:
-            return False
-        if self.streaming_transcriber is None:
-            return False
-        return self.streaming_transcriber.helper_active
-
-    def _stream_helper_scope(self) -> Literal["live_session_only"]:
-        return "live_session_only"
-
-    def _stream_fallback_reason(self) -> str | None:
-        if not self.settings.streaming_enabled:
-            return None
-        if self.streaming_transcriber is None:
-            return "streaming_transcriber_unavailable"
-        return self.streaming_transcriber.fallback_reason
-
-    def _finalization_mode(self) -> Literal["offline_seal"]:
-        return "offline_seal"
-
-    def _final_audio_source(self) -> Literal["canonical_session_audio"]:
-        return "canonical_session_audio"
-
-    def _tail_trim_mode(self) -> Literal["rms", "vad"]:
-        return self._tail_trimmer_for_runtime().last_outcome.tail_trim_mode
-
-    def _vad_active(self) -> bool:
-        return self._tail_trimmer_for_runtime().last_outcome.vad_active
-
-    def _vad_fallback_reason(self) -> str | None:
-        return self._tail_trimmer_for_runtime().last_outcome.vad_fallback_reason
-
-    def prepare_vad(self) -> None:
-        self._tail_trimmer_for_runtime().prepare()
-
-    def _tail_trimmer_for_runtime(self) -> SealPathTailTrimmer:
-        tail_trimmer = getattr(self, "tail_trimmer", None)
-        if not isinstance(tail_trimmer, SealPathTailTrimmer):
-            tail_trimmer = SealPathTailTrimmer(
-                vad_enabled=bool(getattr(self, "_vad_enabled", False)),
-                silence_floor_db=float(getattr(self.settings, "silence_floor_db", -40.0)),
-                warmup_sample_rate=int(getattr(self.audio, "sample_rate", 16_000)),
-            )
-            self.tail_trimmer = tail_trimmer
-        return tail_trimmer
-
-    def _gpu_mem_mb(self) -> int | None:
-        try:
-            import torch
-        except ImportError:  # pragma: no cover - inference extra not installed
-            return None
-
-        effective_device = str(getattr(self, "_effective_device", ""))
-        if not effective_device.startswith("cuda"):
-            return None
-        if not torch.cuda.is_available():
-            return None
-
-        device_index: int | None = None
-        if ":" in effective_device:
-            _, suffix = effective_device.split(":", 1)
-            if suffix.isdigit():
-                device_index = int(suffix)
-
-        reserved_bytes = torch.cuda.memory_reserved(device_index or 0)
-        return int(reserved_bytes / (1024 * 1024))
-
-    async def _finalise_transcription(self, audio_samples: np.ndarray) -> tuple[str, int]:
-        # The full capture buffer is the only authoritative source for final decode.
-        loop = asyncio.get_running_loop()
-        tail_trimmer = self._tail_trimmer_for_runtime()
-        trim_outcome = await loop.run_in_executor(
-            None,
-            partial(tail_trimmer.trim, audio_samples, self.audio.sample_rate),
-        )
-        trimmed = trim_outcome.samples
-        effective_device = str(getattr(self, "_effective_device", self.settings.device))
-        if trimmed.size == 0:
-            logger.info("Skipping offline transcription: silence trimming removed all samples")
-            _release_cuda_cache(effective_device)
-            return "", 0
-        infer_started = time.perf_counter()
-        try:
-            text = await self._transcribe_samples_serialized(trimmed)
-            infer_ms = int((time.perf_counter() - infer_started) * 1000)
-            return text, infer_ms
-        finally:
-            _release_cuda_cache(effective_device)
-
-    def _start_stream_drain_loop(self, websocket: WebSocket, session_id: UUID) -> None:
-        if self._stream_drain_task is not None:
-            return
-        self._stream_drain_running = True
-
-        async def _drain() -> None:
-            while self._stream_drain_running:
-                audio_levels = self.audio.take_audio_levels()
-                if audio_levels:
-                    await self._emit_audio_level(websocket, session_id, max(audio_levels))
-                chunks = self.audio.take_stream_chunks()
-                if self._active_stream:
-                    for chunk in chunks:
-                        self._active_stream.feed(chunk)
-                        await self._emit_live_interim_from_chunk(websocket, session_id, chunk)
-                await asyncio.sleep(0.05)
-
-        self._stream_drain_task = asyncio.create_task(_drain())
-
-    async def _stop_stream_drain_loop(self) -> None:
-        if self._stream_drain_task is None:
-            return
-        self._stream_drain_running = False
-        task = self._stream_drain_task
-        self._stream_drain_task = None
-        if task is asyncio.current_task():
-            return
-        if not task.done():
-            task.cancel()
-        try:
-            await task
-        except asyncio.CancelledError:
-            return
-        except Exception as exc:  # noqa: BLE001
-            logger.debug(
-                "Stream drain loop stopped with {} during shutdown",
-                exc.__class__.__name__,
-            )
 
 
 def create_app(settings: ServerSettings) -> FastAPI:
@@ -1127,19 +170,21 @@ def create_app(settings: ServerSettings) -> FastAPI:
 
     @asynccontextmanager
     async def lifespan(app: FastAPI):
+        del app
+        orchestrator = server.orchestrator
         logger.info("Starting audio capture")
-        server.audio.start()
+        orchestrator.audio.start()
         logger.info("Warming Parakeet model on {}", settings.device)
         try:
-            await asyncio.to_thread(server.transcriber.warmup)
+            await asyncio.to_thread(orchestrator.transcriber.warmup)
         except Exception as exc:  # noqa: BLE001
             logger.warning("Model warmup skipped: {}", exc)
         _release_cuda_cache(settings.device)
-        if server._vad_enabled:
-            await asyncio.to_thread(server.prepare_vad)
+        if orchestrator._vad_enabled:
+            await asyncio.to_thread(orchestrator.prepare_vad)
         runtime_degraded = (
-            server.settings.streaming_enabled and not server._stream_helper_active()
-        ) or (server._vad_enabled and not server._vad_active())
+            orchestrator.settings.streaming_enabled and not orchestrator._stream_helper_active()
+        ) or (orchestrator._vad_enabled and not orchestrator._vad_active())
         _log = logger.warning if runtime_degraded else logger.info
         _log(
             "Runtime truth: device_requested={}, device_effective={}, streaming_enabled={}, "
@@ -1147,23 +192,23 @@ def create_app(settings: ServerSettings) -> FastAPI:
             "stream_fallback_reason={}, finalization_mode={}, final_audio_source={}, "
             "tail_trim_mode={}, vad_enabled={}, vad_active={}, vad_fallback_reason={}, "
             "overlay_events_enabled={}",
-            server._requested_device,
-            server._effective_device,
-            server.settings.streaming_enabled,
-            server._stream_helper_active(),
-            server._stream_helper_scope(),
-            server._stream_fallback_reason(),
-            server._finalization_mode(),
-            server._final_audio_source(),
-            server._tail_trim_mode(),
-            server._vad_enabled,
-            server._vad_active(),
-            server._vad_fallback_reason(),
-            server.settings.overlay_events_enabled,
+            orchestrator._requested_device,
+            orchestrator._effective_device,
+            orchestrator.settings.streaming_enabled,
+            orchestrator._stream_helper_active(),
+            orchestrator._stream_helper_scope(),
+            orchestrator._stream_fallback_reason(),
+            orchestrator._finalization_mode(),
+            orchestrator._final_audio_source(),
+            orchestrator._tail_trim_mode(),
+            orchestrator._vad_enabled,
+            orchestrator._vad_active(),
+            orchestrator._vad_fallback_reason(),
+            orchestrator.settings.overlay_events_enabled,
         )
         yield
         logger.info("Stopping audio capture")
-        server.audio.stop()
+        orchestrator.audio.stop()
 
     app = FastAPI(title="Parakeet STT Daemon", version="0.2.0", lifespan=lifespan)
 
@@ -1184,4 +229,4 @@ def create_app(settings: ServerSettings) -> FastAPI:
     return app
 
 
-__all__ = ["create_app", "DaemonServer"]
+__all__ = ["DaemonServer", "create_app"]

--- a/parakeet-stt-daemon/src/parakeet_stt_daemon/session_orchestrator.py
+++ b/parakeet-stt-daemon/src/parakeet_stt_daemon/session_orchestrator.py
@@ -1,0 +1,1023 @@
+"""Session orchestration for the Daemon Stream path and Seal path.
+
+The SessionOrchestrator owns the Daemon's in-process Session lifecycle. It
+does not know about WebSockets; callers translate transport messages into
+intents and receive Stream path and Seal path progress through an EventSink.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import math
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from functools import partial
+from typing import Literal
+from uuid import UUID
+
+import numpy as np
+from loguru import logger
+
+from .audio import AudioInput
+from .config import ServerSettings
+from .events import (
+    AudioLevelEvent,
+    ErrorCode,
+    EventSink,
+    EventSinkClosed,
+    FinalResultEvent,
+    InterimStateEvent,
+    InterimTextEvent,
+    SessionEndedEvent,
+    SessionErrorEvent,
+    SessionStartedEvent,
+    SessionWarningEvent,
+)
+from .messages import (
+    InterimStateValue,
+    SessionEndReason,
+    StatusMessage,
+)
+from .model import (
+    ParakeetStreamingSession,
+    ParakeetStreamingTranscriber,
+    ParakeetTranscriber,
+    _release_cuda_cache,
+    load_parakeet_model,
+)
+from .overlay_interim import (
+    OverlayInterimTranscriptContext,
+    OverlayInterimTranscriptStabilizer,
+    append_overlay_interim_context,
+)
+from .session import Session, SessionBusyError, SessionManager, SessionNotFoundError, SessionState
+from .tail_trim import SealPathTailTrimmer
+
+SESSION_GUARD_POLL_SECS = 0.1
+SESSION_GUARD_WARNING_FRACTION = 0.8  # emit warning at 80% of limit
+_REAL_ASYNCIO_SLEEP = asyncio.sleep
+
+
+@dataclass(frozen=True, slots=True)
+class StartSessionIntent:
+    session_id: UUID
+    owner_token: int
+    event_sink: EventSink
+    preferred_lang: str | None = "auto"
+
+
+@dataclass(frozen=True, slots=True)
+class StopSessionIntent:
+    session_id: UUID
+    owner_token: int
+    event_sink: EventSink
+    post_roll_secs: float = 0.25
+
+
+@dataclass(frozen=True, slots=True)
+class AbortSessionIntent:
+    session_id: UUID
+    owner_token: int
+    event_sink: EventSink
+    reason: Literal["timeout", "user", "error"]
+
+
+class SessionOrchestrator:
+    """Coordinate Session lifecycle and Daemon runtime paths."""
+
+    def __init__(self, settings: ServerSettings) -> None:
+        self.settings = settings
+        self.sessions = SessionManager()
+        sample_rate = 16_000
+        duration_limit_samples = max(1, int(settings.max_session_seconds * sample_rate))
+        explicit_sample_limit = (
+            int(settings.max_session_samples)
+            if settings.max_session_samples is not None
+            else duration_limit_samples
+        )
+        self._session_sample_limit = max(1, min(duration_limit_samples, explicit_sample_limit))
+        self._session_age_limit_ms = max(1, int(settings.max_session_seconds * 1000))
+        self.audio = AudioInput(
+            sample_rate=sample_rate,
+            channels=1,
+            dtype="float32",
+            device=settings.mic_device,
+            max_session_samples=self._session_sample_limit,
+        )
+        self.model = load_parakeet_model(device=settings.device)
+        self.transcriber = ParakeetTranscriber(self.model)
+        self._requested_device = str(settings.device)
+        self._effective_device = str(
+            getattr(self.model, "_parakeet_effective_device", self._requested_device)
+        )
+        self._session_lock = asyncio.Lock()
+        self._inference_lock = asyncio.Lock()
+        self.streaming_transcriber: ParakeetStreamingTranscriber | None = (
+            ParakeetStreamingTranscriber(
+                self.model,
+                chunk_secs=settings.chunk_secs,
+                right_context_secs=settings.right_context_secs,
+                left_context_secs=settings.left_context_secs,
+                batch_size=settings.batch_size,
+            )
+            if settings.streaming_enabled
+            else None
+        )
+        self._active_stream: ParakeetStreamingSession | None = None
+        self._stream_drain_task: asyncio.Task | None = None
+        self._stream_drain_running = False
+        self._session_guard_task: asyncio.Task | None = None
+        self._session_guard_running = False
+        self._last_audio_ms: int | None = None
+        self._last_audio_stop_ms: int | None = None
+        self._last_finalize_ms: int | None = None
+        self._last_infer_ms: int | None = None
+        self._last_send_ms: int | None = None
+        self._live_interim_audio = np.zeros((0,), dtype=np.float32)
+        self._live_interim_failed = False
+        self._vad_enabled = bool(settings.vad_enabled)
+        self.tail_trimmer = SealPathTailTrimmer(
+            vad_enabled=self._vad_enabled,
+            silence_floor_db=float(settings.silence_floor_db),
+            warmup_sample_rate=sample_rate,
+        )
+        if settings.streaming_enabled:
+            chunk_samples = int(settings.chunk_secs * self.audio.sample_rate)
+            self.audio.configure_stream_chunk_size(chunk_samples)
+        self._overlay_interim_stabilizer_by_session: dict[
+            UUID, OverlayInterimTranscriptStabilizer
+        ] = {}
+
+    async def start(self, intent: StartSessionIntent) -> None:
+        await self._handle_start(intent)
+
+    async def stop(self, intent: StopSessionIntent) -> None:
+        await self._handle_stop(intent)
+
+    async def abort(self, intent: AbortSessionIntent) -> None:
+        await self._handle_abort(intent)
+
+    async def _handle_start(self, message: StartSessionIntent) -> None:
+        logger.debug("start_session received: {}", message)
+        owner_token = message.owner_token
+        event_sink = message.event_sink
+        try:
+            session = await self.sessions.start_session(message.session_id, owner_token=owner_token)
+        except SessionBusyError:
+            await self._send_error(
+                event_sink, message.session_id, "SESSION_BUSY", "A session is already active"
+            )
+            return
+        try:
+            self._live_interim_audio = np.zeros((0,), dtype=np.float32)
+            self._live_interim_failed = False
+            self._clear_overlay_session_runtime(message.session_id)
+            self.audio.start_session()
+            if self.streaming_transcriber:
+                self._active_stream = self.streaming_transcriber.start_session(
+                    self.audio.sample_rate
+                )
+                self._start_stream_drain_loop(event_sink, message.session_id)
+            self._start_session_guard_loop(event_sink, message.session_id, owner_token=owner_token)
+
+            await event_sink.emit(
+                SessionStartedEvent(
+                    session_id=message.session_id,
+                    ts=datetime.now(tz=UTC),
+                    mic_device=str(self.settings.mic_device) if self.settings.mic_device else None,
+                    lang=message.preferred_lang,
+                )
+            )
+            await self._emit_interim_state(
+                event_sink,
+                message.session_id,
+                state=InterimStateValue.LISTENING,
+            )
+        except EventSinkClosed:
+            await self._cleanup_active_session(
+                "start_session event sink disconnected",
+                expected_session_id=message.session_id,
+                expected_owner_token=owner_token,
+                require_session_match=True,
+                require_owner_match=True,
+            )
+            raise
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Failed to start session {}: {}", message.session_id, exc)
+            await self._cleanup_active_session(
+                f"start_session rollback: {exc.__class__.__name__}",
+                expected_session_id=message.session_id,
+                expected_owner_token=owner_token,
+                require_session_match=True,
+                require_owner_match=True,
+            )
+            try:
+                await self._send_error(
+                    event_sink,
+                    message.session_id,
+                    "UNEXPECTED",
+                    "Failed to start session",
+                )
+            except Exception as send_exc:  # noqa: BLE001
+                logger.debug("Failed to send start_session error response: {}", send_exc)
+            return
+        logger.info("Session {} started", session.session_id)
+
+    async def _handle_stop(self, message: StopSessionIntent) -> None:
+        logger.debug("stop_session received: {}", message)
+        await self._stop_active_session(
+            message.event_sink,
+            message.session_id,
+            owner_token=message.owner_token,
+            post_roll_secs=message.post_roll_secs,
+        )
+
+    async def _stop_active_session(
+        self,
+        event_sink: EventSink,
+        session_id: UUID,
+        *,
+        owner_token: int,
+        post_roll_secs: float,
+    ) -> None:
+        if post_roll_secs > 0:
+            await asyncio.sleep(post_roll_secs)  # brief post-roll to capture tail audio
+        async with self._session_lock_for_runtime():
+            try:
+                session = await self.sessions.stop_session(session_id, owner_token=owner_token)
+            except SessionNotFoundError:
+                await self._send_error(
+                    event_sink, session_id, "SESSION_NOT_FOUND", "No matching active session"
+                )
+                return
+            self._stop_session_guard_loop()
+            await self._emit_interim_state(
+                event_sink,
+                session.session_id,
+                state=InterimStateValue.PROCESSING,
+            )
+            audio_stop_started = time.perf_counter()
+            audio_samples, ready_chunks, _tail = self.audio.stop_session_with_streaming()
+            await self._stop_stream_drain_loop()
+            # Final correctness must come from the capture layer's canonical buffer,
+            # not whatever the drain task managed to mirror into `_active_stream`.
+            self._active_stream = None
+            audio_stop_ms = int((time.perf_counter() - audio_stop_started) * 1000)
+            audio_duration_raw = len(audio_samples) / self.audio.sample_rate
+            audio_ms = int(audio_duration_raw * 1000)
+
+            if audio_samples.size == 0:
+                await self._send_error(
+                    event_sink,
+                    session.session_id,
+                    "AUDIO_DEVICE",
+                    "No audio captured for session",
+                )
+                await self._emit_session_ended(
+                    event_sink, session.session_id, reason=SessionEndReason.ERROR
+                )
+                await self.sessions.clear(session.session_id, owner_token=owner_token)
+                self._clear_overlay_session_runtime(session.session_id)
+                self._live_interim_audio = np.zeros((0,), dtype=np.float32)
+                self._live_interim_failed = False
+                return
+
+            finalize_ms: int | None = None
+            infer_ms: int | None = None
+            try:
+                interim_updates = await self._collect_interim_text_updates(
+                    session.session_id,
+                    ready_chunks,
+                )
+                flushed_interim = self._overlay_interim_stabilizer(
+                    session.session_id
+                ).flush_pending_tail()
+                if flushed_interim is not None:
+                    interim_updates.append(flushed_interim.text)
+                if interim_updates:
+                    await self._emit_interim_state(
+                        event_sink,
+                        session.session_id,
+                        state=InterimStateValue.INTERIM,
+                    )
+                    for interim_text in interim_updates:
+                        await self._emit_interim_text(
+                            event_sink,
+                            session.session_id,
+                            text=interim_text,
+                        )
+                await self._emit_interim_state(
+                    event_sink,
+                    session.session_id,
+                    state=InterimStateValue.FINALIZING,
+                )
+                finalize_started = time.perf_counter()
+                text, infer_ms = await self._finalise_transcription(audio_samples)
+                finalize_ms = int((time.perf_counter() - finalize_started) * 1000)
+            except Exception as exc:  # noqa: BLE001
+                logger.exception("Failed to transcribe session {}: {}", session.session_id, exc)
+                await self._send_error(
+                    event_sink, session.session_id, "MODEL", "Transcription failed"
+                )
+                await self._emit_session_ended(
+                    event_sink, session.session_id, reason=SessionEndReason.ERROR
+                )
+                await self.sessions.clear(session.session_id, owner_token=owner_token)
+                self._clear_overlay_session_runtime(session.session_id)
+                self._live_interim_audio = np.zeros((0,), dtype=np.float32)
+                self._live_interim_failed = False
+                return
+
+            latency_ms = int((datetime.now(tz=UTC) - session.last_updated).total_seconds() * 1000)
+            send_started = datetime.now(tz=UTC)
+            await event_sink.emit(
+                FinalResultEvent(
+                    session_id=session.session_id,
+                    text=text,
+                    latency_ms=latency_ms,
+                    audio_ms=audio_ms,
+                    lang=self.settings.language,
+                    confidence=None,
+                    tail_trim_mode=self._tail_trim_mode(),
+                    vad_active=self._vad_active(),
+                    vad_fallback_reason=self._vad_fallback_reason(),
+                )
+            )
+            send_ms = int((datetime.now(tz=UTC) - send_started).total_seconds() * 1000)
+            await self._emit_session_ended(
+                event_sink, session.session_id, reason=SessionEndReason.FINAL
+            )
+            await self.sessions.clear(session.session_id, owner_token=owner_token)
+            self._clear_overlay_session_runtime(session.session_id)
+            self._live_interim_audio = np.zeros((0,), dtype=np.float32)
+            self._live_interim_failed = False
+            self._last_audio_ms = audio_ms
+            self._last_audio_stop_ms = audio_stop_ms
+            self._last_finalize_ms = finalize_ms
+            self._last_infer_ms = infer_ms
+            self._last_send_ms = send_ms
+
+            # Diagnostic logging for truncation investigation
+            text_len = len(text)
+            chars_per_sec = text_len / audio_duration_raw if audio_duration_raw > 0 else 0
+            logger.info(
+                "Session {} completed: audio_raw={:.2f}s, audio_ms={}, audio_stop_ms={}, "
+                "latency_ms={}, finalize_ms={}, infer_ms={}, send_ms={}, text_len={}, "
+                "chars_per_sec={:.1f}, live_session_helper_active={}, "
+                "live_session_helper_scope={}, stream_fallback_reason={}, "
+                "finalization_mode={}, final_audio_source={}, tail_trim_mode={}, "
+                "vad_enabled={}, vad_active={}, vad_fallback_reason={}",
+                session.session_id,
+                audio_duration_raw,
+                audio_ms,
+                audio_stop_ms,
+                latency_ms,
+                finalize_ms,
+                infer_ms,
+                send_ms,
+                text_len,
+                chars_per_sec,
+                self._stream_helper_active(),
+                self._stream_helper_scope(),
+                self._stream_fallback_reason(),
+                self._finalization_mode(),
+                self._final_audio_source(),
+                self._tail_trim_mode(),
+                bool(getattr(self, "_vad_enabled", False)),
+                self._vad_active(),
+                self._vad_fallback_reason(),
+            )
+
+    async def _handle_abort(self, message: AbortSessionIntent) -> None:
+        logger.debug("abort_session received: {}", message)
+        cleaned = await self._cleanup_active_session(
+            f"abort_session requested ({message.reason})",
+            expected_session_id=message.session_id,
+            expected_owner_token=message.owner_token,
+            require_session_match=True,
+            require_owner_match=True,
+        )
+        if cleaned:
+            await self._emit_session_ended(
+                message.event_sink, message.session_id, reason=SessionEndReason.ABORT
+            )
+            code = "SESSION_ABORTED"
+            error_message = f"Session aborted: {message.reason}"
+        else:
+            code = "SESSION_NOT_FOUND"
+            error_message = "No matching active session"
+        await self._send_error(message.event_sink, message.session_id, code, error_message)
+
+    async def _cleanup_active_session(
+        self,
+        reason: str,
+        expected_session_id: UUID | None = None,
+        expected_owner_token: int | None = None,
+        *,
+        require_session_match: bool = False,
+        require_owner_match: bool = False,
+        event_sink: EventSink | None = None,
+        session_end_reason: SessionEndReason | None = None,
+    ) -> bool:
+        """Reset all runtime state tied to an active session."""
+        async with self._session_lock_for_runtime():
+            active = self.sessions.active
+            if require_session_match:
+                if expected_session_id is None and active is not None:
+                    logger.debug(
+                        "Skipping cleanup with no expected session (active session is {})",
+                        active.session_id,
+                    )
+                    return False
+                if expected_session_id is not None and (
+                    active is None or active.session_id != expected_session_id
+                ):
+                    logger.debug(
+                        "Skipping cleanup for session {} (active session is {})",
+                        expected_session_id,
+                        active.session_id if active else None,
+                    )
+                    return False
+            if require_owner_match:
+                if expected_owner_token is None and active is not None:
+                    logger.debug(
+                        "Skipping cleanup with no expected owner (active owner is {})",
+                        active.owner_token,
+                    )
+                    return False
+                if expected_owner_token is not None and (
+                    active is None or active.owner_token != expected_owner_token
+                ):
+                    logger.debug(
+                        "Skipping cleanup for owner {} (active owner is {})",
+                        expected_owner_token,
+                        active.owner_token if active else None,
+                    )
+                    return False
+            if (
+                active is not None
+                and expected_session_id is not None
+                and active.session_id != expected_session_id
+            ):
+                logger.debug(
+                    "Skipping cleanup for session {} (active session is {})",
+                    expected_session_id,
+                    active.session_id,
+                )
+                return False
+            if (
+                active is not None
+                and expected_owner_token is not None
+                and active.owner_token != expected_owner_token
+            ):
+                logger.debug(
+                    "Skipping cleanup for owner {} (active owner is {})",
+                    expected_owner_token,
+                    active.owner_token,
+                )
+                return False
+
+            active_session_id = active.session_id if active else None
+            active_owner_token = active.owner_token if active else None
+            if active_session_id is not None:
+                logger.warning("Cleaning up active session {} ({})", active_session_id, reason)
+            else:
+                logger.debug("Cleaning residual runtime state with no active session ({})", reason)
+            self.audio.abort_session()
+            await self._stop_stream_drain_loop()
+            self._stop_session_guard_loop()
+            if active_session_id is not None:
+                await self.sessions.clear(active_session_id, owner_token=active_owner_token)
+                self._clear_overlay_session_runtime(active_session_id)
+            self._active_stream = None
+            self._live_interim_audio = np.zeros((0,), dtype=np.float32)
+            self._live_interim_failed = False
+            if active_session_id is not None and event_sink is not None and session_end_reason:
+                await self._emit_session_ended(
+                    event_sink, active_session_id, reason=session_end_reason
+                )
+            return active_session_id is not None
+
+    def _audio_session_limit_exceeded(self) -> bool:
+        checker = getattr(self.audio, "session_limit_exceeded", None)
+        if not callable(checker):
+            return False
+        try:
+            return bool(checker())
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Failed checking audio session limit state: {}", exc)
+            return False
+
+    def _session_guard_warning_due(self, session: Session) -> bool:
+        """Return True when session has reached the warning threshold (80% of limit)."""
+        effective_limit_ms = self._effective_session_limit_ms()
+        if effective_limit_ms is None:
+            return False
+        threshold_ms = int(effective_limit_ms * SESSION_GUARD_WARNING_FRACTION)
+        return session.audio_duration_ms >= threshold_ms
+
+    def _session_remaining_seconds(self, session: Session) -> float:
+        effective_limit_ms = self._effective_session_limit_ms()
+        if effective_limit_ms is None:
+            return 0.0
+        return max(0.0, (effective_limit_ms - session.audio_duration_ms) / 1000.0)
+
+    def _effective_session_limit_ms(self) -> int | None:
+        limits_ms: list[int] = []
+        session_age_limit_ms = getattr(self, "_session_age_limit_ms", None)
+        if session_age_limit_ms is not None:
+            limits_ms.append(max(1, int(session_age_limit_ms)))
+
+        explicit_sample_limit = getattr(self.settings, "max_session_samples", None)
+        sample_rate = int(getattr(self.audio, "sample_rate", 0))
+        session_sample_limit = getattr(self, "_session_sample_limit", None)
+        if (
+            explicit_sample_limit is not None
+            and session_sample_limit is not None
+            and sample_rate > 0
+        ):
+            sample_limit_ms = math.ceil((int(session_sample_limit) * 1000) / sample_rate)
+            limits_ms.append(max(1, sample_limit_ms))
+
+        return min(limits_ms) if limits_ms else None
+
+    def _effective_session_limit_seconds(self) -> float:
+        effective_limit_ms = self._effective_session_limit_ms()
+        if effective_limit_ms is None:
+            return 0.0
+        return effective_limit_ms / 1000.0
+
+    def _start_session_guard_loop(
+        self,
+        event_sink: EventSink,
+        session_id: UUID,
+        *,
+        owner_token: int,
+    ) -> None:
+        if getattr(self, "_session_guard_task", None) is not None:
+            return
+        self._session_guard_running = True
+        self._session_guard_warning_emitted = False
+
+        async def _guard() -> None:
+            try:
+                while bool(getattr(self, "_session_guard_running", False)):
+                    active = self.sessions.active
+                    if active is None or active.session_id != session_id:
+                        break
+
+                    if self._audio_session_limit_exceeded():
+                        logger.info(
+                            "Session {} reached audio sample limit; auto-stopping",
+                            session_id,
+                        )
+                        if not self._session_guard_warning_emitted:
+                            self._session_guard_warning_emitted = True
+                            await self._emit_session_warning(event_sink, session_id, active)
+                        await self._stop_active_session(
+                            event_sink,
+                            session_id,
+                            owner_token=owner_token,
+                            post_roll_secs=0.0,
+                        )
+                        break
+
+                    # The wall-clock guard remains a hard ceiling even if the audio
+                    # callback has not yet accumulated the equivalent sample cap.
+                    session_age_limit_ms = getattr(self, "_session_age_limit_ms", None)
+                    duration_limit_reached = session_age_limit_ms is not None and (
+                        active.audio_duration_ms >= int(session_age_limit_ms)
+                    )
+                    if duration_limit_reached:
+                        if not self._session_guard_warning_emitted:
+                            self._session_guard_warning_emitted = True
+                            await self._emit_session_warning(event_sink, session_id, active)
+                        logger.info(
+                            "Session {} reached wall-clock limit; auto-stopping",
+                            session_id,
+                        )
+                        await self._stop_active_session(
+                            event_sink,
+                            session_id,
+                            owner_token=owner_token,
+                            post_roll_secs=0.0,
+                        )
+                        break
+
+                    # At 80%: emit warning so overlay turns amber.
+                    if not self._session_guard_warning_emitted and self._session_guard_warning_due(
+                        active
+                    ):
+                        self._session_guard_warning_emitted = True
+                        await self._emit_session_warning(event_sink, session_id, active)
+
+                    await _REAL_ASYNCIO_SLEEP(SESSION_GUARD_POLL_SECS)
+            except asyncio.CancelledError:
+                raise
+            finally:
+                if getattr(self, "_session_guard_task", None) is asyncio.current_task():
+                    self._session_guard_task = None
+                self._session_guard_running = False
+
+        self._session_guard_task = asyncio.create_task(_guard())
+
+    def _stop_session_guard_loop(self) -> None:
+        task = getattr(self, "_session_guard_task", None)
+        if task is None:
+            return
+        self._session_guard_running = False
+        self._session_guard_task = None
+        if not task.done() and task is not asyncio.current_task():
+            task.cancel()
+
+    async def _send_error(
+        self, event_sink: EventSink, session_id: UUID | None, code: ErrorCode, message: str
+    ) -> None:
+        await event_sink.emit(SessionErrorEvent(session_id=session_id, code=code, message=message))
+
+    def _session_lock_for_runtime(self) -> asyncio.Lock:
+        lock = getattr(self, "_session_lock", None)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._session_lock = lock
+        return lock
+
+    def _inference_lock_for_runtime(self) -> asyncio.Lock:
+        lock = getattr(self, "_inference_lock", None)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._inference_lock = lock
+        return lock
+
+    async def _transcribe_samples_serialized(self, samples: np.ndarray) -> str:
+        loop = asyncio.get_running_loop()
+        async with self._inference_lock_for_runtime():
+            inference = loop.run_in_executor(
+                None,
+                partial(
+                    self.transcriber.transcribe_samples,
+                    samples,
+                    sample_rate=self.audio.sample_rate,
+                ),
+            )
+            try:
+                return await asyncio.shield(inference)
+            except asyncio.CancelledError:
+                try:
+                    await inference
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug(
+                        "Cancelled inference finished with {} before releasing gate",
+                        exc.__class__.__name__,
+                    )
+                raise
+
+    def _clear_overlay_session_runtime(self, session_id: UUID) -> None:
+        overlay_stabilizers = getattr(self, "_overlay_interim_stabilizer_by_session", None)
+        if isinstance(overlay_stabilizers, dict):
+            overlay_stabilizers.pop(session_id, None)
+
+    def _overlay_interim_stabilizer(
+        self,
+        session_id: UUID,
+    ) -> OverlayInterimTranscriptStabilizer:
+        overlay_stabilizers = getattr(self, "_overlay_interim_stabilizer_by_session", None)
+        if not isinstance(overlay_stabilizers, dict):
+            overlay_stabilizers = {}
+            self._overlay_interim_stabilizer_by_session = overlay_stabilizers
+        stabilizer = overlay_stabilizers.get(session_id)
+        if stabilizer is None:
+            stabilizer = OverlayInterimTranscriptStabilizer()
+            overlay_stabilizers[session_id] = stabilizer
+        return stabilizer
+
+    def _overlay_interim_context(
+        self,
+        session_id: UUID,
+        context_samples: int,
+    ) -> OverlayInterimTranscriptContext:
+        return OverlayInterimTranscriptContext(
+            session_id=session_id,
+            context_samples=context_samples,
+            sample_rate=int(self.audio.sample_rate),
+        )
+
+    async def _emit_interim_state(
+        self,
+        event_sink: EventSink,
+        session_id: UUID,
+        *,
+        state: InterimStateValue,
+    ) -> None:
+        await event_sink.emit(InterimStateEvent(session_id=session_id, state=state))
+
+    async def _emit_audio_level(
+        self,
+        event_sink: EventSink,
+        session_id: UUID,
+        rms: float,
+    ) -> None:
+        await event_sink.emit(AudioLevelEvent(session_id=session_id, rms=rms))
+
+    async def _collect_interim_text_updates(
+        self,
+        session_id: UUID,
+        ready_chunks: list[np.ndarray],
+    ) -> list[str]:
+        if not self.settings.overlay_events_enabled:
+            return []
+        if not ready_chunks:
+            return []
+
+        rolling_audio = np.zeros((0,), dtype=np.float32)
+        updates: list[str] = []
+
+        for chunk in ready_chunks:
+            chunk_audio = np.asarray(chunk, dtype=np.float32).reshape(-1)
+            if chunk_audio.size == 0:
+                continue
+            rolling_audio = append_overlay_interim_context(rolling_audio, chunk_audio)
+            stabilizer = self._overlay_interim_stabilizer(session_id)
+            source_seq = stabilizer.next_source_seq("stop_replay")
+            context = self._overlay_interim_context(session_id, int(rolling_audio.size))
+            try:
+                candidate = await self._transcribe_samples_serialized(rolling_audio)
+            except Exception as exc:  # noqa: BLE001
+                logger.debug(
+                    "Incremental interim source unavailable for this session: {}",
+                    exc.__class__.__name__,
+                )
+                stabilizer.record_skip(
+                    source="stop_replay",
+                    source_seq=source_seq,
+                    context=context,
+                    reason="transcribe_error",
+                    error_class=exc.__class__.__name__,
+                )
+                break
+            stabilized = stabilizer.accept(
+                "stop_replay",
+                source_seq,
+                candidate,
+                context,
+            )
+            if stabilized is not None:
+                updates.append(stabilized.text)
+        return updates
+
+    async def _emit_interim_text(
+        self,
+        event_sink: EventSink,
+        session_id: UUID,
+        *,
+        text: str,
+    ) -> None:
+        await event_sink.emit(InterimTextEvent(session_id=session_id, text=text))
+
+    async def _emit_session_ended(
+        self,
+        event_sink: EventSink,
+        session_id: UUID,
+        *,
+        reason: SessionEndReason,
+    ) -> None:
+        await event_sink.emit(SessionEndedEvent(session_id=session_id, reason=reason))
+
+    async def _emit_session_warning(
+        self,
+        event_sink: EventSink,
+        session_id: UUID,
+        session: Session,
+    ) -> None:
+        remaining = self._session_remaining_seconds(session)
+        limit = self._effective_session_limit_seconds()
+        await event_sink.emit(
+            SessionWarningEvent(
+                session_id=session_id,
+                remaining_seconds=remaining,
+                limit_seconds=limit,
+            )
+        )
+
+    async def _emit_live_interim_from_chunk(
+        self,
+        event_sink: EventSink,
+        session_id: UUID,
+        chunk: np.ndarray,
+    ) -> None:
+        if not self.settings.overlay_events_enabled:
+            return
+        if self._live_interim_failed:
+            return
+        chunk_audio = np.asarray(chunk, dtype=np.float32).reshape(-1)
+        if chunk_audio.size == 0:
+            return
+        self._live_interim_audio = append_overlay_interim_context(
+            self._live_interim_audio,
+            chunk_audio,
+        )
+        stabilizer = self._overlay_interim_stabilizer(session_id)
+        source_seq = stabilizer.next_source_seq("live")
+        context = self._overlay_interim_context(session_id, int(self._live_interim_audio.size))
+        try:
+            candidate = await self._transcribe_samples_serialized(self._live_interim_audio)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(
+                "Live incremental interim source unavailable for this session: {}",
+                exc.__class__.__name__,
+            )
+            stabilizer.record_skip(
+                source="live",
+                source_seq=source_seq,
+                context=context,
+                reason="transcribe_error",
+                error_class=exc.__class__.__name__,
+            )
+            self._live_interim_failed = True
+            return
+        stabilized = stabilizer.accept(
+            "live",
+            source_seq,
+            candidate,
+            context,
+        )
+        if stabilized is not None:
+            await self._emit_interim_text(event_sink, session_id, text=stabilized.text)
+
+    def status(
+        self,
+        *,
+        overlay_events_enabled: bool,
+        overlay_events_emitted: int,
+        overlay_events_dropped: int,
+    ) -> StatusMessage:
+        active = self.sessions.active
+        state = active.state if active else SessionState.IDLE
+        requested_device = getattr(self, "_requested_device", str(self.settings.device))
+        effective_device = getattr(self, "_effective_device", requested_device)
+        return StatusMessage(
+            state=state,
+            sessions_active=int(active is not None),
+            gpu_mem_mb=self._gpu_mem_mb(),
+            device=requested_device,
+            effective_device=effective_device,
+            streaming_enabled=self.settings.streaming_enabled,
+            stream_helper_active=self._stream_helper_active(),
+            stream_helper_scope=self._stream_helper_scope(),
+            stream_fallback_reason=self._stream_fallback_reason(),
+            finalization_mode=self._finalization_mode(),
+            final_audio_source=self._final_audio_source(),
+            tail_trim_mode=self._tail_trim_mode(),
+            vad_enabled=bool(getattr(self, "_vad_enabled", False)),
+            vad_active=self._vad_active(),
+            vad_fallback_reason=self._vad_fallback_reason(),
+            overlay_events_enabled=overlay_events_enabled,
+            overlay_events_emitted=overlay_events_emitted,
+            overlay_events_dropped=overlay_events_dropped,
+            chunk_secs=self.settings.chunk_secs if self.settings.streaming_enabled else None,
+            active_session_age_ms=active.audio_duration_ms if active else None,
+            audio_stop_ms=getattr(self, "_last_audio_stop_ms", None),
+            finalize_ms=getattr(self, "_last_finalize_ms", None),
+            infer_ms=getattr(self, "_last_infer_ms", None),
+            send_ms=getattr(self, "_last_send_ms", None),
+            last_audio_ms=getattr(self, "_last_audio_ms", None),
+            last_infer_ms=getattr(self, "_last_infer_ms", None),
+            last_send_ms=getattr(self, "_last_send_ms", None),
+        )
+
+    def _stream_helper_active(self) -> bool:
+        if not self.settings.streaming_enabled:
+            return False
+        if self.streaming_transcriber is None:
+            return False
+        return self.streaming_transcriber.helper_active
+
+    def _stream_helper_scope(self) -> Literal["live_session_only"]:
+        return "live_session_only"
+
+    def _stream_fallback_reason(self) -> str | None:
+        if not self.settings.streaming_enabled:
+            return None
+        if self.streaming_transcriber is None:
+            return "streaming_transcriber_unavailable"
+        return self.streaming_transcriber.fallback_reason
+
+    def _finalization_mode(self) -> Literal["offline_seal"]:
+        return "offline_seal"
+
+    def _final_audio_source(self) -> Literal["canonical_session_audio"]:
+        return "canonical_session_audio"
+
+    def _tail_trim_mode(self) -> Literal["rms", "vad"]:
+        return self._tail_trimmer_for_runtime().last_outcome.tail_trim_mode
+
+    def _vad_active(self) -> bool:
+        return self._tail_trimmer_for_runtime().last_outcome.vad_active
+
+    def _vad_fallback_reason(self) -> str | None:
+        return self._tail_trimmer_for_runtime().last_outcome.vad_fallback_reason
+
+    def prepare_vad(self) -> None:
+        self._tail_trimmer_for_runtime().prepare()
+
+    def _tail_trimmer_for_runtime(self) -> SealPathTailTrimmer:
+        tail_trimmer = getattr(self, "tail_trimmer", None)
+        if not isinstance(tail_trimmer, SealPathTailTrimmer):
+            tail_trimmer = SealPathTailTrimmer(
+                vad_enabled=bool(getattr(self, "_vad_enabled", False)),
+                silence_floor_db=float(getattr(self.settings, "silence_floor_db", -40.0)),
+                warmup_sample_rate=int(getattr(self.audio, "sample_rate", 16_000)),
+            )
+            self.tail_trimmer = tail_trimmer
+        return tail_trimmer
+
+    def _gpu_mem_mb(self) -> int | None:
+        try:
+            import torch
+        except ImportError:  # pragma: no cover - inference extra not installed
+            return None
+
+        effective_device = str(getattr(self, "_effective_device", ""))
+        if not effective_device.startswith("cuda"):
+            return None
+        if not torch.cuda.is_available():
+            return None
+
+        device_index: int | None = None
+        if ":" in effective_device:
+            _, suffix = effective_device.split(":", 1)
+            if suffix.isdigit():
+                device_index = int(suffix)
+
+        reserved_bytes = torch.cuda.memory_reserved(device_index or 0)
+        return int(reserved_bytes / (1024 * 1024))
+
+    async def _finalise_transcription(self, audio_samples: np.ndarray) -> tuple[str, int]:
+        # The full capture buffer is the only authoritative source for final decode.
+        loop = asyncio.get_running_loop()
+        tail_trimmer = self._tail_trimmer_for_runtime()
+        trim_outcome = await loop.run_in_executor(
+            None,
+            partial(tail_trimmer.trim, audio_samples, self.audio.sample_rate),
+        )
+        trimmed = trim_outcome.samples
+        effective_device = str(getattr(self, "_effective_device", self.settings.device))
+        if trimmed.size == 0:
+            logger.info("Skipping offline transcription: silence trimming removed all samples")
+            _release_cuda_cache(effective_device)
+            return "", 0
+        infer_started = time.perf_counter()
+        try:
+            text = await self._transcribe_samples_serialized(trimmed)
+            infer_ms = int((time.perf_counter() - infer_started) * 1000)
+            return text, infer_ms
+        finally:
+            _release_cuda_cache(effective_device)
+
+    def _start_stream_drain_loop(self, event_sink: EventSink, session_id: UUID) -> None:
+        if self._stream_drain_task is not None:
+            return
+        self._stream_drain_running = True
+
+        async def _drain() -> None:
+            while self._stream_drain_running:
+                audio_levels = self.audio.take_audio_levels()
+                if audio_levels:
+                    await self._emit_audio_level(event_sink, session_id, max(audio_levels))
+                chunks = self.audio.take_stream_chunks()
+                if self._active_stream:
+                    for chunk in chunks:
+                        self._active_stream.feed(chunk)
+                        await self._emit_live_interim_from_chunk(event_sink, session_id, chunk)
+                await asyncio.sleep(0.05)
+
+        self._stream_drain_task = asyncio.create_task(_drain())
+
+    async def _stop_stream_drain_loop(self) -> None:
+        if self._stream_drain_task is None:
+            return
+        self._stream_drain_running = False
+        task = self._stream_drain_task
+        self._stream_drain_task = None
+        if task is asyncio.current_task():
+            return
+        if not task.done():
+            task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            return
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(
+                "Stream drain loop stopped with {} during shutdown",
+                exc.__class__.__name__,
+            )
+
+
+__all__ = [
+    "AbortSessionIntent",
+    "SessionOrchestrator",
+    "StartSessionIntent",
+    "StopSessionIntent",
+]

--- a/parakeet-stt-daemon/tests/test_offline_in_memory_transcription.py
+++ b/parakeet-stt-daemon/tests/test_offline_in_memory_transcription.py
@@ -11,10 +11,10 @@ from typing import Any, cast
 
 import numpy as np
 
-from parakeet_stt_daemon import server as server_module
+from parakeet_stt_daemon import session_orchestrator as orchestrator_module
 from parakeet_stt_daemon.config import ServerSettings
 from parakeet_stt_daemon.model import ParakeetTranscriber
-from parakeet_stt_daemon.server import DaemonServer
+from parakeet_stt_daemon.session_orchestrator import SessionOrchestrator
 from parakeet_stt_daemon.tail_trim import SealPathTailTrimmer, TailTrimOutcome
 
 
@@ -118,7 +118,7 @@ def test_transcribe_samples_empty_audio_returns_empty_string_without_model_call(
 
 def test_server_offline_finalize_uses_in_memory_transcriber() -> None:
     async def scenario() -> None:
-        server = cast(Any, DaemonServer.__new__(DaemonServer))
+        server = cast(Any, SessionOrchestrator.__new__(SessionOrchestrator))
         server.settings = ServerSettings(device="cpu", streaming_enabled=False)
         server.audio = SimpleNamespace(sample_rate=16_000)
         server.transcriber = _RecordingTranscriber()
@@ -126,7 +126,7 @@ def test_server_offline_finalize_uses_in_memory_transcriber() -> None:
         server._active_stream = None
 
         samples = np.array([0.2, 0.1, 0.05], dtype=np.float32)
-        typed_server = cast(DaemonServer, server)
+        typed_server = cast(SessionOrchestrator, server)
         text, infer_ms = await typed_server._finalise_transcription(samples)
 
         assert text == "offline text"
@@ -142,7 +142,7 @@ def test_server_offline_finalize_uses_in_memory_transcriber() -> None:
 
 def test_server_offline_finalize_skips_model_call_when_trimmed_audio_empty(monkeypatch) -> None:
     async def scenario() -> None:
-        server = cast(Any, DaemonServer.__new__(DaemonServer))
+        server = cast(Any, SessionOrchestrator.__new__(SessionOrchestrator))
         server.settings = ServerSettings(device="cuda", streaming_enabled=False)
         server.audio = SimpleNamespace(sample_rate=16_000)
         server.transcriber = _RecordingTranscriber()
@@ -163,13 +163,13 @@ def test_server_offline_finalize_skips_model_call_when_trimmed_audio_empty(monke
         released_devices: list[str] = []
 
         monkeypatch.setattr(
-            server_module,
+            orchestrator_module,
             "_release_cuda_cache",
             lambda device: released_devices.append(device),
         )
 
         samples = np.array([0.2, 0.1, 0.05], dtype=np.float32)
-        typed_server = cast(DaemonServer, server)
+        typed_server = cast(SessionOrchestrator, server)
         text, infer_ms = await typed_server._finalise_transcription(samples)
 
         assert text == ""
@@ -182,7 +182,7 @@ def test_server_offline_finalize_skips_model_call_when_trimmed_audio_empty(monke
 
 def test_server_finalize_uses_canonical_audio_even_when_stream_session_exists() -> None:
     async def scenario() -> None:
-        server = cast(Any, DaemonServer.__new__(DaemonServer))
+        server = cast(Any, SessionOrchestrator.__new__(SessionOrchestrator))
         server.settings = ServerSettings(device="cpu", streaming_enabled=True)
         server.audio = SimpleNamespace(sample_rate=16_000)
         server.transcriber = _RecordingTranscriber()
@@ -191,7 +191,7 @@ def test_server_finalize_uses_canonical_audio_even_when_stream_session_exists() 
         server.tail_trimmer = _tail_trimmer_with_trim(_identity_tail_trim)
 
         samples = np.array([0.2, 0.1, 0.05, 0.4], dtype=np.float32)
-        typed_server = cast(DaemonServer, server)
+        typed_server = cast(SessionOrchestrator, server)
         text, infer_ms = await typed_server._finalise_transcription(samples)
 
         assert text == "offline text"
@@ -210,7 +210,7 @@ def test_server_finalize_uses_canonical_audio_even_when_stream_session_exists() 
 
 def test_server_finalize_offloads_tail_trim_off_event_loop() -> None:
     async def scenario() -> None:
-        server = cast(Any, DaemonServer.__new__(DaemonServer))
+        server = cast(Any, SessionOrchestrator.__new__(SessionOrchestrator))
         server.settings = ServerSettings(device="cpu", streaming_enabled=False)
         server.audio = SimpleNamespace(sample_rate=16_000)
         server.transcriber = _RecordingTranscriber()
@@ -230,7 +230,7 @@ def test_server_finalize_offloads_tail_trim_off_event_loop() -> None:
             progress.set()
 
         finalize_task = asyncio.create_task(
-            cast(DaemonServer, server)._finalise_transcription(
+            cast(SessionOrchestrator, server)._finalise_transcription(
                 np.array([0.2, 0.1, 0.05], dtype=np.float32)
             )
         )
@@ -248,7 +248,7 @@ def test_server_finalize_offloads_tail_trim_off_event_loop() -> None:
 
 def test_server_finalize_releases_cuda_cache_after_model_call(monkeypatch) -> None:
     async def scenario() -> None:
-        server = cast(Any, DaemonServer.__new__(DaemonServer))
+        server = cast(Any, SessionOrchestrator.__new__(SessionOrchestrator))
         server.settings = ServerSettings(device="cuda", streaming_enabled=False)
         server.audio = SimpleNamespace(sample_rate=16_000)
         server.transcriber = _RecordingTranscriber()
@@ -259,12 +259,12 @@ def test_server_finalize_releases_cuda_cache_after_model_call(monkeypatch) -> No
         released_devices: list[str] = []
 
         monkeypatch.setattr(
-            server_module,
+            orchestrator_module,
             "_release_cuda_cache",
             lambda device: released_devices.append(device),
         )
 
-        text, infer_ms = await cast(DaemonServer, server)._finalise_transcription(
+        text, infer_ms = await cast(SessionOrchestrator, server)._finalise_transcription(
             np.array([0.2, 0.1, 0.05], dtype=np.float32)
         )
 

--- a/parakeet-stt-daemon/tests/test_overlay_event_stream.py
+++ b/parakeet-stt-daemon/tests/test_overlay_event_stream.py
@@ -13,16 +13,19 @@ from uuid import UUID, uuid4
 import numpy as np
 from loguru import logger
 
-from parakeet_stt_daemon import server as server_module
+from parakeet_stt_daemon import session_orchestrator as orchestrator_module
 from parakeet_stt_daemon.config import ServerSettings
+from parakeet_stt_daemon.events import WebSocketEventSinkState
 from parakeet_stt_daemon.messages import (
     AbortSession,
     ClientMessageType,
+    ParsedMessage,
     StartSession,
     StopSession,
 )
 from parakeet_stt_daemon.server import DaemonServer
 from parakeet_stt_daemon.session import SessionManager
+from parakeet_stt_daemon.session_orchestrator import SessionOrchestrator
 
 
 class FakeAudio:
@@ -44,6 +47,9 @@ class FakeAudio:
 
     def abort_session(self) -> None:
         self.abort_calls += 1
+
+    def take_audio_levels(self) -> list[float]:
+        return []
 
     def take_stream_chunks(self) -> list[np.ndarray]:
         return []
@@ -139,51 +145,77 @@ def _build_server(
     incremental_fail_at_call: int | None = None,
 ) -> DaemonServer:
     server = cast(Any, DaemonServer.__new__(DaemonServer))
-    server.settings = ServerSettings(
+    orchestrator = cast(Any, SessionOrchestrator.__new__(SessionOrchestrator))
+    settings = ServerSettings(
         device="cpu",
         status_enabled=True,
         streaming_enabled=False,
         overlay_events_enabled=overlay_events_enabled,
     )
-    server.sessions = SessionManager()
-    server.audio = FakeAudio(ready_chunks=ready_chunks)
-    server.model = object()
-    server.transcriber = FakeIncrementalTranscriber(
+    server.settings = settings
+    server.orchestrator = orchestrator
+    server.event_sinks = WebSocketEventSinkState(
+        overlay_events_enabled=settings.overlay_events_enabled
+    )
+    server._websocket_send_locks = {}
+    orchestrator.settings = settings
+    orchestrator.sessions = SessionManager()
+    orchestrator.audio = FakeAudio(ready_chunks=ready_chunks)
+    orchestrator.model = object()
+    orchestrator.transcriber = FakeIncrementalTranscriber(
         incremental_outputs,
         fail_at_call=incremental_fail_at_call,
     )
-    server._session_lock = asyncio.Lock()
-    server._inference_lock = asyncio.Lock()
-    server.streaming_transcriber = None
-    server._active_stream = None
-    server._stream_drain_task = None
-    server._stream_drain_running = False
-    server._session_guard_task = None
-    server._session_guard_running = False
-    server._session_sample_limit = 1_600
-    server._session_age_limit_ms = 90_000
-    server._requested_device = "cpu"
-    server._effective_device = "cpu"
-    server._last_audio_ms = None
-    server._last_audio_stop_ms = None
-    server._last_finalize_ms = None
-    server._last_infer_ms = None
-    server._last_send_ms = None
-    server._live_interim_audio = np.zeros((0,), dtype=np.float32)
-    server._live_interim_failed = False
-    server._overlay_event_seq_by_session = {}
-    server._overlay_last_interim_text_by_session = {}
-    server._overlay_interim_stabilizer_by_session = {}
-    server._overlay_state_by_session = {}
-    server._overlay_events_emitted = 0
-    server._overlay_events_dropped = 0
-    server._websocket_send_locks = {}
+    orchestrator._session_lock = asyncio.Lock()
+    orchestrator._inference_lock = asyncio.Lock()
+    orchestrator.streaming_transcriber = None
+    orchestrator._active_stream = None
+    orchestrator._stream_drain_task = None
+    orchestrator._stream_drain_running = False
+    orchestrator._session_guard_task = None
+    orchestrator._session_guard_running = False
+    orchestrator._session_sample_limit = 1_600
+    orchestrator._session_age_limit_ms = 90_000
+    orchestrator._requested_device = "cpu"
+    orchestrator._effective_device = "cpu"
+    orchestrator._last_audio_ms = None
+    orchestrator._last_audio_stop_ms = None
+    orchestrator._last_finalize_ms = None
+    orchestrator._last_infer_ms = None
+    orchestrator._last_send_ms = None
+    orchestrator._live_interim_audio = np.zeros((0,), dtype=np.float32)
+    orchestrator._live_interim_failed = False
+    orchestrator._overlay_interim_stabilizer_by_session = {}
 
     async def fake_finalize(_audio_samples: np.ndarray) -> tuple[str, int]:
         return "overlay test text", 7
 
-    server._finalise_transcription = fake_finalize
+    orchestrator._finalise_transcription = fake_finalize
     return cast(DaemonServer, server)
+
+
+async def _dispatch_message(
+    server: DaemonServer,
+    websocket: FakeWebSocket,
+    message: StartSession | StopSession | AbortSession,
+) -> None:
+    await server._dispatch(
+        cast(Any, websocket),
+        ParsedMessage(kind=ClientMessageType(message.type), model=message),
+    )
+
+
+async def _emit_live_interim_from_chunk(
+    server: DaemonServer,
+    websocket: FakeWebSocket,
+    session_id: UUID,
+    chunk: np.ndarray,
+) -> None:
+    await server.orchestrator._emit_live_interim_from_chunk(
+        server._event_sink(cast(Any, websocket)),
+        session_id,
+        chunk,
+    )
 
 
 def _start_message(session_id: UUID) -> StartSession:
@@ -206,7 +238,7 @@ def _disable_server_sleep(monkeypatch) -> None:
     async def no_sleep(_seconds: float) -> None:
         return None
 
-    monkeypatch.setattr("parakeet_stt_daemon.server.asyncio.sleep", no_sleep)
+    monkeypatch.setattr("parakeet_stt_daemon.session_orchestrator.asyncio.sleep", no_sleep)
 
 
 def _pause_guard_sleep(monkeypatch) -> tuple[asyncio.Event, asyncio.Event]:
@@ -217,7 +249,7 @@ def _pause_guard_sleep(monkeypatch) -> tuple[asyncio.Event, asyncio.Event]:
         guard_sleep_entered.set()
         await allow_guard_resume.wait()
 
-    monkeypatch.setattr(server_module, "_REAL_ASYNCIO_SLEEP", fake_guard_sleep)
+    monkeypatch.setattr(orchestrator_module, "_REAL_ASYNCIO_SLEEP", fake_guard_sleep)
     return guard_sleep_entered, allow_guard_resume
 
 
@@ -239,8 +271,8 @@ def test_overlay_events_disabled_emits_only_baseline_messages(monkeypatch) -> No
         websocket = FakeWebSocket()
         session_id = uuid4()
 
-        await server._handle_start(cast(Any, websocket), _start_message(session_id))
-        await server._handle_stop(cast(Any, websocket), _stop_message(session_id))
+        await _dispatch_message(server, websocket, _start_message(session_id))
+        await _dispatch_message(server, websocket, _stop_message(session_id))
 
         sent_types = [cast(str, payload["type"]) for payload in websocket.sent_json]
         assert sent_types == ["session_started", "final_result"]
@@ -255,15 +287,15 @@ def test_stop_session_finalizes_gracefully_when_sample_limit_breached(monkeypatc
         guard_sleep_entered, allow_guard_resume = _pause_guard_sleep(monkeypatch)
 
         server = _build_server(overlay_events_enabled=False)
-        audio = cast(FakeAudio, server.audio)
+        audio = cast(FakeAudio, server.orchestrator.audio)
         websocket = FakeWebSocket()
         session_id = uuid4()
 
-        await server._handle_start(cast(Any, websocket), _start_message(session_id))
+        await _dispatch_message(server, websocket, _start_message(session_id))
         await asyncio.wait_for(guard_sleep_entered.wait(), timeout=1.0)
 
         audio._session_limit_exceeded = True
-        await server._handle_stop(cast(Any, websocket), _stop_message(session_id))
+        await _dispatch_message(server, websocket, _stop_message(session_id))
         allow_guard_resume.set()
         await asyncio.sleep(0)
 
@@ -272,7 +304,7 @@ def test_stop_session_finalizes_gracefully_when_sample_limit_breached(monkeypatc
         assert "final_result" in sent_types
         assert audio.abort_calls == 0
         assert audio.stop_calls == 1
-        assert server.sessions.active is None
+        assert server.orchestrator.sessions.active is None
 
     asyncio.run(scenario())
 
@@ -285,8 +317,8 @@ def test_overlay_events_enabled_stream_is_ordered_and_final_once(monkeypatch) ->
         websocket = FakeWebSocket()
         session_id = uuid4()
 
-        await server._handle_start(cast(Any, websocket), _start_message(session_id))
-        await server._handle_stop(cast(Any, websocket), _stop_message(session_id))
+        await _dispatch_message(server, websocket, _start_message(session_id))
+        await _dispatch_message(server, websocket, _stop_message(session_id))
 
         sent_types = [cast(str, payload["type"]) for payload in websocket.sent_json]
         assert sent_types == [
@@ -330,10 +362,10 @@ def test_overlay_sequence_does_not_leak_across_sessions(monkeypatch) -> None:
         first = uuid4()
         second = uuid4()
 
-        await server._handle_start(cast(Any, websocket), _start_message(first))
-        await server._handle_stop(cast(Any, websocket), _stop_message(first))
-        await server._handle_start(cast(Any, websocket), _start_message(second))
-        await server._handle_stop(cast(Any, websocket), _stop_message(second))
+        await _dispatch_message(server, websocket, _start_message(first))
+        await _dispatch_message(server, websocket, _stop_message(first))
+        await _dispatch_message(server, websocket, _start_message(second))
+        await _dispatch_message(server, websocket, _stop_message(second))
 
         interim_by_session: dict[str, list[int]] = {}
         for payload in websocket.sent_json:
@@ -364,8 +396,8 @@ def test_overlay_send_failures_do_not_block_final_result(monkeypatch) -> None:
 
         _set_dynamic_attr(websocket, "send_json", send_json)
 
-        await server._handle_start(cast(Any, websocket), _start_message(session_id))
-        await server._handle_stop(cast(Any, websocket), _stop_message(session_id))
+        await _dispatch_message(server, websocket, _start_message(session_id))
+        await _dispatch_message(server, websocket, _stop_message(session_id))
 
         sent_types = [cast(str, payload["type"]) for payload in websocket.sent_json]
         assert sent_types == ["session_started", "final_result"]
@@ -394,8 +426,8 @@ def test_interim_text_emitted_when_incremental_source_validates(monkeypatch) -> 
         websocket = FakeWebSocket()
         session_id = uuid4()
 
-        await server._handle_start(cast(Any, websocket), _start_message(session_id))
-        await server._handle_stop(cast(Any, websocket), _stop_message(session_id))
+        await _dispatch_message(server, websocket, _start_message(session_id))
+        await _dispatch_message(server, websocket, _stop_message(session_id))
 
         sent_types = [cast(str, payload["type"]) for payload in websocket.sent_json]
         assert sent_types == [
@@ -442,8 +474,8 @@ def test_incremental_source_failure_does_not_break_final_result(monkeypatch) -> 
         websocket = FakeWebSocket()
         session_id = uuid4()
 
-        await server._handle_start(cast(Any, websocket), _start_message(session_id))
-        await server._handle_stop(cast(Any, websocket), _stop_message(session_id))
+        await _dispatch_message(server, websocket, _start_message(session_id))
+        await _dispatch_message(server, websocket, _stop_message(session_id))
 
         sent_types = [cast(str, payload["type"]) for payload in websocket.sent_json]
         assert sent_types == [
@@ -474,18 +506,18 @@ def test_live_interim_chunk_emission_confirms_repeated_text_before_append(monkey
         websocket = FakeWebSocket()
         session_id = uuid4()
 
-        await server._handle_start(cast(Any, websocket), _start_message(session_id))
-        await server._emit_live_interim_from_chunk(
-            cast(Any, websocket), session_id, np.full((400,), 0.1, dtype=np.float32)
+        await _dispatch_message(server, websocket, _start_message(session_id))
+        await _emit_live_interim_from_chunk(
+            server, cast(Any, websocket), session_id, np.full((400,), 0.1, dtype=np.float32)
         )
-        await server._emit_live_interim_from_chunk(
-            cast(Any, websocket), session_id, np.full((400,), 0.2, dtype=np.float32)
+        await _emit_live_interim_from_chunk(
+            server, cast(Any, websocket), session_id, np.full((400,), 0.2, dtype=np.float32)
         )
-        await server._emit_live_interim_from_chunk(
-            cast(Any, websocket), session_id, np.full((400,), 0.3, dtype=np.float32)
+        await _emit_live_interim_from_chunk(
+            server, cast(Any, websocket), session_id, np.full((400,), 0.3, dtype=np.float32)
         )
-        await server._emit_live_interim_from_chunk(
-            cast(Any, websocket), session_id, np.full((400,), 0.4, dtype=np.float32)
+        await _emit_live_interim_from_chunk(
+            server, cast(Any, websocket), session_id, np.full((400,), 0.4, dtype=np.float32)
         )
 
         sent_types = [cast(str, payload["type"]) for payload in websocket.sent_json]
@@ -521,9 +553,9 @@ def test_live_interim_first_snapshot_is_visible_immediately(monkeypatch) -> None
         websocket = FakeWebSocket()
         session_id = uuid4()
 
-        await server._handle_start(cast(Any, websocket), _start_message(session_id))
-        await server._emit_live_interim_from_chunk(
-            cast(Any, websocket), session_id, np.full((400,), 0.1, dtype=np.float32)
+        await _dispatch_message(server, websocket, _start_message(session_id))
+        await _emit_live_interim_from_chunk(
+            server, cast(Any, websocket), session_id, np.full((400,), 0.1, dtype=np.float32)
         )
 
         interim_texts = [
@@ -547,15 +579,15 @@ def test_live_interim_zero_overlap_rewrite_replaces_mutable_tail(monkeypatch) ->
         websocket = FakeWebSocket()
         session_id = uuid4()
 
-        await server._handle_start(cast(Any, websocket), _start_message(session_id))
-        await server._emit_live_interim_from_chunk(
-            cast(Any, websocket), session_id, np.full((400,), 0.1, dtype=np.float32)
+        await _dispatch_message(server, websocket, _start_message(session_id))
+        await _emit_live_interim_from_chunk(
+            server, cast(Any, websocket), session_id, np.full((400,), 0.1, dtype=np.float32)
         )
-        await server._emit_live_interim_from_chunk(
-            cast(Any, websocket), session_id, np.full((400,), 0.2, dtype=np.float32)
+        await _emit_live_interim_from_chunk(
+            server, cast(Any, websocket), session_id, np.full((400,), 0.2, dtype=np.float32)
         )
-        await server._emit_live_interim_from_chunk(
-            cast(Any, websocket), session_id, np.full((400,), 0.3, dtype=np.float32)
+        await _emit_live_interim_from_chunk(
+            server, cast(Any, websocket), session_id, np.full((400,), 0.3, dtype=np.float32)
         )
 
         interim_texts = [
@@ -581,12 +613,12 @@ def test_live_interim_stabilizer_logs_when_streaming_debug_enabled(monkeypatch) 
         session_id = uuid4()
 
         with _capture_loguru_messages() as log_output:
-            await server._handle_start(cast(Any, websocket), _start_message(session_id))
-            await server._emit_live_interim_from_chunk(
-                cast(Any, websocket), session_id, np.full((400,), 0.1, dtype=np.float32)
+            await _dispatch_message(server, websocket, _start_message(session_id))
+            await _emit_live_interim_from_chunk(
+                server, cast(Any, websocket), session_id, np.full((400,), 0.1, dtype=np.float32)
             )
-            await server._emit_live_interim_from_chunk(
-                cast(Any, websocket), session_id, np.full((400,), 0.2, dtype=np.float32)
+            await _emit_live_interim_from_chunk(
+                server, cast(Any, websocket), session_id, np.full((400,), 0.2, dtype=np.float32)
             )
 
         messages = log_output.getvalue()
@@ -616,8 +648,8 @@ def test_stop_path_stabilizer_logs_when_streaming_debug_enabled(monkeypatch) -> 
         session_id = uuid4()
 
         with _capture_loguru_messages() as log_output:
-            await server._handle_start(cast(Any, websocket), _start_message(session_id))
-            await server._handle_stop(cast(Any, websocket), _stop_message(session_id))
+            await _dispatch_message(server, websocket, _start_message(session_id))
+            await _dispatch_message(server, websocket, _stop_message(session_id))
 
         messages = log_output.getvalue()
         assert "source=stop_replay source_seq=0" in messages
@@ -642,9 +674,9 @@ def test_stabilizer_logs_empty_candidate_action_when_debug_enabled(monkeypatch) 
         session_id = uuid4()
 
         with _capture_loguru_messages() as log_output:
-            await server._handle_start(cast(Any, websocket), _start_message(session_id))
-            await server._emit_live_interim_from_chunk(
-                cast(Any, websocket), session_id, np.full((400,), 0.1, dtype=np.float32)
+            await _dispatch_message(server, websocket, _start_message(session_id))
+            await _emit_live_interim_from_chunk(
+                server, cast(Any, websocket), session_id, np.full((400,), 0.1, dtype=np.float32)
             )
 
         messages = log_output.getvalue()
@@ -670,9 +702,9 @@ def test_stabilizer_logs_skip_on_live_transcribe_error_when_debug_enabled(monkey
         session_id = uuid4()
 
         with _capture_loguru_messages() as log_output:
-            await server._handle_start(cast(Any, websocket), _start_message(session_id))
-            await server._emit_live_interim_from_chunk(
-                cast(Any, websocket), session_id, np.full((400,), 0.1, dtype=np.float32)
+            await _dispatch_message(server, websocket, _start_message(session_id))
+            await _emit_live_interim_from_chunk(
+                server, cast(Any, websocket), session_id, np.full((400,), 0.1, dtype=np.float32)
             )
 
         messages = log_output.getvalue()
@@ -697,12 +729,12 @@ def test_stabilizer_logging_is_disabled_by_default(monkeypatch) -> None:
         session_id = uuid4()
 
         with _capture_loguru_messages() as log_output:
-            await server._handle_start(cast(Any, websocket), _start_message(session_id))
-            await server._emit_live_interim_from_chunk(
-                cast(Any, websocket), session_id, np.full((400,), 0.1, dtype=np.float32)
+            await _dispatch_message(server, websocket, _start_message(session_id))
+            await _emit_live_interim_from_chunk(
+                server, cast(Any, websocket), session_id, np.full((400,), 0.1, dtype=np.float32)
             )
-            await server._emit_live_interim_from_chunk(
-                cast(Any, websocket), session_id, np.full((400,), 0.2, dtype=np.float32)
+            await _emit_live_interim_from_chunk(
+                server, cast(Any, websocket), session_id, np.full((400,), 0.2, dtype=np.float32)
             )
 
         messages = log_output.getvalue()
@@ -723,12 +755,12 @@ def test_live_interim_case_only_updates_are_emitted(monkeypatch) -> None:
         websocket = FakeWebSocket()
         session_id = uuid4()
 
-        await server._handle_start(cast(Any, websocket), _start_message(session_id))
-        await server._emit_live_interim_from_chunk(
-            cast(Any, websocket), session_id, np.full((400,), 0.1, dtype=np.float32)
+        await _dispatch_message(server, websocket, _start_message(session_id))
+        await _emit_live_interim_from_chunk(
+            server, cast(Any, websocket), session_id, np.full((400,), 0.1, dtype=np.float32)
         )
-        await server._emit_live_interim_from_chunk(
-            cast(Any, websocket), session_id, np.full((400,), 0.2, dtype=np.float32)
+        await _emit_live_interim_from_chunk(
+            server, cast(Any, websocket), session_id, np.full((400,), 0.2, dtype=np.float32)
         )
 
         interim_texts = [
@@ -763,10 +795,10 @@ def test_live_interim_stabilizer_preserves_full_session_transcript_when_window_r
         websocket = FakeWebSocket()
         session_id = uuid4()
 
-        await server._handle_start(cast(Any, websocket), _start_message(session_id))
+        await _dispatch_message(server, websocket, _start_message(session_id))
         for chunk in ready_chunks[:3]:
-            await server._emit_live_interim_from_chunk(cast(Any, websocket), session_id, chunk)
-        await server._handle_stop(cast(Any, websocket), _stop_message(session_id))
+            await _emit_live_interim_from_chunk(server, websocket, session_id, chunk)
+        await _dispatch_message(server, websocket, _stop_message(session_id))
 
         interim_texts = [
             cast(str, payload["text"])
@@ -790,7 +822,7 @@ def test_stop_waits_for_in_flight_live_interim_before_final_send(monkeypatch) ->
 
         server = _build_server(overlay_events_enabled=True)
         transcriber = BlockingIncrementalTranscriber("late interim")
-        _set_dynamic_attr(server, "transcriber", transcriber)
+        _set_dynamic_attr(server.orchestrator, "transcriber", transcriber)
         websocket = FakeWebSocket()
         session_id = uuid4()
         final_started = asyncio.Event()
@@ -804,20 +836,21 @@ def test_stop_waits_for_in_flight_live_interim_before_final_send(monkeypatch) ->
 
         _set_dynamic_attr(websocket, "send_json", send_json)
 
-        await server._handle_start(cast(Any, websocket), _start_message(session_id))
+        await _dispatch_message(server, websocket, _start_message(session_id))
         live_task = asyncio.create_task(
-            server._emit_live_interim_from_chunk(
+            _emit_live_interim_from_chunk(
+                server,
                 cast(Any, websocket),
                 session_id,
                 np.full((400,), 0.2, dtype=np.float32),
             )
         )
-        server._stream_drain_task = live_task
-        server._stream_drain_running = True
+        server.orchestrator._stream_drain_task = live_task
+        server.orchestrator._stream_drain_running = True
         await asyncio.to_thread(transcriber.started.wait)
 
         stop_task = asyncio.create_task(
-            server._handle_stop(cast(Any, websocket), _stop_message(session_id))
+            _dispatch_message(server, websocket, _stop_message(session_id))
         )
         await asyncio.sleep(0)
 
@@ -855,29 +888,33 @@ def test_stop_path_serializes_live_interim_and_final_decode(monkeypatch) -> None
 
         server = _build_server(overlay_events_enabled=True)
         transcriber = SerializingTranscriber()
-        _set_dynamic_attr(server, "transcriber", transcriber)
+        _set_dynamic_attr(server.orchestrator, "transcriber", transcriber)
         _set_dynamic_attr(
-            server,
+            server.orchestrator,
             "_finalise_transcription",
-            DaemonServer._finalise_transcription.__get__(server, DaemonServer),
+            SessionOrchestrator._finalise_transcription.__get__(
+                server.orchestrator,
+                SessionOrchestrator,
+            ),
         )
         websocket = FakeWebSocket()
         session_id = uuid4()
 
-        await server._handle_start(cast(Any, websocket), _start_message(session_id))
+        await _dispatch_message(server, websocket, _start_message(session_id))
         live_task = asyncio.create_task(
-            server._emit_live_interim_from_chunk(
+            _emit_live_interim_from_chunk(
+                server,
                 cast(Any, websocket),
                 session_id,
                 np.full((400,), 0.2, dtype=np.float32),
             )
         )
-        server._stream_drain_task = live_task
-        server._stream_drain_running = True
+        server.orchestrator._stream_drain_task = live_task
+        server.orchestrator._stream_drain_running = True
         await asyncio.to_thread(transcriber.live_started.wait)
 
         stop_task = asyncio.create_task(
-            server._handle_stop(cast(Any, websocket), _stop_message(session_id))
+            _dispatch_message(server, websocket, _stop_message(session_id))
         )
         await asyncio.sleep(0)
 
@@ -909,9 +946,10 @@ def test_abort_emits_session_ended_and_no_final_result() -> None:
         websocket = FakeWebSocket()
         session_id = uuid4()
 
-        await server._handle_start(cast(Any, websocket), _start_message(session_id))
-        await server._handle_abort(
-            cast(Any, websocket),
+        await _dispatch_message(server, websocket, _start_message(session_id))
+        await _dispatch_message(
+            server,
+            websocket,
             AbortSession(
                 type=ClientMessageType.ABORT_SESSION,
                 session_id=session_id,
@@ -943,8 +981,8 @@ def test_phase6_quick_utterance_contract_preserves_final_once(monkeypatch) -> No
         websocket = FakeWebSocket()
         session_id = uuid4()
 
-        await server._handle_start(cast(Any, websocket), _start_message(session_id))
-        await server._handle_stop(cast(Any, websocket), _stop_message(session_id))
+        await _dispatch_message(server, websocket, _start_message(session_id))
+        await _dispatch_message(server, websocket, _stop_message(session_id))
 
         sent_types = [cast(str, payload["type"]) for payload in websocket.sent_json]
         assert sent_types.count("final_result") == 1
@@ -994,10 +1032,10 @@ def test_phase6_long_dictation_contract_preserves_monotonic_interim_tail(monkeyp
         websocket = FakeWebSocket()
         session_id = uuid4()
 
-        await server._handle_start(cast(Any, websocket), _start_message(session_id))
+        await _dispatch_message(server, websocket, _start_message(session_id))
         for chunk in ready_chunks:
-            await server._emit_live_interim_from_chunk(cast(Any, websocket), session_id, chunk)
-        await server._handle_stop(cast(Any, websocket), _stop_message(session_id))
+            await _emit_live_interim_from_chunk(server, websocket, session_id, chunk)
+        await _dispatch_message(server, websocket, _stop_message(session_id))
 
         sent_types = [cast(str, payload["type"]) for payload in websocket.sent_json]
         assert sent_types.count("final_result") == 1
@@ -1037,22 +1075,22 @@ def test_phase6_daemon_reconnect_contract_recovers_with_fresh_session(monkeypatc
         first_session = uuid4()
         second_session = uuid4()
 
-        await server._handle_start(cast(Any, first_socket), _start_message(first_session))
-        await server._emit_live_interim_from_chunk(
-            cast(Any, first_socket), first_session, np.full((400,), 0.2, dtype=np.float32)
+        await _dispatch_message(server, first_socket, _start_message(first_session))
+        await _emit_live_interim_from_chunk(
+            server, cast(Any, first_socket), first_session, np.full((400,), 0.2, dtype=np.float32)
         )
-        await server._emit_live_interim_from_chunk(
-            cast(Any, first_socket), first_session, np.full((400,), 0.3, dtype=np.float32)
+        await _emit_live_interim_from_chunk(
+            server, cast(Any, first_socket), first_session, np.full((400,), 0.3, dtype=np.float32)
         )
-        cleaned = await server._cleanup_active_session(
+        cleaned = await server.orchestrator._cleanup_active_session(
             "websocket disconnected",
             expected_session_id=first_session,
             require_session_match=True,
         )
         assert cleaned is True
-        assert server.sessions.active is None
-        await server._handle_start(cast(Any, second_socket), _start_message(second_session))
-        await server._handle_stop(cast(Any, second_socket), _stop_message(second_session))
+        assert server.orchestrator.sessions.active is None
+        await _dispatch_message(server, second_socket, _start_message(second_session))
+        await _dispatch_message(server, second_socket, _stop_message(second_session))
 
         sent_types = [cast(str, payload["type"]) for payload in second_socket.sent_json]
         assert sent_types.count("final_result") == 1
@@ -1089,11 +1127,11 @@ def test_phase6_overlay_crash_mid_session_contract_keeps_final_non_fatal(monkeyp
 
         _set_dynamic_attr(websocket, "send_json", flaky_send_json)
 
-        await server._handle_start(cast(Any, websocket), _start_message(session_id))
-        await server._emit_live_interim_from_chunk(
-            cast(Any, websocket), session_id, np.full((400,), 0.2, dtype=np.float32)
+        await _dispatch_message(server, websocket, _start_message(session_id))
+        await _emit_live_interim_from_chunk(
+            server, cast(Any, websocket), session_id, np.full((400,), 0.2, dtype=np.float32)
         )
-        await server._handle_stop(cast(Any, websocket), _stop_message(session_id))
+        await _dispatch_message(server, websocket, _stop_message(session_id))
 
         sent_types = [cast(str, payload["type"]) for payload in websocket.sent_json]
         assert sent_types.count("final_result") == 1
@@ -1115,12 +1153,12 @@ def test_live_interim_context_window_grows_across_session() -> None:
         websocket = FakeWebSocket()
         session_id = uuid4()
 
-        await server._handle_start(cast(Any, websocket), _start_message(session_id))
+        await _dispatch_message(server, websocket, _start_message(session_id))
         chunk = np.full((8_000,), 0.2, dtype=np.float32)
         for _ in range(8):
-            await server._emit_live_interim_from_chunk(cast(Any, websocket), session_id, chunk)
+            await _emit_live_interim_from_chunk(server, websocket, session_id, chunk)
 
-        sample_sizes = cast(Any, server.transcriber).sample_sizes
+        sample_sizes = cast(Any, server.orchestrator.transcriber).sample_sizes
         assert sample_sizes == sorted(sample_sizes)
         assert sample_sizes[-1] == 8 * 8_000
 
@@ -1140,10 +1178,10 @@ def test_stop_path_interim_context_window_grows_across_chunks(monkeypatch) -> No
         websocket = FakeWebSocket()
         session_id = uuid4()
 
-        await server._handle_start(cast(Any, websocket), _start_message(session_id))
-        await server._handle_stop(cast(Any, websocket), _stop_message(session_id))
+        await _dispatch_message(server, websocket, _start_message(session_id))
+        await _dispatch_message(server, websocket, _stop_message(session_id))
 
-        sample_sizes = cast(Any, server.transcriber).sample_sizes
+        sample_sizes = cast(Any, server.orchestrator.transcriber).sample_sizes
         assert sample_sizes == sorted(sample_sizes)
         assert sample_sizes[-1] == 8 * 8_000
 

--- a/parakeet-stt-daemon/tests/test_session_cleanup.py
+++ b/parakeet-stt-daemon/tests/test_session_cleanup.py
@@ -10,17 +10,20 @@ from uuid import UUID, uuid4
 import numpy as np
 from fastapi import WebSocketDisconnect
 
-from parakeet_stt_daemon import server as server_module
 from parakeet_stt_daemon.audio import AudioInput
 from parakeet_stt_daemon.config import ServerSettings
+from parakeet_stt_daemon.events import EventSink, EventSinkClosed, WebSocketEventSinkState
 from parakeet_stt_daemon.messages import (
     AbortSession,
     ClientMessageType,
+    ParsedMessage,
+    SessionEndReason,
     StartSession,
     StopSession,
 )
 from parakeet_stt_daemon.server import DaemonServer
 from parakeet_stt_daemon.session import Session, SessionManager
+from parakeet_stt_daemon.session_orchestrator import SessionOrchestrator
 
 
 class FakeAudio:
@@ -47,6 +50,9 @@ class FakeAudio:
         return samples, [], np.zeros((0,), dtype=np.float32)
 
     def take_stream_chunks(self) -> list[object]:
+        return []
+
+    def take_audio_levels(self) -> list[float]:
         return []
 
     def session_limit_exceeded(self) -> bool:
@@ -130,37 +136,39 @@ def _start_event(session_id: UUID) -> dict[str, object]:
 
 def _build_server() -> DaemonServer:
     server = cast(Any, DaemonServer.__new__(DaemonServer))
-    server.settings = ServerSettings(device="cpu", status_enabled=True, streaming_enabled=False)
-    server.sessions = SessionManager()
-    server.audio = FakeAudio()
-    server.model = object()
-    server.transcriber = object()
-    server._session_lock = asyncio.Lock()
-    server._inference_lock = asyncio.Lock()
-    server.streaming_transcriber = None
-    server._active_stream = object()
-    server._stream_drain_task = None
-    server._stream_drain_running = False
-    server._session_guard_task = None
-    server._session_guard_running = False
-    server._session_sample_limit = 1_440_000
-    server._session_age_limit_ms = 90_000
-    server._requested_device = "cpu"
-    server._effective_device = "cpu"
-    server._last_audio_ms = None
-    server._last_audio_stop_ms = None
-    server._last_finalize_ms = None
-    server._last_infer_ms = None
-    server._last_send_ms = None
-    server._live_interim_audio = np.zeros((0,), dtype=np.float32)
-    server._live_interim_failed = False
-    server._overlay_event_seq_by_session = {}
-    server._overlay_last_interim_text_by_session = {}
-    server._overlay_interim_transcript_by_session = {}
-    server._overlay_state_by_session = {}
-    server._overlay_events_emitted = 0
-    server._overlay_events_dropped = 0
+    orchestrator = cast(Any, SessionOrchestrator.__new__(SessionOrchestrator))
+    settings = ServerSettings(device="cpu", status_enabled=True, streaming_enabled=False)
+    server.settings = settings
+    server.orchestrator = orchestrator
+    server.event_sinks = WebSocketEventSinkState(
+        overlay_events_enabled=settings.overlay_events_enabled
+    )
     server._websocket_send_locks = {}
+    orchestrator.settings = settings
+    orchestrator.sessions = SessionManager()
+    orchestrator.audio = FakeAudio()
+    orchestrator.model = object()
+    orchestrator.transcriber = object()
+    orchestrator._session_lock = asyncio.Lock()
+    orchestrator._inference_lock = asyncio.Lock()
+    orchestrator.streaming_transcriber = None
+    orchestrator._active_stream = object()
+    orchestrator._stream_drain_task = None
+    orchestrator._stream_drain_running = False
+    orchestrator._session_guard_task = None
+    orchestrator._session_guard_running = False
+    orchestrator._session_sample_limit = 1_440_000
+    orchestrator._session_age_limit_ms = 90_000
+    orchestrator._requested_device = "cpu"
+    orchestrator._effective_device = "cpu"
+    orchestrator._last_audio_ms = None
+    orchestrator._last_audio_stop_ms = None
+    orchestrator._last_finalize_ms = None
+    orchestrator._last_infer_ms = None
+    orchestrator._last_send_ms = None
+    orchestrator._live_interim_audio = np.zeros((0,), dtype=np.float32)
+    orchestrator._live_interim_failed = False
+    orchestrator._overlay_interim_stabilizer_by_session = {}
 
     async def fake_collect_interim_text_updates(
         _session_id: UUID, _ready_chunks: list[object]
@@ -170,26 +178,20 @@ def _build_server() -> DaemonServer:
     async def fake_finalize(_audio_samples: np.ndarray) -> tuple[str, int]:
         return "final text", 7
 
-    server._collect_interim_text_updates = fake_collect_interim_text_updates
-    server._finalise_transcription = fake_finalize
+    orchestrator._collect_interim_text_updates = fake_collect_interim_text_updates
+    orchestrator._finalise_transcription = fake_finalize
     return cast(DaemonServer, server)
 
 
-def _pause_guard_sleep(monkeypatch) -> tuple[asyncio.Event, asyncio.Event]:
-    guard_sleep_entered = asyncio.Event()
-    allow_guard_resume = asyncio.Event()
-
-    async def fake_guard_sleep(_seconds: float) -> None:
-        guard_sleep_entered.set()
-        await allow_guard_resume.wait()
-
-    monkeypatch.setattr(server_module, "_REAL_ASYNCIO_SLEEP", fake_guard_sleep)
-    return guard_sleep_entered, allow_guard_resume
-
-
-async def _wait_for_session_to_clear(server: DaemonServer) -> None:
-    while server.sessions.active is not None:
-        await asyncio.sleep(0)
+async def _dispatch_message(
+    server: DaemonServer,
+    websocket: FakeWebSocket,
+    message: StartSession | StopSession | AbortSession,
+) -> None:
+    await server._dispatch(
+        cast(Any, websocket),
+        ParsedMessage(kind=ClientMessageType(message.type), model=message),
+    )
 
 
 def test_audio_input_enforces_session_sample_limit() -> None:
@@ -229,21 +231,21 @@ def test_audio_input_clips_pre_roll_to_session_sample_limit() -> None:
 def test_disconnect_cleans_active_session_state() -> None:
     async def scenario() -> None:
         server = _build_server()
-        audio = cast(FakeAudio, server.audio)
+        audio = cast(FakeAudio, server.orchestrator.audio)
         websocket = FakeWebSocket([WebSocketDisconnect()])
         session_id = uuid4()
-        await server.sessions.start_session(session_id, owner_token=id(websocket))
+        await server.orchestrator.sessions.start_session(session_id, owner_token=id(websocket))
 
         drain_task = DummyDrainTask()
-        server._stream_drain_task = cast(Any, drain_task)
-        server._stream_drain_running = True
+        server.orchestrator._stream_drain_task = cast(Any, drain_task)
+        server.orchestrator._stream_drain_running = True
 
         await server.handle_websocket(cast(Any, websocket))
 
-        assert server.sessions.active is None
+        assert server.orchestrator.sessions.active is None
         assert audio.abort_calls == 1
-        assert server._active_stream is None
-        assert server._stream_drain_task is None
+        assert server.orchestrator._active_stream is None
+        assert server.orchestrator._stream_drain_task is None
         assert drain_task.cancel_called is True
         assert drain_task.awaited is True
 
@@ -253,7 +255,7 @@ def test_disconnect_cleans_active_session_state() -> None:
 def test_handler_exception_cleans_active_session_state() -> None:
     async def scenario() -> None:
         server = _build_server()
-        audio = cast(FakeAudio, server.audio)
+        audio = cast(FakeAudio, server.orchestrator.audio)
         websocket = FakeWebSocket(
             [
                 {
@@ -264,7 +266,7 @@ def test_handler_exception_cleans_active_session_state() -> None:
             ]
         )
         session_id = uuid4()
-        await server.sessions.start_session(session_id, owner_token=id(websocket))
+        await server.orchestrator.sessions.start_session(session_id, owner_token=id(websocket))
 
         async def explode_dispatch(*_args, **_kwargs) -> None:
             raise RuntimeError("boom")
@@ -272,83 +274,12 @@ def test_handler_exception_cleans_active_session_state() -> None:
         _set_dynamic_attr(server, "_dispatch", explode_dispatch)
         await server.handle_websocket(cast(Any, websocket))
 
-        assert server.sessions.active is None
+        assert server.orchestrator.sessions.active is None
         assert audio.abort_calls == 1
-        assert server._active_stream is None
+        assert server.orchestrator._active_stream is None
         assert websocket.sent_json
         assert websocket.sent_json[-1]["type"] == "error"
         assert websocket.sent_json[-1]["code"] == "UNEXPECTED"
-
-    asyncio.run(scenario())
-
-
-def test_abort_only_cleans_matching_session() -> None:
-    async def scenario() -> None:
-        server = _build_server()
-        audio = cast(FakeAudio, server.audio)
-        active_session_id = uuid4()
-        websocket = FakeWebSocket([])
-        await server.sessions.start_session(active_session_id, owner_token=id(websocket))
-
-        message = AbortSession(
-            type=ClientMessageType.ABORT_SESSION,
-            session_id=uuid4(),
-            reason="user",
-            timestamp=datetime.now(tz=UTC),
-        )
-        await server._handle_abort(cast(Any, websocket), message)
-
-        assert server.sessions.active is not None
-        assert server.sessions.active.session_id == active_session_id
-        assert audio.abort_calls == 0
-        assert websocket.sent_json
-        assert websocket.sent_json[-1]["type"] == "error"
-        assert websocket.sent_json[-1]["code"] == "SESSION_NOT_FOUND"
-
-    asyncio.run(scenario())
-
-
-def test_stop_session_missing_id_returns_not_found() -> None:
-    async def scenario() -> None:
-        server = _build_server()
-        session_id = uuid4()
-        websocket = FakeWebSocket([])
-
-        message = StopSession(
-            type=ClientMessageType.STOP_SESSION,
-            session_id=session_id,
-            timestamp=datetime.now(tz=UTC),
-        )
-        await server._handle_stop(cast(Any, websocket), message)
-
-        assert websocket.sent_json
-        assert websocket.sent_json[-1]["type"] == "error"
-        assert websocket.sent_json[-1]["code"] == "SESSION_NOT_FOUND"
-
-    asyncio.run(scenario())
-
-
-def test_abort_session_returns_aborted_on_match() -> None:
-    async def scenario() -> None:
-        server = _build_server()
-        audio = cast(FakeAudio, server.audio)
-        session_id = uuid4()
-        websocket = FakeWebSocket([])
-        await server.sessions.start_session(session_id, owner_token=id(websocket))
-
-        message = AbortSession(
-            type=ClientMessageType.ABORT_SESSION,
-            session_id=session_id,
-            reason="user",
-            timestamp=datetime.now(tz=UTC),
-        )
-        await server._handle_abort(cast(Any, websocket), message)
-
-        assert server.sessions.active is None
-        assert audio.abort_calls == 1
-        assert websocket.sent_json
-        assert websocket.sent_json[-1]["type"] == "error"
-        assert websocket.sent_json[-1]["code"] == "SESSION_ABORTED"
 
     asyncio.run(scenario())
 
@@ -370,17 +301,17 @@ def test_invalid_request_errors_on_parse_failure() -> None:
 def test_start_session_rolls_back_when_audio_start_fails() -> None:
     async def scenario() -> None:
         server = _build_server()
-        audio = cast(FakeAudio, server.audio)
+        audio = cast(FakeAudio, server.orchestrator.audio)
         audio.raise_on_start = True
         session_id = uuid4()
 
         websocket = FakeWebSocket([])
-        await server._handle_start(cast(Any, websocket), _start_message(session_id))
+        await _dispatch_message(server, websocket, _start_message(session_id))
 
-        assert server.sessions.active is None
+        assert server.orchestrator.sessions.active is None
         assert audio.start_calls == 1
         assert audio.abort_calls == 1
-        assert server._active_stream is None
+        assert server.orchestrator._active_stream is None
         assert websocket.sent_json
         assert websocket.sent_json[-1]["type"] == "error"
         assert websocket.sent_json[-1]["code"] == "UNEXPECTED"
@@ -391,16 +322,18 @@ def test_start_session_rolls_back_when_audio_start_fails() -> None:
 def test_start_session_rolls_back_when_stream_start_fails() -> None:
     async def scenario() -> None:
         server = _build_server()
-        audio = cast(FakeAudio, server.audio)
-        server.streaming_transcriber = cast(Any, FakeStreamingTranscriber(raise_on_start=True))
+        audio = cast(FakeAudio, server.orchestrator.audio)
+        server.orchestrator.streaming_transcriber = cast(
+            Any, FakeStreamingTranscriber(raise_on_start=True)
+        )
         session_id = uuid4()
 
         websocket = FakeWebSocket([])
-        await server._handle_start(cast(Any, websocket), _start_message(session_id))
+        await _dispatch_message(server, websocket, _start_message(session_id))
 
-        assert server.sessions.active is None
+        assert server.orchestrator.sessions.active is None
         assert audio.abort_calls == 1
-        assert server._active_stream is None
+        assert server.orchestrator._active_stream is None
         assert websocket.sent_json
         assert websocket.sent_json[-1]["type"] == "error"
         assert websocket.sent_json[-1]["code"] == "UNEXPECTED"
@@ -411,20 +344,22 @@ def test_start_session_rolls_back_when_stream_start_fails() -> None:
 def test_start_session_rolls_back_when_drain_loop_start_fails() -> None:
     async def scenario() -> None:
         server = _build_server()
-        audio = cast(FakeAudio, server.audio)
-        server.streaming_transcriber = cast(Any, FakeStreamingTranscriber())
+        audio = cast(FakeAudio, server.orchestrator.audio)
+        server.orchestrator.streaming_transcriber = cast(Any, FakeStreamingTranscriber())
         session_id = uuid4()
 
         def explode_start_stream_drain_loop(_websocket: Any, _session_id: UUID) -> None:
             raise RuntimeError("drain loop failed")
 
-        _set_dynamic_attr(server, "_start_stream_drain_loop", explode_start_stream_drain_loop)
+        _set_dynamic_attr(
+            server.orchestrator, "_start_stream_drain_loop", explode_start_stream_drain_loop
+        )
         websocket = FakeWebSocket([])
-        await server._handle_start(cast(Any, websocket), _start_message(session_id))
+        await _dispatch_message(server, websocket, _start_message(session_id))
 
-        assert server.sessions.active is None
+        assert server.orchestrator.sessions.active is None
         assert audio.abort_calls == 1
-        assert server._active_stream is None
+        assert server.orchestrator._active_stream is None
         assert websocket.sent_json
         assert websocket.sent_json[-1]["type"] == "error"
         assert websocket.sent_json[-1]["code"] == "UNEXPECTED"
@@ -435,7 +370,7 @@ def test_start_session_rolls_back_when_drain_loop_start_fails() -> None:
 def test_start_session_rolls_back_when_session_started_send_fails() -> None:
     async def scenario() -> None:
         server = _build_server()
-        audio = cast(FakeAudio, server.audio)
+        audio = cast(FakeAudio, server.orchestrator.audio)
         session_id = uuid4()
         websocket = FakeWebSocket([])
 
@@ -449,11 +384,11 @@ def test_start_session_rolls_back_when_session_started_send_fails() -> None:
             websocket.sent_json.append(payload)
 
         _set_dynamic_attr(websocket, "send_json", fail_first_send)
-        await server._handle_start(cast(Any, websocket), _start_message(session_id))
+        await _dispatch_message(server, websocket, _start_message(session_id))
 
-        assert server.sessions.active is None
+        assert server.orchestrator.sessions.active is None
         assert audio.abort_calls == 1
-        assert server._active_stream is None
+        assert server.orchestrator._active_stream is None
         assert send_attempts == 2
         assert websocket.sent_json
         assert websocket.sent_json[-1]["type"] == "error"
@@ -465,8 +400,8 @@ def test_start_session_rolls_back_when_session_started_send_fails() -> None:
 def test_start_session_streaming_send_failure_stops_drain_loop() -> None:
     async def scenario() -> None:
         server = _build_server()
-        audio = cast(FakeAudio, server.audio)
-        server.streaming_transcriber = cast(Any, FakeStreamingTranscriber())
+        audio = cast(FakeAudio, server.orchestrator.audio)
+        server.orchestrator.streaming_transcriber = cast(Any, FakeStreamingTranscriber())
         session_id = uuid4()
         websocket = FakeWebSocket([])
 
@@ -480,14 +415,14 @@ def test_start_session_streaming_send_failure_stops_drain_loop() -> None:
             websocket.sent_json.append(payload)
 
         _set_dynamic_attr(websocket, "send_json", fail_first_send)
-        await server._handle_start(cast(Any, websocket), _start_message(session_id))
+        await _dispatch_message(server, websocket, _start_message(session_id))
         await asyncio.sleep(0)
 
-        assert server.sessions.active is None
+        assert server.orchestrator.sessions.active is None
         assert audio.abort_calls == 1
-        assert server._active_stream is None
-        assert server._stream_drain_task is None
-        assert server._stream_drain_running is False
+        assert server.orchestrator._active_stream is None
+        assert server.orchestrator._stream_drain_task is None
+        assert server.orchestrator._stream_drain_running is False
         assert send_attempts == 2
         assert websocket.sent_json
         assert websocket.sent_json[-1]["type"] == "error"
@@ -496,10 +431,10 @@ def test_start_session_streaming_send_failure_stops_drain_loop() -> None:
     asyncio.run(scenario())
 
 
-def test_start_session_disconnect_rolls_back_and_bubbles_disconnect() -> None:
+def test_start_session_disconnect_rolls_back_and_bubbles_sink_closed() -> None:
     async def scenario() -> None:
         server = _build_server()
-        audio = cast(FakeAudio, server.audio)
+        audio = cast(FakeAudio, server.orchestrator.audio)
         session_id = uuid4()
         websocket = FakeWebSocket([])
 
@@ -508,15 +443,15 @@ def test_start_session_disconnect_rolls_back_and_bubbles_disconnect() -> None:
 
         _set_dynamic_attr(websocket, "send_json", raise_disconnect)
         try:
-            await server._handle_start(cast(Any, websocket), _start_message(session_id))
-        except WebSocketDisconnect:
+            await _dispatch_message(server, websocket, _start_message(session_id))
+        except EventSinkClosed:
             pass
         else:
-            raise AssertionError("expected WebSocketDisconnect")
+            raise AssertionError("expected EventSinkClosed")
 
-        assert server.sessions.active is None
+        assert server.orchestrator.sessions.active is None
         assert audio.abort_calls == 1
-        assert server._active_stream is None
+        assert server.orchestrator._active_stream is None
         assert not websocket.sent_json
 
     asyncio.run(scenario())
@@ -525,7 +460,7 @@ def test_start_session_disconnect_rolls_back_and_bubbles_disconnect() -> None:
 def test_handle_websocket_disconnect_during_start_does_not_cleanup_new_session() -> None:
     async def scenario() -> None:
         server = _build_server()
-        audio = cast(FakeAudio, server.audio)
+        audio = cast(FakeAudio, server.orchestrator.audio)
         start_session_id = uuid4()
         replacement_session_id = uuid4()
         websocket = FakeWebSocket([_start_event(start_session_id)])
@@ -534,7 +469,7 @@ def test_handle_websocket_disconnect_during_start_does_not_cleanup_new_session()
             raise WebSocketDisconnect()
 
         _set_dynamic_attr(websocket, "send_json", raise_disconnect)
-        original_cleanup = server._cleanup_active_session
+        original_cleanup = server.orchestrator._cleanup_active_session
         cleanup_calls = 0
 
         async def cleanup_with_interleaving(
@@ -544,26 +479,32 @@ def test_handle_websocket_disconnect_during_start_does_not_cleanup_new_session()
             *,
             require_session_match: bool = False,
             require_owner_match: bool = False,
+            event_sink: EventSink | None = None,
+            session_end_reason: SessionEndReason | None = None,
         ) -> bool:
             nonlocal cleanup_calls
             cleanup_calls += 1
             if cleanup_calls == 2:
-                await server.sessions.start_session(replacement_session_id, owner_token=-1)
+                await server.orchestrator.sessions.start_session(
+                    replacement_session_id, owner_token=-1
+                )
             return await original_cleanup(
                 reason,
                 expected_session_id=expected_session_id,
                 expected_owner_token=expected_owner_token,
                 require_session_match=require_session_match,
                 require_owner_match=require_owner_match,
+                event_sink=event_sink,
+                session_end_reason=session_end_reason,
             )
 
-        _set_dynamic_attr(server, "_cleanup_active_session", cleanup_with_interleaving)
+        _set_dynamic_attr(server.orchestrator, "_cleanup_active_session", cleanup_with_interleaving)
         await server.handle_websocket(cast(Any, websocket))
 
         assert cleanup_calls == 2
         assert audio.abort_calls == 1
-        assert server.sessions.active is not None
-        assert server.sessions.active.session_id == replacement_session_id
+        assert server.orchestrator.sessions.active is not None
+        assert server.orchestrator.sessions.active.session_id == replacement_session_id
 
     asyncio.run(scenario())
 
@@ -572,16 +513,19 @@ def test_status_reports_runtime_truth_and_last_timings() -> None:
     async def scenario() -> None:
         server = _build_server()
         server.settings = ServerSettings(device="cuda", status_enabled=True, streaming_enabled=True)
-        server._requested_device = "cuda"
-        server._effective_device = "cpu"
-        server.streaming_transcriber = cast(Any, FakeStreamingTranscriber(helper_active=False))
-        server._last_audio_ms = 1200
-        server._last_audio_stop_ms = 9
-        server._last_finalize_ms = 120
-        server._last_infer_ms = 85
-        server._last_send_ms = 4
+        server.orchestrator.settings = server.settings
+        server.orchestrator._requested_device = "cuda"
+        server.orchestrator._effective_device = "cpu"
+        server.orchestrator.streaming_transcriber = cast(
+            Any, FakeStreamingTranscriber(helper_active=False)
+        )
+        server.orchestrator._last_audio_ms = 1200
+        server.orchestrator._last_audio_stop_ms = 9
+        server.orchestrator._last_finalize_ms = 120
+        server.orchestrator._last_infer_ms = 85
+        server.orchestrator._last_send_ms = 4
         session_id = uuid4()
-        await server.sessions.start_session(session_id, owner_token=1)
+        await server.orchestrator.sessions.start_session(session_id, owner_token=1)
 
         status = server.status()
 
@@ -603,33 +547,6 @@ def test_status_reports_runtime_truth_and_last_timings() -> None:
     asyncio.run(scenario())
 
 
-def test_session_guard_emits_warning_and_stops_when_audio_limit_exceeded(monkeypatch) -> None:
-    async def scenario() -> None:
-        guard_sleep_entered, allow_guard_resume = _pause_guard_sleep(monkeypatch)
-        server = _build_server()
-        audio = cast(FakeAudio, server.audio)
-        websocket = FakeWebSocket([])
-        session_id = uuid4()
-
-        await server._handle_start(cast(Any, websocket), _start_message(session_id))
-        await asyncio.wait_for(guard_sleep_entered.wait(), timeout=1.0)
-        audio._session_limit_exceeded = True
-        allow_guard_resume.set()
-        # Guard should stop on its own without aborting the session.
-        await asyncio.sleep(0.15)
-
-        # Session stays active — finalization happens on stop_session.
-        assert server.sessions.active is not None
-        assert audio.abort_calls == 0
-        warning_payloads = [
-            payload for payload in websocket.sent_json if payload.get("type") == "session_warning"
-        ]
-        assert warning_payloads
-        assert warning_payloads[-1]["warning"] == "approaching_limit"
-
-    asyncio.run(scenario())
-
-
 def test_session_guard_warning_threshold_tracks_effective_sample_cap() -> None:
     server = _build_server()
     server.settings = ServerSettings(
@@ -639,67 +556,43 @@ def test_session_guard_warning_threshold_tracks_effective_sample_cap() -> None:
         max_session_seconds=90.0,
         max_session_samples=16_000,
     )
-    server._session_age_limit_ms = 90_000
-    server._session_sample_limit = 16_000
+    server.orchestrator.settings = server.settings
+    server.orchestrator._session_age_limit_ms = 90_000
+    server.orchestrator._session_sample_limit = 16_000
     session = Session(session_id=uuid4(), owner_token=1)
     session.started_at = datetime.now(tz=UTC) - timedelta(milliseconds=850)
 
-    assert server._effective_session_limit_seconds() == 1.0
-    assert server._session_guard_warning_due(session) is True
-    assert 0.0 <= server._session_remaining_seconds(session) <= 0.2
+    assert server.orchestrator._effective_session_limit_seconds() == 1.0
+    assert server.orchestrator._session_guard_warning_due(session) is True
+    assert 0.0 <= server.orchestrator._session_remaining_seconds(session) <= 0.2
 
 
 def test_disconnect_from_non_owner_websocket_leaves_active_session_state() -> None:
     async def scenario() -> None:
         server = _build_server()
-        audio = cast(FakeAudio, server.audio)
+        audio = cast(FakeAudio, server.orchestrator.audio)
         owner_websocket = FakeWebSocket([])
         other_websocket = FakeWebSocket([WebSocketDisconnect()])
         session_id = uuid4()
-        await server.sessions.start_session(session_id, owner_token=id(owner_websocket))
+        await server.orchestrator.sessions.start_session(
+            session_id, owner_token=id(owner_websocket)
+        )
 
         active_stream = cast(Any, object())
         drain_task = DummyDrainTask()
-        server._active_stream = active_stream
-        server._stream_drain_task = cast(Any, drain_task)
-        server._stream_drain_running = True
+        server.orchestrator._active_stream = active_stream
+        server.orchestrator._stream_drain_task = cast(Any, drain_task)
+        server.orchestrator._stream_drain_running = True
 
         await server.handle_websocket(cast(Any, other_websocket))
 
-        assert server.sessions.active is not None
-        assert server.sessions.active.session_id == session_id
-        assert server.sessions.active.owner_token == id(owner_websocket)
+        assert server.orchestrator.sessions.active is not None
+        assert server.orchestrator.sessions.active.session_id == session_id
+        assert server.orchestrator.sessions.active.owner_token == id(owner_websocket)
         assert audio.abort_calls == 0
-        assert server._active_stream is active_stream
-        assert server._stream_drain_task is drain_task
+        assert server.orchestrator._active_stream is active_stream
+        assert server.orchestrator._stream_drain_task is drain_task
         assert drain_task.cancel_called is False
-
-    asyncio.run(scenario())
-
-
-def test_session_guard_auto_stops_when_duration_limit_exceeded() -> None:
-    async def scenario() -> None:
-        server = _build_server()
-        audio = cast(FakeAudio, server.audio)
-        server._session_age_limit_ms = 0
-        websocket = FakeWebSocket([])
-        session_id = uuid4()
-
-        await server._handle_start(cast(Any, websocket), _start_message(session_id))
-        await asyncio.sleep(0.15)
-
-        assert server.sessions.active is None
-        assert audio.abort_calls == 0
-        assert audio.stop_calls == 1
-        warning_payloads = [
-            payload for payload in websocket.sent_json if payload.get("type") == "session_warning"
-        ]
-        final_payloads = [
-            payload for payload in websocket.sent_json if payload.get("type") == "final_result"
-        ]
-        assert warning_payloads
-        assert final_payloads
-        assert warning_payloads[-1]["warning"] == "approaching_limit"
 
     asyncio.run(scenario())
 
@@ -710,18 +603,20 @@ def test_stop_session_from_non_owner_returns_not_found() -> None:
         owner_websocket = FakeWebSocket([])
         other_websocket = FakeWebSocket([])
         session_id = uuid4()
-        await server.sessions.start_session(session_id, owner_token=id(owner_websocket))
+        await server.orchestrator.sessions.start_session(
+            session_id, owner_token=id(owner_websocket)
+        )
 
         message = StopSession(
             type=ClientMessageType.STOP_SESSION,
             session_id=session_id,
             timestamp=datetime.now(tz=UTC),
         )
-        await server._handle_stop(cast(Any, other_websocket), message)
+        await _dispatch_message(server, other_websocket, message)
 
-        assert server.sessions.active is not None
-        assert server.sessions.active.session_id == session_id
-        assert server.sessions.active.owner_token == id(owner_websocket)
+        assert server.orchestrator.sessions.active is not None
+        assert server.orchestrator.sessions.active.session_id == session_id
+        assert server.orchestrator.sessions.active.owner_token == id(owner_websocket)
         assert other_websocket.sent_json
         assert other_websocket.sent_json[-1]["type"] == "error"
         assert other_websocket.sent_json[-1]["code"] == "SESSION_NOT_FOUND"
@@ -732,11 +627,13 @@ def test_stop_session_from_non_owner_returns_not_found() -> None:
 def test_abort_session_from_non_owner_returns_not_found() -> None:
     async def scenario() -> None:
         server = _build_server()
-        audio = cast(FakeAudio, server.audio)
+        audio = cast(FakeAudio, server.orchestrator.audio)
         owner_websocket = FakeWebSocket([])
         other_websocket = FakeWebSocket([])
         session_id = uuid4()
-        await server.sessions.start_session(session_id, owner_token=id(owner_websocket))
+        await server.orchestrator.sessions.start_session(
+            session_id, owner_token=id(owner_websocket)
+        )
 
         message = AbortSession(
             type=ClientMessageType.ABORT_SESSION,
@@ -744,11 +641,11 @@ def test_abort_session_from_non_owner_returns_not_found() -> None:
             reason="user",
             timestamp=datetime.now(tz=UTC),
         )
-        await server._handle_abort(cast(Any, other_websocket), message)
+        await _dispatch_message(server, other_websocket, message)
 
-        assert server.sessions.active is not None
-        assert server.sessions.active.session_id == session_id
-        assert server.sessions.active.owner_token == id(owner_websocket)
+        assert server.orchestrator.sessions.active is not None
+        assert server.orchestrator.sessions.active.session_id == session_id
+        assert server.orchestrator.sessions.active.owner_token == id(owner_websocket)
         assert audio.abort_calls == 0
         assert other_websocket.sent_json
         assert other_websocket.sent_json[-1]["type"] == "error"

--- a/parakeet-stt-daemon/tests/test_session_orchestrator.py
+++ b/parakeet-stt-daemon/tests/test_session_orchestrator.py
@@ -1,0 +1,344 @@
+"""SessionOrchestrator lifecycle tests using RecordingEventSink."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from typing import Any, TypeVar, cast
+from uuid import UUID, uuid4
+
+import numpy as np
+from pytest import MonkeyPatch
+
+from parakeet_stt_daemon import session_orchestrator as orchestrator_module
+from parakeet_stt_daemon.config import ServerSettings
+from parakeet_stt_daemon.events import (
+    FinalResultEvent,
+    RecordingEventSink,
+    SessionEndedEvent,
+    SessionErrorEvent,
+    SessionWarningEvent,
+)
+from parakeet_stt_daemon.messages import SessionEndReason
+from parakeet_stt_daemon.session import SessionManager
+from parakeet_stt_daemon.session_orchestrator import (
+    AbortSessionIntent,
+    SessionOrchestrator,
+    StartSessionIntent,
+    StopSessionIntent,
+)
+
+
+class FakeAudio:
+    sample_rate = 16_000
+
+    def __init__(self, *, samples: np.ndarray | None = None) -> None:
+        self.samples = samples if samples is not None else np.ones((1_600,), dtype=np.float32)
+        self.abort_calls = 0
+        self.limit_exceeded = False
+        self.start_calls = 0
+        self.stop_calls = 0
+
+    def start_session(self) -> None:
+        self.start_calls += 1
+
+    def abort_session(self) -> None:
+        self.abort_calls += 1
+
+    def stop_session_with_streaming(self) -> tuple[np.ndarray, list[np.ndarray], np.ndarray]:
+        self.stop_calls += 1
+        return self.samples, [], np.zeros((0,), dtype=np.float32)
+
+    def take_audio_levels(self) -> list[float]:
+        return []
+
+    def take_stream_chunks(self) -> list[np.ndarray]:
+        return []
+
+    def session_limit_exceeded(self) -> bool:
+        return self.limit_exceeded
+
+
+class FakeStreamingTranscriber:
+    helper_active = True
+    fallback_reason: str | None = None
+
+    def start_session(self, _sample_rate: int) -> object:
+        return object()
+
+
+def _build_orchestrator(
+    *,
+    streaming_enabled: bool = False,
+    max_session_seconds: float = 90.0,
+) -> SessionOrchestrator:
+    orchestrator = cast(Any, SessionOrchestrator.__new__(SessionOrchestrator))
+    settings = ServerSettings(
+        device="cpu",
+        streaming_enabled=streaming_enabled,
+        overlay_events_enabled=True,
+        max_session_seconds=max_session_seconds,
+    )
+    orchestrator.settings = settings
+    orchestrator.sessions = SessionManager()
+    orchestrator.audio = FakeAudio()
+    orchestrator.model = object()
+    orchestrator.transcriber = object()
+    orchestrator._session_lock = asyncio.Lock()
+    orchestrator._inference_lock = asyncio.Lock()
+    orchestrator.streaming_transcriber = FakeStreamingTranscriber() if streaming_enabled else None
+    orchestrator._active_stream = None
+    orchestrator._stream_drain_task = None
+    orchestrator._stream_drain_running = False
+    orchestrator._session_guard_task = None
+    orchestrator._session_guard_running = False
+    orchestrator._session_sample_limit = int(max_session_seconds * FakeAudio.sample_rate)
+    orchestrator._session_age_limit_ms = int(max_session_seconds * 1000)
+    orchestrator._requested_device = "cpu"
+    orchestrator._effective_device = "cpu"
+    orchestrator._last_audio_ms = None
+    orchestrator._last_audio_stop_ms = None
+    orchestrator._last_finalize_ms = None
+    orchestrator._last_infer_ms = None
+    orchestrator._last_send_ms = None
+    orchestrator._live_interim_audio = np.zeros((0,), dtype=np.float32)
+    orchestrator._live_interim_failed = False
+    orchestrator._overlay_interim_stabilizer_by_session = {}
+    orchestrator._vad_enabled = False
+
+    async def fake_collect_interim_text_updates(
+        _session_id: UUID, _ready_chunks: list[np.ndarray]
+    ) -> list[str]:
+        return []
+
+    async def fake_finalise(_audio_samples: np.ndarray) -> tuple[str, int]:
+        return "final text", 7
+
+    orchestrator._collect_interim_text_updates = fake_collect_interim_text_updates
+    orchestrator._finalise_transcription = fake_finalise
+    return cast(SessionOrchestrator, orchestrator)
+
+
+T = TypeVar("T")
+
+
+def _events_of_type(
+    sink: RecordingEventSink,
+    event_type: type[T],
+) -> list[T]:
+    return [event for event in sink.events if isinstance(event, event_type)]
+
+
+async def _start(
+    orchestrator: SessionOrchestrator,
+    sink: RecordingEventSink,
+    session_id: UUID,
+    *,
+    owner_token: int = 1,
+) -> None:
+    await orchestrator.start(
+        StartSessionIntent(
+            session_id=session_id,
+            owner_token=owner_token,
+            event_sink=sink,
+        )
+    )
+
+
+def test_start_while_busy_emits_session_busy() -> None:
+    async def scenario() -> None:
+        orchestrator = _build_orchestrator()
+        sink = RecordingEventSink()
+        await _start(orchestrator, sink, uuid4())
+
+        await _start(orchestrator, sink, uuid4())
+
+        errors = _events_of_type(sink, SessionErrorEvent)
+        assert errors
+        assert errors[-1].code == "SESSION_BUSY"
+
+    asyncio.run(scenario())
+
+
+def test_stop_without_start_emits_session_not_found() -> None:
+    async def scenario() -> None:
+        orchestrator = _build_orchestrator()
+        sink = RecordingEventSink()
+        session_id = uuid4()
+
+        await orchestrator.stop(
+            StopSessionIntent(
+                session_id=session_id,
+                owner_token=1,
+                event_sink=sink,
+                post_roll_secs=0.0,
+            )
+        )
+
+        errors = _events_of_type(sink, SessionErrorEvent)
+        assert errors == [
+            SessionErrorEvent(
+                session_id=session_id,
+                code="SESSION_NOT_FOUND",
+                message="No matching active session",
+            )
+        ]
+
+    asyncio.run(scenario())
+
+
+def test_abort_mid_stream_cleans_runtime_without_final_result() -> None:
+    async def scenario() -> None:
+        orchestrator = _build_orchestrator(streaming_enabled=True)
+        sink = RecordingEventSink()
+        session_id = uuid4()
+
+        await _start(orchestrator, sink, session_id)
+        assert orchestrator._active_stream is not None
+
+        await orchestrator.abort(
+            AbortSessionIntent(
+                session_id=session_id,
+                owner_token=1,
+                event_sink=sink,
+                reason="user",
+            )
+        )
+
+        assert orchestrator.sessions.active is None
+        assert cast(FakeAudio, orchestrator.audio).abort_calls == 1
+        assert _events_of_type(sink, FinalResultEvent) == []
+        ended = _events_of_type(sink, SessionEndedEvent)
+        assert ended
+        assert ended[-1].reason == SessionEndReason.ABORT
+
+    asyncio.run(scenario())
+
+
+def test_guard_loop_warns_at_80_percent_then_terminates_at_100_percent(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    async def scenario() -> None:
+        orchestrator = _build_orchestrator(max_session_seconds=1.0)
+        sink = RecordingEventSink()
+        session_id = uuid4()
+        sleep_calls = 0
+
+        async def fake_guard_sleep(_seconds: float) -> None:
+            nonlocal sleep_calls
+            sleep_calls += 1
+            active = orchestrator.sessions.active
+            if active is not None and sleep_calls == 1:
+                active.started_at = datetime.now(tz=UTC) - timedelta(milliseconds=850)
+            elif active is not None and sleep_calls == 2:
+                active.started_at = datetime.now(tz=UTC) - timedelta(milliseconds=1100)
+            await asyncio.sleep(0)
+
+        monkeypatch.setattr(orchestrator_module, "_REAL_ASYNCIO_SLEEP", fake_guard_sleep)
+
+        await _start(orchestrator, sink, session_id)
+        for _ in range(20):
+            if orchestrator.sessions.active is None:
+                break
+            await asyncio.sleep(0)
+
+        assert orchestrator.sessions.active is None
+        assert cast(FakeAudio, orchestrator.audio).stop_calls == 1
+        warnings = _events_of_type(sink, SessionWarningEvent)
+        assert len(warnings) == 1
+        assert warnings[0].warning == "approaching_limit"
+        assert warnings[0].remaining_seconds <= 0.2
+
+    asyncio.run(scenario())
+
+
+def test_guard_loop_auto_stops_when_audio_sample_limit_is_exceeded(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    async def scenario() -> None:
+        orchestrator = _build_orchestrator(max_session_seconds=1.0)
+        audio = cast(FakeAudio, orchestrator.audio)
+        sink = RecordingEventSink()
+        session_id = uuid4()
+
+        async def fake_guard_sleep(_seconds: float) -> None:
+            active = orchestrator.sessions.active
+            if active is not None:
+                active.started_at = datetime.now(tz=UTC) - timedelta(milliseconds=850)
+                audio.limit_exceeded = True
+            await asyncio.sleep(0)
+
+        monkeypatch.setattr(orchestrator_module, "_REAL_ASYNCIO_SLEEP", fake_guard_sleep)
+
+        await _start(orchestrator, sink, session_id)
+        for _ in range(20):
+            if orchestrator.sessions.active is None:
+                break
+            await asyncio.sleep(0)
+
+        assert orchestrator.sessions.active is None
+        assert audio.stop_calls == 1
+        warnings = _events_of_type(sink, SessionWarningEvent)
+        assert len(warnings) == 1
+        assert warnings[0].warning == "approaching_limit"
+        finals = _events_of_type(sink, FinalResultEvent)
+        ended = _events_of_type(sink, SessionEndedEvent)
+        assert len(finals) == 1
+        assert ended
+        assert ended[-1].reason == SessionEndReason.FINAL
+
+    asyncio.run(scenario())
+
+
+def test_clean_disconnect_during_streaming_emits_abort_end_reason() -> None:
+    async def scenario() -> None:
+        orchestrator = _build_orchestrator(streaming_enabled=True)
+        sink = RecordingEventSink()
+        session_id = uuid4()
+        await _start(orchestrator, sink, session_id)
+
+        cleaned = await orchestrator._cleanup_active_session(
+            "websocket disconnected",
+            expected_session_id=session_id,
+            expected_owner_token=1,
+            require_session_match=True,
+            require_owner_match=True,
+            event_sink=sink,
+            session_end_reason=SessionEndReason.ABORT,
+        )
+
+        assert cleaned is True
+        assert orchestrator.sessions.active is None
+        ended = _events_of_type(sink, SessionEndedEvent)
+        assert ended
+        assert ended[-1].reason == SessionEndReason.ABORT
+
+    asyncio.run(scenario())
+
+
+def test_finalization_emits_one_final_result_then_final_session_ended() -> None:
+    async def scenario() -> None:
+        orchestrator = _build_orchestrator()
+        sink = RecordingEventSink()
+        session_id = uuid4()
+        await _start(orchestrator, sink, session_id)
+
+        await orchestrator.stop(
+            StopSessionIntent(
+                session_id=session_id,
+                owner_token=1,
+                event_sink=sink,
+                post_roll_secs=0.0,
+            )
+        )
+
+        finals = _events_of_type(sink, FinalResultEvent)
+        ended = _events_of_type(sink, SessionEndedEvent)
+        assert len(finals) == 1
+        assert len(ended) == 1
+        assert ended[0].reason == SessionEndReason.FINAL
+        final_index = sink.events.index(finals[0])
+        ended_index = sink.events.index(ended[0])
+        assert final_index < ended_index
+
+    asyncio.run(scenario())

--- a/parakeet-stt-daemon/tests/test_streaming_truth.py
+++ b/parakeet-stt-daemon/tests/test_streaming_truth.py
@@ -9,8 +9,9 @@ from uuid import uuid4
 import numpy as np
 
 from parakeet_stt_daemon.config import ServerSettings
-from parakeet_stt_daemon.server import DaemonServer
+from parakeet_stt_daemon.messages import StatusMessage
 from parakeet_stt_daemon.session import SessionManager
+from parakeet_stt_daemon.session_orchestrator import SessionOrchestrator
 from parakeet_stt_daemon.tail_trim import SealPathTailTrimmer
 
 
@@ -65,55 +66,57 @@ def _build_server(
     streaming_enabled: bool = True,
     streaming_transcriber: Any = None,
     vad_enabled: bool = False,
-) -> DaemonServer:
-    server = cast(Any, DaemonServer.__new__(DaemonServer))
-    server.settings = ServerSettings(
+) -> SessionOrchestrator:
+    orchestrator = cast(Any, SessionOrchestrator.__new__(SessionOrchestrator))
+    orchestrator.settings = ServerSettings(
         device="cpu",
         status_enabled=True,
         streaming_enabled=streaming_enabled,
         vad_enabled=vad_enabled,
     )
-    server.sessions = SessionManager()
-    server.audio = FakeAudio()
-    server.model = object()
-    server.transcriber = object()
-    server._session_lock = asyncio.Lock()
-    server._inference_lock = asyncio.Lock()
-    server.streaming_transcriber = streaming_transcriber
-    server._active_stream = None
-    server._stream_drain_task = None
-    server._stream_drain_running = False
-    server._requested_device = "cpu"
-    server._effective_device = "cpu"
-    server._last_audio_ms = None
-    server._last_audio_stop_ms = None
-    server._last_finalize_ms = None
-    server._last_infer_ms = None
-    server._last_send_ms = None
-    server._live_interim_audio = np.zeros((0,), dtype=np.float32)
-    server._live_interim_failed = False
-    server._overlay_event_seq_by_session = {}
-    server._overlay_last_interim_text_by_session = {}
-    server._overlay_interim_transcript_by_session = {}
-    server._overlay_state_by_session = {}
-    server._overlay_events_emitted = 0
-    server._overlay_events_dropped = 0
-    server._websocket_send_locks = {}
-    server._vad_enabled = vad_enabled
-    server.tail_trimmer = SealPathTailTrimmer(
+    orchestrator.sessions = SessionManager()
+    orchestrator.audio = FakeAudio()
+    orchestrator.model = object()
+    orchestrator.transcriber = object()
+    orchestrator._session_lock = asyncio.Lock()
+    orchestrator._inference_lock = asyncio.Lock()
+    orchestrator.streaming_transcriber = streaming_transcriber
+    orchestrator._active_stream = None
+    orchestrator._stream_drain_task = None
+    orchestrator._stream_drain_running = False
+    orchestrator._requested_device = "cpu"
+    orchestrator._effective_device = "cpu"
+    orchestrator._last_audio_ms = None
+    orchestrator._last_audio_stop_ms = None
+    orchestrator._last_finalize_ms = None
+    orchestrator._last_infer_ms = None
+    orchestrator._last_send_ms = None
+    orchestrator._live_interim_audio = np.zeros((0,), dtype=np.float32)
+    orchestrator._live_interim_failed = False
+    orchestrator._overlay_interim_stabilizer_by_session = {}
+    orchestrator._vad_enabled = vad_enabled
+    orchestrator.tail_trimmer = SealPathTailTrimmer(
         vad_enabled=vad_enabled,
-        silence_floor_db=float(server.settings.silence_floor_db),
+        silence_floor_db=float(orchestrator.settings.silence_floor_db),
         vad_adapter=FakeVadAdapter(),
         warmup_sample_rate=FakeAudio.sample_rate,
     )
-    return cast(DaemonServer, server)
+    return cast(SessionOrchestrator, orchestrator)
+
+
+def _status(orchestrator: SessionOrchestrator) -> StatusMessage:
+    return orchestrator.status(
+        overlay_events_enabled=orchestrator.settings.overlay_events_enabled,
+        overlay_events_emitted=0,
+        overlay_events_dropped=0,
+    )
 
 
 def test_status_streaming_disabled_by_config() -> None:
     """When streaming is disabled by config, helper fields reflect that."""
     server = _build_server(streaming_enabled=False)
 
-    status = server.status()
+    status = _status(server)
 
     assert status.streaming_enabled is False
     assert status.stream_helper_active is False
@@ -136,7 +139,7 @@ def test_status_streaming_enabled_helper_active() -> None:
     )
     server = _build_server(streaming_transcriber=transcriber)
 
-    status = server.status()
+    status = _status(server)
 
     assert status.streaming_enabled is True
     assert status.stream_helper_active is True
@@ -150,7 +153,7 @@ def test_status_streaming_enabled_helper_active() -> None:
 def test_status_vad_enabled_pending_load_is_explicit() -> None:
     server = _build_server(streaming_enabled=False, vad_enabled=True)
 
-    status = server.status()
+    status = _status(server)
 
     assert status.vad_enabled is True
     assert status.vad_active is False
@@ -162,7 +165,7 @@ def test_status_vad_enabled_and_loaded_is_active() -> None:
     server = _build_server(streaming_enabled=False, vad_enabled=True)
     server.prepare_vad()
 
-    status = server.status()
+    status = _status(server)
 
     assert status.vad_enabled is True
     assert status.vad_active is True
@@ -195,7 +198,7 @@ def test_status_streaming_enabled_helper_inactive() -> None:
     )
     server = _build_server(streaming_transcriber=transcriber)
 
-    status = server.status()
+    status = _status(server)
 
     assert status.streaming_enabled is True
     assert status.stream_helper_active is False
@@ -209,7 +212,7 @@ def test_status_streaming_enabled_transcriber_none() -> None:
     """When streaming_transcriber is None despite enabled config."""
     server = _build_server(streaming_transcriber=None)
 
-    status = server.status()
+    status = _status(server)
 
     assert status.streaming_enabled is True
     assert status.stream_helper_active is False
@@ -254,7 +257,7 @@ def test_status_includes_active_session_age_when_session_active() -> None:
         session_id = uuid4()
         await server.sessions.start_session(session_id, owner_token=1)
 
-        status = server.status()
+        status = _status(server)
         assert status.active_session_age_ms is not None
         assert status.active_session_age_ms >= 0
 
@@ -265,7 +268,7 @@ def test_status_no_active_session_age_when_idle() -> None:
     """active_session_age_ms is None when no session is active."""
     server = _build_server(streaming_enabled=False)
 
-    status = server.status()
+    status = _status(server)
     assert status.active_session_age_ms is None
 
 
@@ -273,7 +276,7 @@ def test_status_last_timings_none_before_first_session() -> None:
     """Timing fields are None before any session completes."""
     server = _build_server(streaming_enabled=False)
 
-    status = server.status()
+    status = _status(server)
     assert status.audio_stop_ms is None
     assert status.finalize_ms is None
     assert status.infer_ms is None
@@ -292,7 +295,7 @@ def test_status_last_timings_populated_after_session() -> None:
     server._last_infer_ms = 120
     server._last_send_ms = 3
 
-    status = server.status()
+    status = _status(server)
     assert status.audio_stop_ms == 12
     assert status.finalize_ms == 180
     assert status.infer_ms == 120


### PR DESCRIPTION
Fixes #61.

## Summary
- Adds `SessionOrchestrator` to own Session lifecycle, stream drain, guard loop, cleanup, and Seal path finalization behind the `EventSink` interface.
- Shrinks `DaemonServer` to a WebSocket/FastAPI adapter that parses client messages, builds intents, and forwards events through `WebSocketEventSink`.
- Moves overlay WebSocket sequencing/counters into `WebSocketEventSinkState` and keeps the wire message order unchanged.
- Adds orchestrator-level `RecordingEventSink` coverage for busy, missing, abort, disconnect, guard-limit, and finalization flows.

## Line Counts
- `parakeet-stt-daemon/src/parakeet_stt_daemon/server.py`: 232 lines.
- `parakeet-stt-daemon/tests/test_session_cleanup.py`: 654 lines, down from the issue baseline of 756 (-102).
- `parakeet-stt-daemon/tests/test_overlay_event_stream.py`: 1188 lines.

## Verification
- `cd parakeet-stt-daemon && uv run pytest -q` -> 142 passed.
- `cd parakeet-stt-daemon && uv run ruff check src tests` -> passed.
- `cd parakeet-stt-daemon && uv run ruff format --check src tests` -> passed.
- `cd parakeet-stt-daemon && uv run ty check src` -> passed.
- `prek run --all-files` -> passed.
- `prek run --stage pre-push --all-files` -> Python pytest and Rust tests passed; Rust clippy fails on pre-existing `parakeet-ptt/src/overlay_renderer.rs:1819` (`clippy::collapsible_match`), identical on `origin/main` and outside this daemon refactor.
- Dev helper smoke on `PARAKEET_ROOT=/home/hugo/Documents/Engineering/parakeet-stt-dev`, `PARAKEET_PORT=18765`, CUDA streaming, overlay events enabled, overlay UI disabled: start, busy-start rejection, abort mid-capture, normal stop/finalization, and status idle checks passed.
- Session-limit smoke with `PARAKEET_MAX_SESSION_SECONDS=1`: warning emitted at 80%, automatic finalization at the cap, `final_result` before `session_ended(final)`, and status returned idle.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More robust session lifecycle and state tracking for reliable live transcription and finalization.
  * Clearer streaming/VAD status reporting and more consistent interim-result handling.

* **Bug Fixes**
  * Improved recovery and cleanup on websocket disconnects and unexpected errors to prevent stuck sessions.
  * Reduced dropped overlay events and better bounding of in-memory per-session state.

* **Tests**
  * Expanded test coverage for session lifecycle, streaming, finalization, and cleanup behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SystemicVoid/parakeet-stt/pull/71?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->