### PR TITLE
fix(overlay): clear completed replay state

### DIFF
--- a/parakeet-ptt/src/app.rs
+++ b/parakeet-ptt/src/app.rs
@@ -2217,6 +2217,17 @@ mod tests {
     }
 
     #[test]
+    fn cli_completion_sound_volume_rejects_values_above_documented_range() {
+        let cli = crate::Cli::parse_from(["parakeet-ptt", "--completion-sound-volume", "100"]);
+        assert_eq!(cli.completion_sound_volume, 100);
+
+        let error =
+            crate::Cli::try_parse_from(["parakeet-ptt", "--completion-sound-volume", "101"])
+                .expect_err("completion sound volume above 100 should be rejected");
+        assert_eq!(error.kind(), clap::error::ErrorKind::ValueValidation);
+    }
+
+    #[test]
     fn cli_overlay_enabled_defaults_to_none() {
         let cli = crate::Cli::parse_from(["parakeet-ptt"]);
         assert_eq!(cli.overlay_enabled, None);

--- a/parakeet-ptt/src/main.rs
+++ b/parakeet-ptt/src/main.rs
@@ -133,7 +133,7 @@ struct Cli {
     completion_sound_path: Option<PathBuf>,
 
     /// Volume for completion sound (0-100).
-    #[arg(long, default_value_t = 100)]
+    #[arg(long, default_value_t = 100, value_parser = clap::value_parser!(u8).range(0..=100))]
     completion_sound_volume: u8,
 
     /// Enable or disable overlay routing (CLI takes precedence over env).

--- a/parakeet-ptt/src/overlay_process.rs
+++ b/parakeet-ptt/src/overlay_process.rs
@@ -355,7 +355,10 @@ impl OverlayProcessManager {
                     self.latest_warning = Some(message.clone());
                 }
             }
-            OverlayIpcMessage::InjectionComplete { .. } => {
+            OverlayIpcMessage::InjectionComplete { session_id, .. } => {
+                if overlay_message_session_id(self.latest_message.as_ref()) == Some(*session_id) {
+                    self.latest_message = None;
+                }
                 self.latest_warning = None;
             }
             OverlayIpcMessage::OutputHint { .. } | OverlayIpcMessage::AudioLevel { .. } => {}
@@ -944,7 +947,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn manager_replay_ignores_injection_complete_as_latest_state() {
+    async fn manager_clears_replay_state_after_injection_complete() {
         let (tx_first, mut rx_first) = mpsc::unbounded_channel();
         let first_sink = OverlayProcessSink::from_sender_for_tests(
             tx_first,
@@ -993,13 +996,19 @@ mod tests {
 
         drop(rx_first);
 
-        manager.send(injection_complete_message);
+        let output_hint = OverlayIpcMessage::OutputHint {
+            output_name: "DP-1".to_string(),
+        };
+        manager.send(output_hint.clone());
 
-        let replayed = timeout(Duration::from_millis(100), rx_second.recv())
+        let forwarded = timeout(Duration::from_millis(100), rx_second.recv())
             .await
-            .expect("second sink should receive replay")
+            .expect("second sink should receive current non-session event")
             .expect("second sink should remain open");
-        assert_eq!(replayed, state_message);
+        assert_eq!(forwarded, output_hint);
+        assert!(timeout(Duration::from_millis(50), rx_second.recv())
+            .await
+            .is_err());
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/parakeet-ptt/src/overlay_process.rs
+++ b/parakeet-ptt/src/overlay_process.rs
@@ -358,8 +358,8 @@ impl OverlayProcessManager {
             OverlayIpcMessage::InjectionComplete { session_id, .. } => {
                 if overlay_message_session_id(self.latest_message.as_ref()) == Some(*session_id) {
                     self.latest_message = None;
+                    self.latest_warning = None;
                 }
-                self.latest_warning = None;
             }
             OverlayIpcMessage::OutputHint { .. } | OverlayIpcMessage::AudioLevel { .. } => {}
         }
@@ -1009,6 +1009,83 @@ mod tests {
         assert!(timeout(Duration::from_millis(50), rx_second.recv())
             .await
             .is_err());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn manager_preserves_warning_replay_after_mismatched_injection_complete() {
+        let (tx_first, mut rx_first) = mpsc::unbounded_channel();
+        let first_sink = OverlayProcessSink::from_sender_for_tests(
+            tx_first,
+            Arc::new(OverlayProcessMetrics::default()),
+        );
+
+        let (tx_second, mut rx_second) = mpsc::unbounded_channel();
+        let second_sink = OverlayProcessSink::from_sender_for_tests(
+            tx_second,
+            Arc::new(OverlayProcessMetrics::default()),
+        );
+
+        let queue = Arc::new(Mutex::new(VecDeque::from([
+            Ok(first_sink),
+            Ok(second_sink),
+        ])));
+        let launcher = queued_launcher(queue);
+        let mut manager = OverlayProcessManager::new_for_tests(
+            OverlayMode::LayerShell,
+            true,
+            launcher,
+            Duration::from_millis(0),
+        );
+
+        let session_id = Uuid::new_v4();
+        let state_message = OverlayIpcMessage::InterimText {
+            session_id,
+            seq: 2,
+            text: "current-state".to_string(),
+        };
+        let warning_message = OverlayIpcMessage::SessionWarning { session_id };
+        manager.send(state_message.clone());
+        manager.send(warning_message.clone());
+        manager.send(OverlayIpcMessage::InjectionComplete {
+            session_id: Uuid::new_v4(),
+            success: true,
+        });
+
+        for expected in [&state_message, &warning_message] {
+            let received = timeout(Duration::from_millis(100), rx_first.recv())
+                .await
+                .expect("first sink should receive session event")
+                .expect("first sink should remain open");
+            assert_eq!(&received, expected);
+        }
+        let _ = timeout(Duration::from_millis(100), rx_first.recv())
+            .await
+            .expect("first sink should receive mismatched completion")
+            .expect("first sink should remain open");
+
+        drop(rx_first);
+
+        let audio_level_message = OverlayIpcMessage::AudioLevel {
+            session_id,
+            level_db: -28.0,
+        };
+        manager.send(audio_level_message.clone());
+
+        let replayed_state = timeout(Duration::from_millis(100), rx_second.recv())
+            .await
+            .expect("second sink should receive replayed state")
+            .expect("second sink should remain open");
+        assert_eq!(replayed_state, state_message);
+        let replayed_warning = timeout(Duration::from_millis(100), rx_second.recv())
+            .await
+            .expect("second sink should receive replayed warning")
+            .expect("second sink should remain open");
+        assert_eq!(replayed_warning, warning_message);
+        let forwarded_audio_level = timeout(Duration::from_millis(100), rx_second.recv())
+            .await
+            .expect("second sink should receive current audio level")
+            .expect("second sink should remain open");
+        assert_eq!(forwarded_audio_level, audio_level_message);
     }
 
     #[tokio::test(flavor = "current_thread")]


### PR DESCRIPTION
Closes #68

## Summary
- Clear the Overlay process manager replay cache when `InjectionComplete` matches the cached session.
- Prevent respawn/output-hint sync from replaying old interim text into a newly opened Overlay after a completed injection.
- Keep warning replay state session-aware when an unrelated `InjectionComplete` arrives.
- Validate `--completion-sound-volume` against its documented 0-100 range after CodeRabbit local gate feedback.

## Scope note
- Frame pacing code is intentionally unchanged in this PR. The latest dev-worktree stack is running for manual validation, and the requested focus for this change is the leftover-text bug.

## Verification (#68)
- targeted: `cd parakeet-ptt && cargo test overlay_process::tests -- --nocapture` -> PASSED
- regression: `cd parakeet-ptt && cargo test overlay_process::tests::manager_clears_replay_state_after_injection_complete -- --nocapture` -> FAILED without fix, PASSED with fix
- review regression: `cd parakeet-ptt && cargo test cli_completion_sound_volume_rejects_values_above_documented_range -- --nocapture` -> PASSED
- full suite: `cd parakeet-ptt && cargo test` -> PASSED
- lint: `cd parakeet-ptt && cargo clippy --all-targets -- -D warnings` -> PASSED
- types: `cd parakeet-ptt && cargo check --all-targets` -> PASSED
- dead-code: N/A, repo has no Rust dead-code gate for this path
- build: `cd parakeet-ptt && cargo build --release --bin parakeet-ptt` -> PASSED
- pre-commit: `prek run --all-files` -> PASSED
- pre-push: Rust clippy + Rust test hook -> PASSED
- static/security: N/A, no separate static/security gate applies to this Rust-only change
- migrations: N/A
- CLI/script smoke: `PARAKEET_ROOT=/home/hugo/Documents/Engineering/parakeet-stt-dev source scripts/stt-helper.sh && stt start` -> PASSED; dev-worktree Daemon and release Client are running for manual overlay test
- UI render: live overlay stack started for manual stale-text verification; no automated screenshot available in this agent session
- destructive/negative: N/A
- review: `coderabbit_review_watch.py local -- --type uncommitted` -> clean; `coderabbit_review_watch.py gate --pr 76` -> clean
- tests added/expanded: `parakeet-ptt/src/overlay_process.rs`, `parakeet-ptt/src/app.rs`
- preexisting failures left: none

## Review triage
- CodeRabbit PR nitpick about session-aware warning clearing: MUST_FIX, fixed in `388ad22`.
- CodeRabbit local gate finding about completion sound volume range: MUST_FIX, fixed in `40d6d08`.
- CodeRabbit docstring coverage warning in generated pre-merge summary: IGNORE, repo does not enforce that check and it is not actionable for this Rust-only behavior fix.
