### PR TITLE
refactor(daemon): centralize runtime truth snapshot

### DIFF
--- a/docs/stt-troubleshooting.md
+++ b/docs/stt-troubleshooting.md
@@ -55,6 +55,12 @@ Canonical-source policy:
 - `stt llm` manages a local `llama-server` in tmux session `parakeet-llm`, waits for `http://<host>:<port>/health`, then delegates to the normal `stt start` path.
 - Machine-local LLM overrides should stay in `PARAKEET_LLM_*` or `PARAKEET_LLM_SERVER_*` env vars from your shell or the ignored repo-local files; do not commit workstation-specific endpoints or launcher paths.
 
+Runtime truth for `/status` and daemon logs is produced by
+`parakeet_stt_daemon.runtime_truth_snapshot.RuntimeTruthSnapshot`. That module is
+the source of truth for effective device, Stream path helper state, Seal path
+finalization source, tail trim mode, VAD fallback, and overlay-event enablement;
+the Helper should read those fields from `/status` instead of re-deriving them.
+
 ## Historical notes (pre-2026 migration hardening)
 
 ## What works

--- a/parakeet-stt-daemon/src/parakeet_stt_daemon/__main__.py
+++ b/parakeet-stt-daemon/src/parakeet_stt_daemon/__main__.py
@@ -11,6 +11,7 @@ import uvicorn
 from loguru import logger
 
 from .config import ServerSettings
+from .runtime_truth_snapshot import format_log_record
 from .server import DaemonServer, create_app
 
 
@@ -211,35 +212,36 @@ def run_checks(settings: ServerSettings) -> None:
         settings.max_session_seconds,
         settings.max_session_samples,
     )
+    runtime_truth = orchestrator.runtime_truth(
+        overlay_events_enabled=settings.overlay_events_enabled
+    )
+    logger.info("Runtime truth: {}", format_log_record(runtime_truth.to_log_record()))
     if settings.streaming_enabled:
-        helper_active = orchestrator._stream_helper_active()
-        fallback_reason = orchestrator._stream_fallback_reason()
-        helper_class = getattr(orchestrator.streaming_transcriber, "_helper_class_name", None)
-        if helper_active:
+        if runtime_truth.stream_helper_active:
             logger.info(
                 "Live session helper: ACTIVE (class={}, scope={})",
-                helper_class,
-                orchestrator._stream_helper_scope(),
+                runtime_truth.stream_helper_class_name,
+                runtime_truth.stream_helper_scope,
             )
         else:
             logger.warning(
                 "Live session helper: INACTIVE (scope={}, reason={})",
-                orchestrator._stream_helper_scope(),
-                fallback_reason,
+                runtime_truth.stream_helper_scope,
+                runtime_truth.stream_fallback_reason,
             )
     logger.info(
         "Final transcript path: {} (audio_source={}, tail_trim_mode={})",
-        orchestrator._finalization_mode(),
-        orchestrator._final_audio_source(),
-        orchestrator._tail_trim_mode(),
+        runtime_truth.finalization_mode,
+        runtime_truth.final_audio_source,
+        runtime_truth.tail_trim_mode,
     )
     if settings.vad_enabled:
-        if orchestrator._vad_active():
+        if runtime_truth.vad_active:
             logger.info("VAD trim: ACTIVE (backend=silero_onnx)")
         else:
             logger.warning(
                 "VAD trim: INACTIVE (reason={}). Tail trim will fall back to RMS.",
-                orchestrator._vad_fallback_reason(),
+                runtime_truth.vad_fallback_reason,
             )
     else:
         logger.info("VAD trim: DISABLED")

--- a/parakeet-stt-daemon/src/parakeet_stt_daemon/runtime_truth_snapshot.py
+++ b/parakeet-stt-daemon/src/parakeet_stt_daemon/runtime_truth_snapshot.py
@@ -1,0 +1,276 @@
+"""Single Runtime truth snapshot for Daemon status and logs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from .messages import StatusMessage
+from .session import SessionState
+from .tail_trim import TailTrimMode
+
+StreamHelperScope = Literal["live_session_only"]
+FinalizationMode = Literal["offline_seal"]
+FinalAudioSource = Literal["canonical_session_audio"]
+
+
+@dataclass(frozen=True, slots=True)
+class DeviceInfo:
+    requested_device: str | None
+    effective_device: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class StreamPathFacts:
+    streaming_enabled: bool
+    helper_active: bool
+    helper_scope: StreamHelperScope
+    helper_class_name: str | None
+    fallback_reason: str | None
+    chunk_secs: float | None
+
+
+@dataclass(frozen=True, slots=True)
+class SealPathFacts:
+    finalization_mode: FinalizationMode = "offline_seal"
+    final_audio_source: FinalAudioSource = "canonical_session_audio"
+
+
+@dataclass(frozen=True, slots=True)
+class TailTrimFacts:
+    tail_trim_mode: TailTrimMode
+    vad_active: bool
+    vad_fallback_reason: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeTruthState:
+    state: SessionState
+    sessions_active: int
+    active_session_age_ms: int | None
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeTruthMetrics:
+    gpu_mem_mb: int | None = None
+    overlay_events_emitted: int | None = None
+    overlay_events_dropped: int | None = None
+    audio_stop_ms: int | None = None
+    finalize_ms: int | None = None
+    infer_ms: int | None = None
+    send_ms: int | None = None
+    last_audio_ms: int | None = None
+    last_infer_ms: int | None = None
+    last_send_ms: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeTruth:
+    device: str | None
+    effective_device: str | None
+    streaming_enabled: bool
+    stream_helper_active: bool
+    stream_helper_scope: StreamHelperScope
+    stream_helper_class_name: str | None
+    stream_fallback_reason: str | None
+    finalization_mode: FinalizationMode
+    final_audio_source: FinalAudioSource
+    tail_trim_mode: TailTrimMode
+    vad_enabled: bool
+    vad_active: bool
+    vad_fallback_reason: str | None
+    overlay_events_enabled: bool
+    chunk_secs: float | None
+
+    @property
+    def degraded(self) -> bool:
+        return (self.streaming_enabled and not self.stream_helper_active) or (
+            self.vad_enabled and not self.vad_active
+        )
+
+    def to_status(self, state: RuntimeTruthState, metrics: RuntimeTruthMetrics) -> StatusMessage:
+        return StatusMessage(
+            state=state.state,
+            sessions_active=state.sessions_active,
+            gpu_mem_mb=metrics.gpu_mem_mb,
+            device=self.device,
+            effective_device=self.effective_device,
+            streaming_enabled=self.streaming_enabled,
+            stream_helper_active=self.stream_helper_active,
+            stream_helper_scope=self.stream_helper_scope,
+            stream_fallback_reason=self.stream_fallback_reason,
+            finalization_mode=self.finalization_mode,
+            final_audio_source=self.final_audio_source,
+            tail_trim_mode=self.tail_trim_mode,
+            vad_enabled=self.vad_enabled,
+            vad_active=self.vad_active,
+            vad_fallback_reason=self.vad_fallback_reason,
+            overlay_events_enabled=self.overlay_events_enabled,
+            overlay_events_emitted=metrics.overlay_events_emitted,
+            overlay_events_dropped=metrics.overlay_events_dropped,
+            chunk_secs=self.chunk_secs,
+            active_session_age_ms=state.active_session_age_ms,
+            audio_stop_ms=metrics.audio_stop_ms,
+            finalize_ms=metrics.finalize_ms,
+            infer_ms=metrics.infer_ms,
+            send_ms=metrics.send_ms,
+            last_audio_ms=metrics.last_audio_ms,
+            last_infer_ms=metrics.last_infer_ms,
+            last_send_ms=metrics.last_send_ms,
+        )
+
+    def to_log_record(self) -> dict[str, object]:
+        return {
+            "device_requested": self.device,
+            "device_effective": self.effective_device,
+            "streaming_enabled": self.streaming_enabled,
+            "live_session_helper_active": self.stream_helper_active,
+            "live_session_helper_scope": self.stream_helper_scope,
+            "live_session_helper_class": self.stream_helper_class_name,
+            "stream_fallback_reason": self.stream_fallback_reason,
+            "finalization_mode": self.finalization_mode,
+            "final_audio_source": self.final_audio_source,
+            "tail_trim_mode": self.tail_trim_mode,
+            "vad_enabled": self.vad_enabled,
+            "vad_active": self.vad_active,
+            "vad_fallback_reason": self.vad_fallback_reason,
+            "overlay_events_enabled": self.overlay_events_enabled,
+        }
+
+
+def snapshot(
+    orchestrator: Any,
+    *,
+    stream_path: StreamPathFacts | None = None,
+    seal_path: SealPathFacts | None = None,
+    last_trim_outcome: object | None = None,
+    device_info: DeviceInfo | None = None,
+    overlay_events_enabled: bool | None = None,
+) -> RuntimeTruth:
+    settings = orchestrator.settings
+    stream_path = stream_path or _stream_path_facts(orchestrator)
+    seal_path = seal_path or SealPathFacts()
+    tail_trim = _tail_trim_facts(orchestrator, last_trim_outcome)
+    device_info = device_info or _device_info(orchestrator)
+    return RuntimeTruth(
+        device=device_info.requested_device,
+        effective_device=device_info.effective_device,
+        streaming_enabled=stream_path.streaming_enabled,
+        stream_helper_active=stream_path.helper_active,
+        stream_helper_scope=stream_path.helper_scope,
+        stream_helper_class_name=stream_path.helper_class_name,
+        stream_fallback_reason=stream_path.fallback_reason,
+        finalization_mode=seal_path.finalization_mode,
+        final_audio_source=seal_path.final_audio_source,
+        tail_trim_mode=tail_trim.tail_trim_mode,
+        vad_enabled=bool(getattr(orchestrator, "_vad_enabled", False)),
+        vad_active=tail_trim.vad_active,
+        vad_fallback_reason=tail_trim.vad_fallback_reason,
+        overlay_events_enabled=(
+            bool(getattr(settings, "overlay_events_enabled", False))
+            if overlay_events_enabled is None
+            else overlay_events_enabled
+        ),
+        chunk_secs=stream_path.chunk_secs,
+    )
+
+
+def format_log_record(record: dict[str, object]) -> str:
+    return ", ".join(f"{key}={_format_log_value(value)}" for key, value in record.items())
+
+
+def _device_info(orchestrator: Any) -> DeviceInfo:
+    settings = orchestrator.settings
+    requested = _string_or_none(
+        getattr(orchestrator, "_requested_device", getattr(settings, "device", None))
+    )
+    effective = _string_or_none(getattr(orchestrator, "_effective_device", requested))
+    return DeviceInfo(requested_device=requested, effective_device=effective)
+
+
+def _stream_path_facts(orchestrator: Any) -> StreamPathFacts:
+    settings = orchestrator.settings
+    streaming_enabled = bool(getattr(settings, "streaming_enabled", False))
+    chunk_secs = _chunk_secs_or_none(settings)
+    streaming_transcriber = getattr(orchestrator, "streaming_transcriber", None)
+    if not streaming_enabled:
+        return StreamPathFacts(
+            streaming_enabled=False,
+            helper_active=False,
+            helper_scope="live_session_only",
+            helper_class_name=None,
+            fallback_reason=None,
+            chunk_secs=None,
+        )
+    if streaming_transcriber is None:
+        return StreamPathFacts(
+            streaming_enabled=True,
+            helper_active=False,
+            helper_scope="live_session_only",
+            helper_class_name=None,
+            fallback_reason="streaming_transcriber_unavailable",
+            chunk_secs=chunk_secs,
+        )
+    return StreamPathFacts(
+        streaming_enabled=True,
+        helper_active=bool(getattr(streaming_transcriber, "helper_active", False)),
+        helper_scope="live_session_only",
+        helper_class_name=_string_or_none(
+            getattr(streaming_transcriber, "_helper_class_name", None)
+        ),
+        fallback_reason=getattr(streaming_transcriber, "fallback_reason", None),
+        chunk_secs=chunk_secs,
+    )
+
+
+def _tail_trim_facts(orchestrator: Any, last_trim_outcome: object | None) -> TailTrimFacts:
+    outcome = last_trim_outcome
+    if outcome is None:
+        tail_trimmer = getattr(orchestrator, "tail_trimmer", None)
+        outcome = getattr(tail_trimmer, "last_outcome", None)
+    if outcome is None and hasattr(orchestrator, "_tail_trimmer_for_runtime"):
+        outcome = orchestrator._tail_trimmer_for_runtime().last_outcome
+    return TailTrimFacts(
+        tail_trim_mode=getattr(outcome, "tail_trim_mode", "rms"),
+        vad_active=bool(getattr(outcome, "vad_active", False)),
+        vad_fallback_reason=getattr(outcome, "vad_fallback_reason", None),
+    )
+
+
+def _format_log_value(value: object) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)
+
+
+def _string_or_none(value: object) -> str | None:
+    if value is None:
+        return None
+    return str(value)
+
+
+def _chunk_secs_or_none(settings: object) -> float | None:
+    value = getattr(settings, "chunk_secs", None)
+    if value is None:
+        return None
+    return float(value)
+
+
+class RuntimeTruthSnapshot:
+    snapshot = staticmethod(snapshot)
+
+
+__all__ = [
+    "DeviceInfo",
+    "RuntimeTruth",
+    "RuntimeTruthMetrics",
+    "RuntimeTruthSnapshot",
+    "RuntimeTruthState",
+    "SealPathFacts",
+    "StreamPathFacts",
+    "TailTrimFacts",
+    "format_log_record",
+    "snapshot",
+]

--- a/parakeet-stt-daemon/src/parakeet_stt_daemon/server.py
+++ b/parakeet-stt-daemon/src/parakeet_stt_daemon/server.py
@@ -29,6 +29,7 @@ from .messages import (
     parse_client_message,
 )
 from .model import _release_cuda_cache
+from .runtime_truth_snapshot import format_log_record
 from .session_orchestrator import (
     AbortSessionIntent,
     SessionOrchestrator,
@@ -158,10 +159,15 @@ class DaemonServer:
         )
 
     def status(self) -> StatusMessage:
-        return self.orchestrator.status(
+        runtime_truth = self.orchestrator.runtime_truth(
             overlay_events_enabled=self.event_sinks.overlay_events_enabled,
-            overlay_events_emitted=self.event_sinks.overlay_events_emitted,
-            overlay_events_dropped=self.event_sinks.overlay_events_dropped,
+        )
+        return runtime_truth.to_status(
+            self.orchestrator.runtime_status_state(),
+            self.orchestrator.runtime_status_metrics(
+                overlay_events_emitted=self.event_sinks.overlay_events_emitted,
+                overlay_events_dropped=self.event_sinks.overlay_events_dropped,
+            ),
         )
 
 
@@ -182,29 +188,14 @@ def create_app(settings: ServerSettings) -> FastAPI:
         _release_cuda_cache(settings.device)
         if orchestrator._vad_enabled:
             await asyncio.to_thread(orchestrator.prepare_vad)
-        runtime_degraded = (
-            orchestrator.settings.streaming_enabled and not orchestrator._stream_helper_active()
-        ) or (orchestrator._vad_enabled and not orchestrator._vad_active())
+        runtime_truth = orchestrator.runtime_truth(
+            overlay_events_enabled=server.event_sinks.overlay_events_enabled
+        )
+        runtime_degraded = runtime_truth.degraded
         _log = logger.warning if runtime_degraded else logger.info
         _log(
-            "Runtime truth: device_requested={}, device_effective={}, streaming_enabled={}, "
-            "live_session_helper_active={}, live_session_helper_scope={}, "
-            "stream_fallback_reason={}, finalization_mode={}, final_audio_source={}, "
-            "tail_trim_mode={}, vad_enabled={}, vad_active={}, vad_fallback_reason={}, "
-            "overlay_events_enabled={}",
-            orchestrator._requested_device,
-            orchestrator._effective_device,
-            orchestrator.settings.streaming_enabled,
-            orchestrator._stream_helper_active(),
-            orchestrator._stream_helper_scope(),
-            orchestrator._stream_fallback_reason(),
-            orchestrator._finalization_mode(),
-            orchestrator._final_audio_source(),
-            orchestrator._tail_trim_mode(),
-            orchestrator._vad_enabled,
-            orchestrator._vad_active(),
-            orchestrator._vad_fallback_reason(),
-            orchestrator.settings.overlay_events_enabled,
+            "Runtime truth: {}",
+            format_log_record(runtime_truth.to_log_record()),
         )
         yield
         logger.info("Stopping audio capture")

--- a/parakeet-stt-daemon/src/parakeet_stt_daemon/session_orchestrator.py
+++ b/parakeet-stt-daemon/src/parakeet_stt_daemon/session_orchestrator.py
@@ -37,7 +37,6 @@ from .events import (
 from .messages import (
     InterimStateValue,
     SessionEndReason,
-    StatusMessage,
 )
 from .model import (
     ParakeetStreamingSession,
@@ -50,6 +49,15 @@ from .overlay_interim import (
     OverlayInterimTranscriptContext,
     OverlayInterimTranscriptStabilizer,
     append_overlay_interim_context,
+)
+from .runtime_truth_snapshot import (
+    RuntimeTruth,
+    RuntimeTruthMetrics,
+    RuntimeTruthState,
+    format_log_record,
+)
+from .runtime_truth_snapshot import (
+    snapshot as runtime_truth_snapshot,
 )
 from .session import Session, SessionBusyError, SessionManager, SessionNotFoundError, SessionState
 from .tail_trim import SealPathTailTrimmer
@@ -331,6 +339,9 @@ class SessionOrchestrator:
 
             latency_ms = int((datetime.now(tz=UTC) - session.last_updated).total_seconds() * 1000)
             send_started = datetime.now(tz=UTC)
+            runtime_truth = self.runtime_truth(
+                overlay_events_enabled=self.settings.overlay_events_enabled
+            )
             await event_sink.emit(
                 FinalResultEvent(
                     session_id=session.session_id,
@@ -339,9 +350,9 @@ class SessionOrchestrator:
                     audio_ms=audio_ms,
                     lang=self.settings.language,
                     confidence=None,
-                    tail_trim_mode=self._tail_trim_mode(),
-                    vad_active=self._vad_active(),
-                    vad_fallback_reason=self._vad_fallback_reason(),
+                    tail_trim_mode=runtime_truth.tail_trim_mode,
+                    vad_active=runtime_truth.vad_active,
+                    vad_fallback_reason=runtime_truth.vad_fallback_reason,
                 )
             )
             send_ms = int((datetime.now(tz=UTC) - send_started).total_seconds() * 1000)
@@ -364,10 +375,7 @@ class SessionOrchestrator:
             logger.info(
                 "Session {} completed: audio_raw={:.2f}s, audio_ms={}, audio_stop_ms={}, "
                 "latency_ms={}, finalize_ms={}, infer_ms={}, send_ms={}, text_len={}, "
-                "chars_per_sec={:.1f}, live_session_helper_active={}, "
-                "live_session_helper_scope={}, stream_fallback_reason={}, "
-                "finalization_mode={}, final_audio_source={}, tail_trim_mode={}, "
-                "vad_enabled={}, vad_active={}, vad_fallback_reason={}",
+                "chars_per_sec={:.1f}, runtime_truth={}",
                 session.session_id,
                 audio_duration_raw,
                 audio_ms,
@@ -378,15 +386,7 @@ class SessionOrchestrator:
                 send_ms,
                 text_len,
                 chars_per_sec,
-                self._stream_helper_active(),
-                self._stream_helper_scope(),
-                self._stream_fallback_reason(),
-                self._finalization_mode(),
-                self._final_audio_source(),
-                self._tail_trim_mode(),
-                bool(getattr(self, "_vad_enabled", False)),
-                self._vad_active(),
-                self._vad_fallback_reason(),
+                format_log_record(runtime_truth.to_log_record()),
             )
 
     async def _handle_abort(self, message: AbortSessionIntent) -> None:
@@ -845,38 +845,31 @@ class SessionOrchestrator:
         if stabilized is not None:
             await self._emit_interim_text(event_sink, session_id, text=stabilized.text)
 
-    def status(
+    def runtime_truth(self, *, overlay_events_enabled: bool) -> RuntimeTruth:
+        return runtime_truth_snapshot(
+            self,
+            last_trim_outcome=self._tail_trimmer_for_runtime().last_outcome,
+            overlay_events_enabled=overlay_events_enabled,
+        )
+
+    def runtime_status_state(self) -> RuntimeTruthState:
+        active = self.sessions.active
+        return RuntimeTruthState(
+            state=active.state if active else SessionState.IDLE,
+            sessions_active=int(active is not None),
+            active_session_age_ms=active.audio_duration_ms if active else None,
+        )
+
+    def runtime_status_metrics(
         self,
         *,
-        overlay_events_enabled: bool,
         overlay_events_emitted: int,
         overlay_events_dropped: int,
-    ) -> StatusMessage:
-        active = self.sessions.active
-        state = active.state if active else SessionState.IDLE
-        requested_device = getattr(self, "_requested_device", str(self.settings.device))
-        effective_device = getattr(self, "_effective_device", requested_device)
-        return StatusMessage(
-            state=state,
-            sessions_active=int(active is not None),
+    ) -> RuntimeTruthMetrics:
+        return RuntimeTruthMetrics(
             gpu_mem_mb=self._gpu_mem_mb(),
-            device=requested_device,
-            effective_device=effective_device,
-            streaming_enabled=self.settings.streaming_enabled,
-            stream_helper_active=self._stream_helper_active(),
-            stream_helper_scope=self._stream_helper_scope(),
-            stream_fallback_reason=self._stream_fallback_reason(),
-            finalization_mode=self._finalization_mode(),
-            final_audio_source=self._final_audio_source(),
-            tail_trim_mode=self._tail_trim_mode(),
-            vad_enabled=bool(getattr(self, "_vad_enabled", False)),
-            vad_active=self._vad_active(),
-            vad_fallback_reason=self._vad_fallback_reason(),
-            overlay_events_enabled=overlay_events_enabled,
             overlay_events_emitted=overlay_events_emitted,
             overlay_events_dropped=overlay_events_dropped,
-            chunk_secs=self.settings.chunk_secs if self.settings.streaming_enabled else None,
-            active_session_age_ms=active.audio_duration_ms if active else None,
             audio_stop_ms=getattr(self, "_last_audio_stop_ms", None),
             finalize_ms=getattr(self, "_last_finalize_ms", None),
             infer_ms=getattr(self, "_last_infer_ms", None),
@@ -885,38 +878,6 @@ class SessionOrchestrator:
             last_infer_ms=getattr(self, "_last_infer_ms", None),
             last_send_ms=getattr(self, "_last_send_ms", None),
         )
-
-    def _stream_helper_active(self) -> bool:
-        if not self.settings.streaming_enabled:
-            return False
-        if self.streaming_transcriber is None:
-            return False
-        return self.streaming_transcriber.helper_active
-
-    def _stream_helper_scope(self) -> Literal["live_session_only"]:
-        return "live_session_only"
-
-    def _stream_fallback_reason(self) -> str | None:
-        if not self.settings.streaming_enabled:
-            return None
-        if self.streaming_transcriber is None:
-            return "streaming_transcriber_unavailable"
-        return self.streaming_transcriber.fallback_reason
-
-    def _finalization_mode(self) -> Literal["offline_seal"]:
-        return "offline_seal"
-
-    def _final_audio_source(self) -> Literal["canonical_session_audio"]:
-        return "canonical_session_audio"
-
-    def _tail_trim_mode(self) -> Literal["rms", "vad"]:
-        return self._tail_trimmer_for_runtime().last_outcome.tail_trim_mode
-
-    def _vad_active(self) -> bool:
-        return self._tail_trimmer_for_runtime().last_outcome.vad_active
-
-    def _vad_fallback_reason(self) -> str | None:
-        return self._tail_trimmer_for_runtime().last_outcome.vad_fallback_reason
 
     def prepare_vad(self) -> None:
         self._tail_trimmer_for_runtime().prepare()

--- a/parakeet-stt-daemon/tests/test_streaming_truth.py
+++ b/parakeet-stt-daemon/tests/test_streaming_truth.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from types import SimpleNamespace
 from typing import Any, cast
 from uuid import uuid4
 
@@ -10,6 +11,7 @@ import numpy as np
 
 from parakeet_stt_daemon.config import ServerSettings
 from parakeet_stt_daemon.messages import StatusMessage
+from parakeet_stt_daemon.runtime_truth_snapshot import RuntimeTruth, snapshot
 from parakeet_stt_daemon.session import SessionManager
 from parakeet_stt_daemon.session_orchestrator import SessionOrchestrator
 from parakeet_stt_daemon.tail_trim import SealPathTailTrimmer
@@ -105,10 +107,21 @@ def _build_server(
 
 
 def _status(orchestrator: SessionOrchestrator) -> StatusMessage:
-    return orchestrator.status(
+    truth = _truth(orchestrator)
+    return truth.to_status(
+        orchestrator.runtime_status_state(),
+        orchestrator.runtime_status_metrics(
+            overlay_events_emitted=0,
+            overlay_events_dropped=0,
+        ),
+    )
+
+
+def _truth(orchestrator: SessionOrchestrator) -> RuntimeTruth:
+    return snapshot(
+        orchestrator,
+        last_trim_outcome=orchestrator.tail_trimmer.last_outcome,
         overlay_events_enabled=orchestrator.settings.overlay_events_enabled,
-        overlay_events_emitted=0,
-        overlay_events_dropped=0,
     )
 
 
@@ -150,6 +163,57 @@ def test_status_streaming_enabled_helper_active() -> None:
     assert status.tail_trim_mode == "rms"
 
 
+def test_runtime_truth_log_record_contains_helper_expected_fields() -> None:
+    transcriber = FakeStreamingTranscriber(helper_active=True, helper_class_name="FakeHelper")
+    server = _build_server(streaming_transcriber=transcriber)
+
+    truth = _truth(server)
+    status = _status(server)
+    log_record = truth.to_log_record()
+
+    assert status.model_dump(include=set(_helper_expected_status_fields())) == {
+        "device": "cpu",
+        "effective_device": "cpu",
+        "streaming_enabled": True,
+        "stream_helper_active": True,
+        "stream_helper_scope": "live_session_only",
+        "stream_fallback_reason": None,
+        "finalization_mode": "offline_seal",
+        "final_audio_source": "canonical_session_audio",
+        "tail_trim_mode": "rms",
+        "vad_enabled": False,
+        "vad_active": False,
+        "vad_fallback_reason": None,
+        "overlay_events_enabled": False,
+    }
+    assert log_record["live_session_helper_active"] is True
+    assert log_record["live_session_helper_class"] == "FakeHelper"
+    assert log_record["finalization_mode"] == "offline_seal"
+    assert log_record["tail_trim_mode"] == "rms"
+
+
+def test_runtime_truth_preserves_missing_optional_device_and_chunk_values() -> None:
+    orchestrator = SimpleNamespace(
+        settings=SimpleNamespace(
+            streaming_enabled=True, chunk_secs=None, overlay_events_enabled=False
+        ),
+        streaming_transcriber=None,
+    )
+    truth = snapshot(
+        orchestrator,
+        last_trim_outcome=SimpleNamespace(
+            tail_trim_mode="rms",
+            vad_active=False,
+            vad_fallback_reason=None,
+        ),
+    )
+
+    assert truth.device is None
+    assert truth.effective_device is None
+    assert truth.chunk_secs is None
+    assert truth.stream_fallback_reason == "streaming_transcriber_unavailable"
+
+
 def test_status_vad_enabled_pending_load_is_explicit() -> None:
     server = _build_server(streaming_enabled=False, vad_enabled=True)
 
@@ -186,8 +250,9 @@ def test_prepare_vad_marks_missing_dependency_explicitly() -> None:
 
     server.prepare_vad()
 
-    assert server._vad_active() is False
-    assert server._vad_fallback_reason() == "load_failed:missing_dependency:onnxruntime"
+    truth = _truth(server)
+    assert truth.vad_active is False
+    assert truth.vad_fallback_reason == "load_failed:missing_dependency:onnxruntime"
 
 
 def test_status_streaming_enabled_helper_inactive() -> None:
@@ -221,13 +286,13 @@ def test_status_streaming_enabled_transcriber_none() -> None:
 
 
 def test_stream_helper_active_reflects_transcriber_state() -> None:
-    """_stream_helper_active() delegates to transcriber.helper_active."""
+    """RuntimeTruth delegates Stream path activity to transcriber.helper_active."""
     transcriber = FakeStreamingTranscriber(helper_active=True)
     server = _build_server(streaming_transcriber=transcriber)
-    assert server._stream_helper_active() is True
+    assert _truth(server).stream_helper_active is True
 
     transcriber.helper_active = False
-    assert server._stream_helper_active() is False
+    assert _truth(server).stream_helper_active is False
 
 
 def test_stream_fallback_reason_init_failed() -> None:
@@ -238,7 +303,7 @@ def test_stream_fallback_reason_init_failed() -> None:
     )
     server = _build_server(streaming_transcriber=transcriber)
 
-    assert server._stream_fallback_reason() == "init_failed:RuntimeError"
+    assert _truth(server).stream_fallback_reason == "init_failed:RuntimeError"
 
 
 def test_stream_fallback_reason_none_when_active() -> None:
@@ -246,7 +311,7 @@ def test_stream_fallback_reason_none_when_active() -> None:
     transcriber = FakeStreamingTranscriber(helper_active=True)
     server = _build_server(streaming_transcriber=transcriber)
 
-    assert server._stream_fallback_reason() is None
+    assert _truth(server).stream_fallback_reason is None
 
 
 def test_status_includes_active_session_age_when_session_active() -> None:
@@ -303,3 +368,21 @@ def test_status_last_timings_populated_after_session() -> None:
     assert status.last_audio_ms == 2500
     assert status.last_infer_ms == 120
     assert status.last_send_ms == 3
+
+
+def _helper_expected_status_fields() -> tuple[str, ...]:
+    return (
+        "device",
+        "effective_device",
+        "streaming_enabled",
+        "stream_helper_active",
+        "stream_helper_scope",
+        "stream_fallback_reason",
+        "finalization_mode",
+        "final_audio_source",
+        "tail_trim_mode",
+        "vad_enabled",
+        "vad_active",
+        "vad_fallback_reason",
+        "overlay_events_enabled",
+    )

--- a/parakeet-stt-daemon/tests/test_stt_helper_runtime_profiles.py
+++ b/parakeet-stt-daemon/tests/test_stt_helper_runtime_profiles.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import shlex
 import subprocess
@@ -72,6 +73,35 @@ def _run_runtime_match(*args: str) -> bool:
     return completed.stdout.strip() == "match=true"
 
 
+def _run_status_runtime_truth(payload_path: Path) -> dict[str, str]:
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("PARAKEET_") and not key.startswith("_STT_")
+    }
+    env["PARAKEET_ROOT"] = str(REPO_ROOT)
+    env["_STT_SKIP_LOCAL_OVERRIDES"] = "1"
+    command = [
+        "bash",
+        "-lc",
+        f"source {shlex.quote(str(HELPER_PATH))} && "
+        f"stt __daemon-status-runtime-truth {shlex.quote(payload_path.as_uri())}",
+    ]
+    completed = subprocess.run(
+        command,
+        check=True,
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+    truth: dict[str, str] = {}
+    for line in completed.stdout.splitlines():
+        key, value = line.split("=", 1)
+        truth[key] = value
+    return truth
+
+
 def test_cpu_profile_resolves_offline_cpu_runtime() -> None:
     config = _run_runtime_config("cpu")
 
@@ -113,3 +143,45 @@ def test_runtime_match_accepts_cpu_fallback_for_accelerator_request() -> None:
 
 def test_runtime_match_rejects_accelerator_when_cpu_requested() -> None:
     assert _run_runtime_match("cpu", "false", "false", "cuda", "false", "false") is False
+
+
+def test_daemon_status_runtime_truth_reads_status_fields_unchanged(tmp_path: Path) -> None:
+    payload_path = tmp_path / "status.json"
+    payload_path.write_text(
+        json.dumps(
+            {
+                "device": "cuda",
+                "effective_device": "cpu",
+                "streaming_enabled": True,
+                "stream_helper_active": False,
+                "stream_helper_scope": "live_session_only",
+                "stream_fallback_reason": None,
+                "finalization_mode": "offline_seal",
+                "final_audio_source": "canonical_session_audio",
+                "tail_trim_mode": "rms",
+                "vad_enabled": True,
+                "vad_active": False,
+                "vad_fallback_reason": "load_failed:missing_dependency:onnxruntime",
+                "overlay_events_enabled": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    truth = _run_status_runtime_truth(payload_path)
+
+    assert truth == {
+        "device": "cuda",
+        "effective_device": "cpu",
+        "streaming_enabled": "true",
+        "stream_helper_active": "false",
+        "stream_helper_scope": "live_session_only",
+        "stream_fallback_reason": "",
+        "finalization_mode": "offline_seal",
+        "final_audio_source": "canonical_session_audio",
+        "tail_trim_mode": "rms",
+        "vad_enabled": "true",
+        "vad_active": "false",
+        "vad_fallback_reason": "load_failed:missing_dependency:onnxruntime",
+        "overlay_events_enabled": "true",
+    }

--- a/scripts/stt-helper.sh
+++ b/scripts/stt-helper.sh
@@ -710,23 +710,45 @@ try:
 except Exception:
     sys.exit(1)
 
-required = {
-    "device": payload.get("device"),
-    "effective_device": payload.get("effective_device"),
-    "streaming_enabled": payload.get("streaming_enabled"),
-    "overlay_events_enabled": payload.get("overlay_events_enabled"),
+fields = (
+    "device",
+    "effective_device",
+    "streaming_enabled",
+    "stream_helper_active",
+    "stream_helper_scope",
+    "stream_fallback_reason",
+    "finalization_mode",
+    "final_audio_source",
+    "tail_trim_mode",
+    "vad_enabled",
+    "vad_active",
+    "vad_fallback_reason",
+    "overlay_events_enabled",
+)
+bool_fields = {
+    "streaming_enabled",
+    "stream_helper_active",
+    "vad_enabled",
+    "vad_active",
+    "overlay_events_enabled",
 }
-for value in required.values():
-    if value is None:
+for key in fields:
+    if key not in payload:
         sys.exit(1)
 
-for key in ("device", "effective_device"):
-    print(f"{key}={required[key]}")
-for key in ("streaming_enabled", "overlay_events_enabled"):
-    value = required[key]
-    if not isinstance(value, bool):
-        sys.exit(1)
-    print(f"{key}={'true' if value else 'false'}")
+for key in fields:
+    value = payload[key]
+    if key in bool_fields:
+        if not isinstance(value, bool):
+            sys.exit(1)
+        print(f"{key}={'true' if value else 'false'}")
+    else:
+        if value is not None and not isinstance(value, str):
+            sys.exit(1)
+        if value is None:
+            print(f"{key}=")
+        else:
+            print(f"{key}={value}")
 PY
     }
 
@@ -1200,6 +1222,14 @@ EOF
             else
                 echo "match=false"
             fi
+            ;;
+        __daemon-status-runtime-truth)
+            if [ "$#" -ne 1 ]; then
+                echo "usage: stt __daemon-status-runtime-truth <status-url>" >&2
+                return 2
+            fi
+
+            _daemon_status_runtime_truth "$1"
             ;;
         start)
             local injection_mode paste_backend_failure_policy


### PR DESCRIPTION
## Summary
- Add RuntimeTruth/RuntimeTruthSnapshot as the daemon-owned source for /status and runtime logs.
- Make DaemonServer.status a thin snapshot -> to_status wrapper and route startup/check/session logs through RuntimeTruth.to_log_record().
- Update stt-helper to consume runtime truth fields from /status JSON directly, with tests proving the existing status wire fields remain unchanged.

## Verification
- cd parakeet-stt-daemon && uv run pytest -q (145 passed)
- cd parakeet-stt-daemon && uv run ruff check src tests && uv run ruff format --check src tests
- cd parakeet-stt-daemon && uv run ty check src
- bash -n scripts/stt-helper.sh
- dev-pinned source scripts/stt-helper.sh && stt help start
- dev-pinned source scripts/stt-helper.sh && stt help llm
- dev-pinned source scripts/stt-helper.sh && stt status
- prek run --all-files
- pre-push: python pytest passed; Rust gates skipped because no matching files

## Manual Smoke
- stt start default stream+seal profile came up cleanly.
- Synthetic WebSocket session emitted final_result/session_ended; /status reported idle runtime truth and last_audio_ms=3758.
- stt off came up cleanly; /status reported streaming_enabled=false and overlay_events_enabled=false.
- Forced VAD load failure with PARAKEET_VAD_ENABLED=true and a temporary shadow module; /status reported vad_fallback_reason=load_failed:ImportError.
- Helper-managed daemon/client were stopped after smoke.

## Review
- CodeRabbit local pass 1 found optional device/chunk defensive handling issues; fixed.
- CodeRabbit local pass 2 found helper class logging still bypassed RuntimeTruth; fixed.
- CodeRabbit PR review body nitpicks for helper string/null validation and null-to-empty test coverage; fixed in e4f103f.
- CodeRabbit PR gate must be clean on the final head before merge.

## Deferred
- N/A

Closes #62

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified operator-facing guidance: /status and daemon logs now reflect a single runtime-truth representation and which exported fields to use.

* **Improvements**
  * Consolidated status reporting and runtime diagnostics around a unified runtime-truth model; startup/shutdown and logs now use its degradation and runtime fields.
  * Refined how runtime fields are computed and emitted by the daemon.

* **Tests**
  * Updated and added tests to validate runtime-truth log/status contents and helper behavior.

* **Tools**
  * Enhanced helper script/CLI to strictly validate and emit runtime-truth fields.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SystemicVoid/parakeet-stt/pull/72?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->