### PR TITLE
refactor(ptt): extract overlay router module

### DIFF
--- a/parakeet-ptt/src/app.rs
+++ b/parakeet-ptt/src/app.rs
@@ -6,7 +6,7 @@
 use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -21,7 +21,7 @@ use uuid::Uuid;
 
 use crate::audio_feedback::AudioFeedback;
 use crate::client::WsClient;
-use crate::config::{ClientConfig, OverlayMode};
+use crate::config::ClientConfig;
 use crate::hotkey::{
     ensure_input_access, parse_pre_modifier_key_names, spawn_hotkey_loop, HotkeyEvent,
     HotkeyIntent, HotkeyTasks,
@@ -33,11 +33,10 @@ use crate::injector_runtime::{
     INJECTION_ENQUEUE_TIMEOUT_MS, INJECTION_QUEUE_CAPACITY,
 };
 use crate::llm::{sanitize_model_answer, LlmAnswerer, LlmProgress};
-use crate::overlay_process::OverlayProcessManager;
+use crate::overlay_router::{OverlayRouter, OverlaySink};
 use crate::protocol::{start_message, stop_message, ClientMessage, ServerMessage};
 use crate::state::PttState;
 use crate::surface_focus::{WaylandFocusCache, WaylandFocusObservation};
-use parakeet_ptt::overlay_ipc::OverlayIpcMessage;
 
 type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
@@ -181,41 +180,6 @@ struct CapturedParentFocus {
 }
 
 #[derive(Debug, Default)]
-struct OverlayRoutingMetrics {
-    routed_interim_state_total: AtomicU64,
-    routed_interim_text_total: AtomicU64,
-    routed_session_ended_total: AtomicU64,
-    dropped_stale_seq_total: AtomicU64,
-    dropped_session_mismatch_total: AtomicU64,
-}
-
-impl OverlayRoutingMetrics {
-    fn note_interim_state(&self) {
-        self.routed_interim_state_total
-            .fetch_add(1, Ordering::Relaxed);
-    }
-
-    fn note_interim_text(&self) {
-        self.routed_interim_text_total
-            .fetch_add(1, Ordering::Relaxed);
-    }
-
-    fn note_session_ended(&self) {
-        self.routed_session_ended_total
-            .fetch_add(1, Ordering::Relaxed);
-    }
-
-    fn note_stale_seq_drop(&self) {
-        self.dropped_stale_seq_total.fetch_add(1, Ordering::Relaxed);
-    }
-
-    fn note_session_mismatch_drop(&self) {
-        self.dropped_session_mismatch_total
-            .fetch_add(1, Ordering::Relaxed);
-    }
-}
-
-#[derive(Debug, Default)]
 struct HotkeyIntentDiagnostics {
     hotkey_down_total: u64,
     hotkey_down_dictate_total: u64,
@@ -281,323 +245,6 @@ impl HotkeyIntentDiagnostics {
             llm_busy_reject_total = self.llm_busy_reject_total,
             "hotkey intent routing diagnostics"
         );
-    }
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub enum OverlayEvent {
-    OutputHint {
-        output_name: String,
-    },
-    InterimState {
-        session_id: Uuid,
-        seq: u64,
-        state: String,
-    },
-    InterimText {
-        session_id: Uuid,
-        seq: u64,
-        text: String,
-    },
-    AudioLevel {
-        session_id: Uuid,
-        level_db: f32,
-    },
-    SessionEnded {
-        session_id: Uuid,
-        reason: Option<String>,
-    },
-    InjectionComplete {
-        session_id: Uuid,
-        success: bool,
-    },
-    SessionWarning {
-        session_id: Uuid,
-    },
-}
-
-pub trait OverlaySink: Send {
-    fn on_overlay_event(&mut self, event: OverlayEvent);
-}
-
-impl<T: OverlaySink + ?Sized> OverlaySink for Box<T> {
-    fn on_overlay_event(&mut self, event: OverlayEvent) {
-        self.as_mut().on_overlay_event(event);
-    }
-}
-
-#[derive(Debug, Default)]
-pub struct NoopOverlaySink;
-
-impl OverlaySink for NoopOverlaySink {
-    fn on_overlay_event(&mut self, event: OverlayEvent) {
-        debug!(?event, "overlay event dropped by noop sink");
-    }
-}
-
-enum RuntimeOverlaySink {
-    Noop(NoopOverlaySink),
-    Process(Box<OverlayProcessManager>),
-}
-
-impl OverlaySink for RuntimeOverlaySink {
-    fn on_overlay_event(&mut self, event: OverlayEvent) {
-        match self {
-            Self::Noop(sink) => sink.on_overlay_event(event),
-            Self::Process(manager) => manager.send(overlay_event_to_ipc(event)),
-        }
-    }
-}
-
-fn overlay_event_to_ipc(event: OverlayEvent) -> OverlayIpcMessage {
-    match event {
-        OverlayEvent::OutputHint { output_name } => OverlayIpcMessage::OutputHint { output_name },
-        OverlayEvent::InterimState {
-            session_id,
-            seq,
-            state,
-        } => OverlayIpcMessage::InterimState {
-            session_id,
-            seq,
-            state,
-        },
-        OverlayEvent::InterimText {
-            session_id,
-            seq,
-            text,
-        } => OverlayIpcMessage::InterimText {
-            session_id,
-            seq,
-            text,
-        },
-        OverlayEvent::AudioLevel {
-            session_id,
-            level_db,
-        } => OverlayIpcMessage::AudioLevel {
-            session_id,
-            level_db,
-        },
-        OverlayEvent::SessionEnded { session_id, reason } => {
-            OverlayIpcMessage::SessionEnded { session_id, reason }
-        }
-        OverlayEvent::InjectionComplete {
-            session_id,
-            success,
-        } => OverlayIpcMessage::InjectionComplete {
-            session_id,
-            success,
-        },
-        OverlayEvent::SessionWarning { session_id } => {
-            OverlayIpcMessage::SessionWarning { session_id }
-        }
-    }
-}
-
-pub fn build_runtime_overlay_sink(
-    mode: OverlayMode,
-    overlay_adaptive_width: bool,
-    focus_cache: Option<WaylandFocusCache>,
-) -> Box<dyn OverlaySink> {
-    match mode {
-        OverlayMode::Disabled => Box::new(RuntimeOverlaySink::Noop(NoopOverlaySink)),
-        OverlayMode::LayerShell | OverlayMode::FallbackWindow => {
-            let manager = OverlayProcessManager::new(mode, overlay_adaptive_width, focus_cache);
-            let metrics = manager.metrics();
-            info!(
-                overlay_spawn_attempt_total = metrics.spawn_attempt_total.load(Ordering::Relaxed),
-                overlay_spawn_success_total = metrics.spawn_success_total.load(Ordering::Relaxed),
-                overlay_spawn_failure_total = metrics.spawn_failure_total.load(Ordering::Relaxed),
-                overlay_active_sink = manager.has_active_sink(),
-                overlay_adaptive_width,
-                "overlay process routing enabled with respawn manager"
-            );
-            Box::new(RuntimeOverlaySink::Process(Box::new(manager)))
-        }
-    }
-}
-
-struct OverlayRouter<S: OverlaySink> {
-    sink: S,
-    metrics: Arc<OverlayRoutingMetrics>,
-    active_session_id: Option<Uuid>,
-    last_seq: Option<u64>,
-    focus_cache: Option<WaylandFocusCache>,
-    last_output_name: Option<String>,
-}
-
-impl<S: OverlaySink> OverlayRouter<S> {
-    fn new(sink: S, focus_cache: Option<WaylandFocusCache>) -> Self {
-        Self {
-            sink,
-            metrics: Arc::new(OverlayRoutingMetrics::default()),
-            active_session_id: None,
-            last_seq: None,
-            focus_cache,
-            last_output_name: None,
-        }
-    }
-
-    #[cfg(test)]
-    fn metrics(&self) -> &Arc<OverlayRoutingMetrics> {
-        &self.metrics
-    }
-
-    fn note_session_started(&mut self, session_id: Uuid) {
-        if self.active_session_id != Some(session_id) {
-            self.active_session_id = Some(session_id);
-            self.last_seq = None;
-            self.last_output_name = None;
-        }
-    }
-
-    fn route_interim_state(
-        &mut self,
-        expected_session_id: Option<Uuid>,
-        session_id: Uuid,
-        seq: u64,
-        state: String,
-    ) {
-        if !self.allow_session(expected_session_id, session_id) || !self.accept_seq(session_id, seq)
-        {
-            return;
-        }
-
-        self.maybe_emit_output_hint();
-        self.sink.on_overlay_event(OverlayEvent::InterimState {
-            session_id,
-            seq,
-            state,
-        });
-        self.metrics.note_interim_state();
-    }
-
-    fn route_interim_text(
-        &mut self,
-        expected_session_id: Option<Uuid>,
-        session_id: Uuid,
-        seq: u64,
-        text: String,
-    ) {
-        if !self.allow_session(expected_session_id, session_id) || !self.accept_seq(session_id, seq)
-        {
-            return;
-        }
-
-        self.maybe_emit_output_hint();
-        self.sink.on_overlay_event(OverlayEvent::InterimText {
-            session_id,
-            seq,
-            text,
-        });
-        self.metrics.note_interim_text();
-    }
-
-    fn route_audio_level(
-        &mut self,
-        expected_session_id: Option<Uuid>,
-        session_id: Uuid,
-        level_db: f32,
-    ) {
-        if !self.allow_session(expected_session_id, session_id) {
-            return;
-        }
-
-        self.sink.on_overlay_event(OverlayEvent::AudioLevel {
-            session_id,
-            level_db,
-        });
-    }
-
-    fn route_session_ended(
-        &mut self,
-        expected_session_id: Option<Uuid>,
-        session_id: Uuid,
-        reason: Option<String>,
-    ) {
-        if !self.allow_session(expected_session_id, session_id) {
-            return;
-        }
-
-        self.sink
-            .on_overlay_event(OverlayEvent::SessionEnded { session_id, reason });
-        self.metrics.note_session_ended();
-
-        if self.active_session_id == Some(session_id) {
-            self.active_session_id = None;
-            self.last_seq = None;
-            self.last_output_name = None;
-        }
-    }
-
-    fn route_injection_complete(&mut self, session_id: Uuid, success: bool) {
-        self.sink.on_overlay_event(OverlayEvent::InjectionComplete {
-            session_id,
-            success,
-        });
-    }
-
-    fn route_session_warning(&mut self, session_id: Uuid) {
-        if self.active_session_id != Some(session_id) {
-            return;
-        }
-        self.sink
-            .on_overlay_event(OverlayEvent::SessionWarning { session_id });
-    }
-
-    fn maybe_emit_output_hint(&mut self) {
-        let Some(focus_cache) = self.focus_cache.as_ref() else {
-            return;
-        };
-
-        let Some(output_name) = focus_cache.current_output_name() else {
-            return;
-        };
-
-        if self.last_output_name.as_deref() == Some(output_name.as_str()) {
-            return;
-        }
-
-        self.last_output_name = Some(output_name.clone());
-        self.sink
-            .on_overlay_event(OverlayEvent::OutputHint { output_name });
-    }
-
-    fn allow_session(&self, expected_session_id: Option<Uuid>, incoming_session_id: Uuid) -> bool {
-        match expected_session_id {
-            Some(expected) if expected != incoming_session_id => {
-                self.metrics.note_session_mismatch_drop();
-                debug!(
-                    expected_session = %expected,
-                    incoming_session = %incoming_session_id,
-                    "dropping overlay event for mismatched active session"
-                );
-                false
-            }
-            _ => true,
-        }
-    }
-
-    fn accept_seq(&mut self, incoming_session_id: Uuid, seq: u64) -> bool {
-        if self.active_session_id != Some(incoming_session_id) {
-            self.active_session_id = Some(incoming_session_id);
-            self.last_seq = None;
-        }
-
-        if let Some(last_seq) = self.last_seq {
-            if seq <= last_seq {
-                self.metrics.note_stale_seq_drop();
-                debug!(
-                    session = %incoming_session_id,
-                    seq,
-                    last_seq,
-                    "dropping stale overlay event sequence"
-                );
-                return false;
-            }
-        }
-
-        self.last_seq = Some(seq);
-        true
     }
 }
 
@@ -785,6 +432,7 @@ pub async fn run(config: ClientConfig, ports: ClientPorts) -> Result<()> {
     );
     let hotkey_runtime = hotkey_source.start(&config)?;
     let (injector_worker, mut injection_reports) = spawn_injector_worker(injection_runner);
+    let focus_cache_for_parent_capture = focus_cache.clone();
     let mut overlay_router = OverlayRouter::new(overlay_sink, focus_cache);
     spawn_event_loop_lag_monitor();
 
@@ -881,7 +529,7 @@ pub async fn run(config: ClientConfig, ports: ClientPorts) -> Result<()> {
                                             let now = TokioInstant::now();
                                             last_hotkey_up_at = Some(now);
                                             last_stop_message = Some((session_id, now));
-                                            if let Some(focus) = capture_parent_focus(overlay_router.focus_cache.as_ref()) {
+                                            if let Some(focus) = capture_parent_focus(focus_cache_for_parent_capture.as_ref()) {
                                                 parent_focus_by_session.insert(
                                                     session_id,
                                                     CapturedParentFocus {
@@ -1626,6 +1274,9 @@ mod tests {
     use crate::overlay_process::{
         OverlayProcessManager, OverlayProcessMetrics, OverlayProcessSink,
     };
+    use crate::overlay_router::{
+        NoopOverlaySink, OverlayEvent, OverlayRouter, OverlaySink, RuntimeOverlaySink,
+    };
     use crate::protocol::{ClientMessage, ServerMessage};
     use crate::state::PttState;
 
@@ -1642,7 +1293,6 @@ mod tests {
         clear_transient_session_state, handle_injection_report, handle_server_message,
         maybe_defer_llm_session_end, run, BoxFuture, CapturedParentFocus, ClientPorts,
         DaemonConnection, DaemonConnector, HotkeyIntentDiagnostics, HotkeyRuntime, HotkeySource,
-        NoopOverlaySink, OverlayEvent, OverlayRouter, OverlaySink, RuntimeOverlaySink,
         SessionIntent, TransientSessionState,
     };
 
@@ -3310,13 +2960,6 @@ mod tests {
         .expect("stale interim text should be dropped without failure");
 
         assert_eq!(worker.metrics().queued_total.load(Ordering::Relaxed), 0);
-        assert_eq!(
-            overlay_router
-                .metrics()
-                .dropped_stale_seq_total
-                .load(Ordering::Relaxed),
-            1
-        );
         let overlay_events = seen_overlay_events
             .lock()
             .expect("overlay recording lock should be available")

--- a/parakeet-ptt/src/main.rs
+++ b/parakeet-ptt/src/main.rs
@@ -7,6 +7,7 @@ mod injector;
 mod injector_runtime;
 mod llm;
 mod overlay_process;
+mod overlay_router;
 mod protocol;
 mod routing;
 mod state;
@@ -402,7 +403,7 @@ async fn run_client_app(
     }
 
     let focus_cache = Some(WaylandFocusCache::new());
-    let overlay_sink = app::build_runtime_overlay_sink(
+    let overlay_sink = overlay_router::build_runtime_overlay_sink(
         overlay_capability.mode,
         overlay_adaptive_width,
         focus_cache.clone(),

--- a/parakeet-ptt/src/overlay_router.rs
+++ b/parakeet-ptt/src/overlay_router.rs
@@ -1,0 +1,491 @@
+//! Client-side Overlay routing for Daemon Session events.
+//!
+//! This Module owns the policy for filtering stale or mismatched Session
+//! events before they reach the Overlay Implementation.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use tracing::{debug, info};
+use uuid::Uuid;
+
+use crate::config::OverlayMode;
+use crate::overlay_process::OverlayProcessManager;
+use crate::surface_focus::WaylandFocusCache;
+use parakeet_ptt::overlay_ipc::OverlayIpcMessage;
+
+#[derive(Debug, Default)]
+struct OverlayRoutingMetrics {
+    routed_interim_state_total: AtomicU64,
+    routed_interim_text_total: AtomicU64,
+    routed_session_ended_total: AtomicU64,
+    dropped_stale_seq_total: AtomicU64,
+    dropped_session_mismatch_total: AtomicU64,
+}
+
+impl OverlayRoutingMetrics {
+    fn note_interim_state(&self) {
+        self.routed_interim_state_total
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn note_interim_text(&self) {
+        self.routed_interim_text_total
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn note_session_ended(&self) {
+        self.routed_session_ended_total
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn note_stale_seq_drop(&self) {
+        self.dropped_stale_seq_total.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn note_session_mismatch_drop(&self) {
+        self.dropped_session_mismatch_total
+            .fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum OverlayEvent {
+    OutputHint {
+        output_name: String,
+    },
+    InterimState {
+        session_id: Uuid,
+        seq: u64,
+        state: String,
+    },
+    InterimText {
+        session_id: Uuid,
+        seq: u64,
+        text: String,
+    },
+    AudioLevel {
+        session_id: Uuid,
+        level_db: f32,
+    },
+    SessionEnded {
+        session_id: Uuid,
+        reason: Option<String>,
+    },
+    InjectionComplete {
+        session_id: Uuid,
+        success: bool,
+    },
+    SessionWarning {
+        session_id: Uuid,
+    },
+}
+
+pub trait OverlaySink: Send {
+    fn on_overlay_event(&mut self, event: OverlayEvent);
+}
+
+impl<T: OverlaySink + ?Sized> OverlaySink for Box<T> {
+    fn on_overlay_event(&mut self, event: OverlayEvent) {
+        self.as_mut().on_overlay_event(event);
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct NoopOverlaySink;
+
+impl OverlaySink for NoopOverlaySink {
+    fn on_overlay_event(&mut self, event: OverlayEvent) {
+        debug!(?event, "overlay event dropped by noop sink");
+    }
+}
+
+pub(crate) enum RuntimeOverlaySink {
+    Noop(NoopOverlaySink),
+    Process(Box<OverlayProcessManager>),
+}
+
+impl OverlaySink for RuntimeOverlaySink {
+    fn on_overlay_event(&mut self, event: OverlayEvent) {
+        match self {
+            Self::Noop(sink) => sink.on_overlay_event(event),
+            Self::Process(manager) => manager.send(overlay_event_to_ipc(event)),
+        }
+    }
+}
+
+fn overlay_event_to_ipc(event: OverlayEvent) -> OverlayIpcMessage {
+    match event {
+        OverlayEvent::OutputHint { output_name } => OverlayIpcMessage::OutputHint { output_name },
+        OverlayEvent::InterimState {
+            session_id,
+            seq,
+            state,
+        } => OverlayIpcMessage::InterimState {
+            session_id,
+            seq,
+            state,
+        },
+        OverlayEvent::InterimText {
+            session_id,
+            seq,
+            text,
+        } => OverlayIpcMessage::InterimText {
+            session_id,
+            seq,
+            text,
+        },
+        OverlayEvent::AudioLevel {
+            session_id,
+            level_db,
+        } => OverlayIpcMessage::AudioLevel {
+            session_id,
+            level_db,
+        },
+        OverlayEvent::SessionEnded { session_id, reason } => {
+            OverlayIpcMessage::SessionEnded { session_id, reason }
+        }
+        OverlayEvent::InjectionComplete {
+            session_id,
+            success,
+        } => OverlayIpcMessage::InjectionComplete {
+            session_id,
+            success,
+        },
+        OverlayEvent::SessionWarning { session_id } => {
+            OverlayIpcMessage::SessionWarning { session_id }
+        }
+    }
+}
+
+pub(crate) fn build_runtime_overlay_sink(
+    mode: OverlayMode,
+    overlay_adaptive_width: bool,
+    focus_cache: Option<WaylandFocusCache>,
+) -> Box<dyn OverlaySink> {
+    match mode {
+        OverlayMode::Disabled => Box::new(RuntimeOverlaySink::Noop(NoopOverlaySink)),
+        OverlayMode::LayerShell | OverlayMode::FallbackWindow => {
+            let manager = OverlayProcessManager::new(mode, overlay_adaptive_width, focus_cache);
+            let metrics = manager.metrics();
+            info!(
+                overlay_spawn_attempt_total = metrics.spawn_attempt_total.load(Ordering::Relaxed),
+                overlay_spawn_success_total = metrics.spawn_success_total.load(Ordering::Relaxed),
+                overlay_spawn_failure_total = metrics.spawn_failure_total.load(Ordering::Relaxed),
+                overlay_active_sink = manager.has_active_sink(),
+                overlay_adaptive_width,
+                "overlay process routing enabled with respawn manager"
+            );
+            Box::new(RuntimeOverlaySink::Process(Box::new(manager)))
+        }
+    }
+}
+
+pub(crate) struct OverlayRouter<S: OverlaySink> {
+    sink: S,
+    metrics: Arc<OverlayRoutingMetrics>,
+    active_session_id: Option<Uuid>,
+    last_seq: Option<u64>,
+    focus_cache: Option<WaylandFocusCache>,
+    last_output_name: Option<String>,
+}
+
+impl<S: OverlaySink> OverlayRouter<S> {
+    pub(crate) fn new(sink: S, focus_cache: Option<WaylandFocusCache>) -> Self {
+        Self {
+            sink,
+            metrics: Arc::new(OverlayRoutingMetrics::default()),
+            active_session_id: None,
+            last_seq: None,
+            focus_cache,
+            last_output_name: None,
+        }
+    }
+
+    #[cfg(test)]
+    fn metrics(&self) -> &Arc<OverlayRoutingMetrics> {
+        &self.metrics
+    }
+
+    pub(crate) fn note_session_started(&mut self, session_id: Uuid) {
+        if self.active_session_id != Some(session_id) {
+            self.active_session_id = Some(session_id);
+            self.last_seq = None;
+            self.last_output_name = None;
+        }
+    }
+
+    pub(crate) fn route_interim_state(
+        &mut self,
+        expected_session_id: Option<Uuid>,
+        session_id: Uuid,
+        seq: u64,
+        state: String,
+    ) {
+        if !self.allow_session(expected_session_id, session_id) || !self.accept_seq(session_id, seq)
+        {
+            return;
+        }
+
+        self.maybe_emit_output_hint();
+        self.sink.on_overlay_event(OverlayEvent::InterimState {
+            session_id,
+            seq,
+            state,
+        });
+        self.metrics.note_interim_state();
+    }
+
+    pub(crate) fn route_interim_text(
+        &mut self,
+        expected_session_id: Option<Uuid>,
+        session_id: Uuid,
+        seq: u64,
+        text: String,
+    ) {
+        if !self.allow_session(expected_session_id, session_id) || !self.accept_seq(session_id, seq)
+        {
+            return;
+        }
+
+        self.maybe_emit_output_hint();
+        self.sink.on_overlay_event(OverlayEvent::InterimText {
+            session_id,
+            seq,
+            text,
+        });
+        self.metrics.note_interim_text();
+    }
+
+    pub(crate) fn route_audio_level(
+        &mut self,
+        expected_session_id: Option<Uuid>,
+        session_id: Uuid,
+        level_db: f32,
+    ) {
+        if !self.allow_session(expected_session_id, session_id) {
+            return;
+        }
+
+        self.sink.on_overlay_event(OverlayEvent::AudioLevel {
+            session_id,
+            level_db,
+        });
+    }
+
+    pub(crate) fn route_session_ended(
+        &mut self,
+        expected_session_id: Option<Uuid>,
+        session_id: Uuid,
+        reason: Option<String>,
+    ) {
+        if !self.allow_session(expected_session_id, session_id) {
+            return;
+        }
+
+        self.sink
+            .on_overlay_event(OverlayEvent::SessionEnded { session_id, reason });
+        self.metrics.note_session_ended();
+
+        if self.active_session_id == Some(session_id) {
+            self.active_session_id = None;
+            self.last_seq = None;
+            self.last_output_name = None;
+        }
+    }
+
+    pub(crate) fn route_injection_complete(&mut self, session_id: Uuid, success: bool) {
+        self.sink.on_overlay_event(OverlayEvent::InjectionComplete {
+            session_id,
+            success,
+        });
+    }
+
+    pub(crate) fn route_session_warning(&mut self, session_id: Uuid) {
+        if self.active_session_id != Some(session_id) {
+            return;
+        }
+        self.sink
+            .on_overlay_event(OverlayEvent::SessionWarning { session_id });
+    }
+
+    fn maybe_emit_output_hint(&mut self) {
+        let Some(focus_cache) = self.focus_cache.as_ref() else {
+            return;
+        };
+
+        let Some(output_name) = focus_cache.current_output_name() else {
+            return;
+        };
+
+        if self.last_output_name.as_deref() == Some(output_name.as_str()) {
+            return;
+        }
+
+        self.last_output_name = Some(output_name.clone());
+        self.sink
+            .on_overlay_event(OverlayEvent::OutputHint { output_name });
+    }
+
+    fn allow_session(&self, expected_session_id: Option<Uuid>, incoming_session_id: Uuid) -> bool {
+        match expected_session_id {
+            Some(expected) if expected != incoming_session_id => {
+                self.metrics.note_session_mismatch_drop();
+                debug!(
+                    expected_session = %expected,
+                    incoming_session = %incoming_session_id,
+                    "dropping overlay event for mismatched active session"
+                );
+                false
+            }
+            _ => true,
+        }
+    }
+
+    fn accept_seq(&mut self, incoming_session_id: Uuid, seq: u64) -> bool {
+        if self.active_session_id != Some(incoming_session_id) {
+            self.active_session_id = Some(incoming_session_id);
+            self.last_seq = None;
+        }
+
+        if let Some(last_seq) = self.last_seq {
+            if seq <= last_seq {
+                self.metrics.note_stale_seq_drop();
+                debug!(
+                    session = %incoming_session_id,
+                    seq,
+                    last_seq,
+                    "dropping stale overlay event sequence"
+                );
+                return false;
+            }
+        }
+
+        self.last_seq = Some(seq);
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::Ordering;
+    use std::sync::{Arc, Mutex};
+
+    use uuid::Uuid;
+
+    use super::{OverlayEvent, OverlayRouter, OverlaySink};
+
+    struct RecordingOverlaySink {
+        seen: Arc<Mutex<Vec<OverlayEvent>>>,
+    }
+
+    impl RecordingOverlaySink {
+        fn new() -> (Self, Arc<Mutex<Vec<OverlayEvent>>>) {
+            let seen = Arc::new(Mutex::new(Vec::new()));
+            (
+                Self {
+                    seen: Arc::clone(&seen),
+                },
+                seen,
+            )
+        }
+    }
+
+    impl OverlaySink for RecordingOverlaySink {
+        fn on_overlay_event(&mut self, event: OverlayEvent) {
+            self.seen
+                .lock()
+                .expect("overlay recording lock should be available")
+                .push(event);
+        }
+    }
+
+    #[test]
+    fn stale_interim_sequences_are_dropped_near_router() {
+        let session_id = Uuid::new_v4();
+        let (sink, seen) = RecordingOverlaySink::new();
+        let mut router = OverlayRouter::new(sink, None);
+
+        router.route_interim_text(None, session_id, 10, "newest".to_string());
+        router.route_interim_text(None, session_id, 9, "stale".to_string());
+
+        assert_eq!(
+            router
+                .metrics()
+                .dropped_stale_seq_total
+                .load(Ordering::Relaxed),
+            1
+        );
+        assert_eq!(
+            seen.lock()
+                .expect("overlay recording lock should be available")
+                .clone(),
+            vec![OverlayEvent::InterimText {
+                session_id,
+                seq: 10,
+                text: "newest".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn mismatched_session_events_are_dropped_near_router() {
+        let active_session_id = Uuid::new_v4();
+        let stale_session_id = Uuid::new_v4();
+        let (sink, seen) = RecordingOverlaySink::new();
+        let mut router = OverlayRouter::new(sink, None);
+        router.note_session_started(active_session_id);
+
+        router.route_interim_text(
+            Some(active_session_id),
+            stale_session_id,
+            1,
+            "stale session".to_string(),
+        );
+        router.route_interim_text(
+            Some(active_session_id),
+            active_session_id,
+            1,
+            "active session".to_string(),
+        );
+
+        assert_eq!(
+            router
+                .metrics()
+                .dropped_session_mismatch_total
+                .load(Ordering::Relaxed),
+            1
+        );
+        assert_eq!(
+            seen.lock()
+                .expect("overlay recording lock should be available")
+                .clone(),
+            vec![OverlayEvent::InterimText {
+                session_id: active_session_id,
+                seq: 1,
+                text: "active session".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn session_warning_requires_active_session() {
+        let active_session_id = Uuid::new_v4();
+        let inactive_session_id = Uuid::new_v4();
+        let (sink, seen) = RecordingOverlaySink::new();
+        let mut router = OverlayRouter::new(sink, None);
+        router.note_session_started(active_session_id);
+
+        router.route_session_warning(inactive_session_id);
+        router.route_session_warning(active_session_id);
+
+        assert_eq!(
+            seen.lock()
+                .expect("overlay recording lock should be available")
+                .clone(),
+            vec![OverlayEvent::SessionWarning {
+                session_id: active_session_id,
+            }]
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #77.

- Moves Client Overlay routing policy from app.rs into a named overlay_router Module.
- Keeps app.rs as runtime orchestration while preserving Session routing, stale sequence drops, mismatched Session drops, output hints, warning routing, and Injection completion routing.
- Adds focused router-local tests for stale sequence drops, mismatched Session drops, and Session warning routing.

## Compatibility

No Daemon protocol, Helper, Profile, Stream path, Seal path, Injection timeout, or runtime behavior changes are intended.

## Verification (#77)

- targeted: cargo test overlay_router --manifest-path Cargo.toml (from parakeet-ptt/) -> PASSED
- targeted: cargo test overlay --manifest-path Cargo.toml (from parakeet-ptt/) -> PASSED
- targeted: cargo test app_injection_report_error_routes_failure_classification --manifest-path Cargo.toml (from parakeet-ptt/) -> PASSED
- targeted: cargo test mixed_stream_enqueues_exactly_one_final_result --manifest-path Cargo.toml (from parakeet-ptt/) -> PASSED
- regression: N/A, pure refactor with existing behavior coverage and new router-local stale/mismatch tests
- full suite: cargo test --manifest-path parakeet-ptt/Cargo.toml -> PASSED
- lint: cargo clippy --manifest-path parakeet-ptt/Cargo.toml --all-targets --all-features -- -D warnings -> PASSED
- types: cargo check --manifest-path parakeet-ptt/Cargo.toml --all-targets --all-features -> PASSED
- dead-code: N/A, no repo dead-code gate discovered for Rust
- build: cargo build --manifest-path parakeet-ptt/Cargo.toml --bins -> PASSED
- pre-commit: prek run --files parakeet-ptt/src/app.rs parakeet-ptt/src/main.rs parakeet-ptt/src/overlay_router.rs -> PASSED; prek run --all-files -> PASSED
- static/security: N/A, no changed security-sensitive surface and no separate Rust security gate discovered
- migrations: N/A
- CLI/script smoke: N/A, no CLI/script behavior changed
- UI render: N/A, no Overlay renderer UI drawing behavior changed
- destructive/negative: N/A
- review: coderabbit_review_watch.py local --base main -> clean, findings=0, summary=.git/coderabbit-review/20260519T113852Z/status.json (codex-fallback: no); PR gate clean, summary=.git/coderabbit-review/20260519T114233Z/gate-summary.json
- tests added/expanded: parakeet-ptt/src/overlay_router.rs
- preexisting failures left: none

## Reviewer triage

CodeRabbit local watcher completed clean with findings=0. CodeRabbit PR gate completed clean with no actionable findings. IGNORE: generic CodeRabbit docstring coverage pre-merge warning is not a valid in-scope finding for this Rust refactor because the repo has no docstring coverage gate, rustdoc-style coverage is not required by local conventions, and cargo clippy plus prek gates are green.

## Deferred follow-ups

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal overlay routing components into a dedicated module for improved code structure.

---

**Note:** This release contains internal code refactoring with no user-facing feature changes or bug fixes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SystemicVoid/parakeet-stt/pull/80?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
