### PR TITLE
test(ptt): add client runtime fixtures

### DIFF
--- a/parakeet-ptt/src/app.rs
+++ b/parakeet-ptt/src/app.rs
@@ -94,6 +94,20 @@ pub struct HotkeyRuntime {
     _tasks: Option<HotkeyTasks>,
 }
 
+#[cfg(test)]
+impl HotkeyRuntime {
+    pub(crate) fn new_for_tests(events: mpsc::UnboundedReceiver<HotkeyEvent>) -> Self {
+        Self {
+            events,
+            listener_count: 1,
+            talk_key: evdev::Key::KEY_RIGHTCTRL,
+            llm_pre_modifier_keys: Vec::new(),
+            llm_pre_modifier_key_name: "KEY_SHIFT".to_string(),
+            _tasks: None,
+        }
+    }
+}
+
 pub trait HotkeySource: Send {
     fn start(&mut self, config: &ClientConfig) -> Result<HotkeyRuntime>;
 }
@@ -1070,24 +1084,25 @@ mod tests {
     use std::time::Duration;
     use std::time::Instant;
 
-    use anyhow::anyhow;
     use clap::Parser;
-    use tokio::sync::mpsc;
     use tokio::task::yield_now;
     use tokio::time::timeout;
     use uuid::Uuid;
 
     use crate::audio_feedback::AudioFeedback;
+    use crate::client_runtime_fixtures::{
+        ClientRuntimeHarness, RecordingInjectionRunner, RecordingOverlaySink,
+    };
     use crate::config::{
         ClientConfig, ClipboardOptions, InjectionConfig, InjectionMode, PasteBackendFailurePolicy,
         PasteKeyBackend, PasteShortcut,
     };
-    use crate::hotkey::{HotkeyEvent, HotkeyIntent};
+    use crate::hotkey::HotkeyIntent;
     use crate::injector::{
         FailInjector, InjectorContext, ParentFocusCapture, PasteChordSender, PasteKeySender,
         TextInjector,
     };
-    use crate::overlay_router::{NoopOverlaySink, OverlayEvent, OverlayRouter, OverlaySink};
+    use crate::overlay_router::{OverlayEvent, OverlayRouter};
     use crate::protocol::{ClientMessage, ServerMessage};
     use crate::state::PttState;
 
@@ -1098,12 +1113,11 @@ mod tests {
         InjectionJobRunner, InjectionOrigin, InjectionReport, InjectionRunError,
         InjectionRunOutput, InjectorSubprocessRunner, UinputSenderState,
     };
-    use crate::llm::{drain_sse_lines, sanitize_model_answer, LlmAnswerer, LlmProgress};
+    use crate::llm::{drain_sse_lines, sanitize_model_answer};
 
     use super::{
         clear_transient_session_state, handle_injection_report, maybe_defer_llm_session_end, run,
-        BoxFuture, CapturedParentFocus, ClientPorts, DaemonConnection, DaemonConnector,
-        HotkeyIntentDiagnostics, HotkeyRuntime, HotkeySource, SessionIntent, TransientSessionState,
+        CapturedParentFocus, HotkeyIntentDiagnostics, SessionIntent, TransientSessionState,
     };
 
     #[test]
@@ -1164,23 +1178,6 @@ mod tests {
         ) -> std::result::Result<InjectionRunOutput, InjectionRunError> {
             self.calls.fetch_add(1, Ordering::Relaxed);
             std::thread::sleep(Duration::from_millis(self.sleep_ms));
-            Ok(InjectionRunOutput::default())
-        }
-    }
-
-    struct RecordingRunner {
-        seen: Arc<Mutex<Vec<String>>>,
-    }
-
-    impl InjectionJobRunner for RecordingRunner {
-        fn run(
-            &self,
-            job: &InjectionJob,
-        ) -> std::result::Result<InjectionRunOutput, InjectionRunError> {
-            self.seen
-                .lock()
-                .expect("recording lock should be available")
-                .push(job.text.to_string());
             Ok(InjectionRunOutput::default())
         }
     }
@@ -1334,126 +1331,6 @@ mod tests {
         path
     }
 
-    struct RecordingOverlaySink {
-        seen: Arc<Mutex<Vec<OverlayEvent>>>,
-    }
-
-    impl OverlaySink for RecordingOverlaySink {
-        fn on_overlay_event(&mut self, event: OverlayEvent) {
-            self.seen
-                .lock()
-                .expect("overlay recording lock should be available")
-                .push(event);
-        }
-    }
-
-    struct FakeHotkeySource {
-        events: Option<mpsc::UnboundedReceiver<HotkeyEvent>>,
-    }
-
-    impl FakeHotkeySource {
-        fn new(events: mpsc::UnboundedReceiver<HotkeyEvent>) -> Self {
-            Self {
-                events: Some(events),
-            }
-        }
-    }
-
-    impl HotkeySource for FakeHotkeySource {
-        fn start(&mut self, _config: &ClientConfig) -> anyhow::Result<HotkeyRuntime> {
-            Ok(HotkeyRuntime {
-                events: self
-                    .events
-                    .take()
-                    .expect("fake hotkey source should only be started once"),
-                listener_count: 1,
-                talk_key: evdev::Key::KEY_RIGHTCTRL,
-                llm_pre_modifier_keys: Vec::new(),
-                llm_pre_modifier_key_name: "KEY_SHIFT".to_string(),
-                _tasks: None,
-            })
-        }
-    }
-
-    struct FakeDaemonConnector {
-        connection: Mutex<Option<FakeDaemonConnection>>,
-    }
-
-    impl FakeDaemonConnector {
-        fn new(connection: FakeDaemonConnection) -> Self {
-            Self {
-                connection: Mutex::new(Some(connection)),
-            }
-        }
-    }
-
-    impl DaemonConnector for FakeDaemonConnector {
-        fn connect<'a>(
-            &'a self,
-            _config: &'a ClientConfig,
-        ) -> BoxFuture<'a, anyhow::Result<Box<dyn DaemonConnection>>> {
-            Box::pin(async move {
-                let connection = self
-                    .connection
-                    .lock()
-                    .expect("fake connection lock should be available")
-                    .take()
-                    .expect("fake connector should only be connected once");
-                Ok(Box::new(connection) as Box<dyn DaemonConnection>)
-            })
-        }
-    }
-
-    struct FakeDaemonConnection {
-        sent: mpsc::UnboundedSender<ClientMessage>,
-        incoming: mpsc::UnboundedReceiver<ServerMessage>,
-    }
-
-    impl DaemonConnection for FakeDaemonConnection {
-        fn send<'a>(&'a mut self, message: &'a ClientMessage) -> BoxFuture<'a, anyhow::Result<()>> {
-            Box::pin(async move {
-                let payload =
-                    serde_json::to_string(message).expect("client message should serialize");
-                let cloned = serde_json::from_str::<ClientMessage>(&payload)
-                    .expect("client message should deserialize");
-                self.sent
-                    .send(cloned)
-                    .map_err(|_| anyhow!("fake sent-message receiver dropped"))
-            })
-        }
-
-        fn next_message<'a>(&'a mut self) -> BoxFuture<'a, anyhow::Result<Option<ServerMessage>>> {
-            Box::pin(async move { Ok(self.incoming.recv().await) })
-        }
-    }
-
-    struct FakeLlmAnswerer;
-
-    impl LlmAnswerer for FakeLlmAnswerer {
-        fn label(&self) -> String {
-            "fake-llm".to_string()
-        }
-
-        fn stream_answer<'a>(&'a self, _prompt: &'a str) -> crate::llm::LlmDeltaStream<'a> {
-            Box::pin(futures::stream::iter([Ok(crate::llm::LlmDelta {
-                content: "fake answer".to_string(),
-            })]))
-        }
-
-        fn health<'a>(&'a self) -> BoxFuture<'a, bool> {
-            Box::pin(async { false })
-        }
-
-        fn answer<'a>(
-            &'a self,
-            _session_id: Uuid,
-            _transcript: String,
-            _progress_tx: mpsc::UnboundedSender<LlmProgress>,
-        ) -> BoxFuture<'a, anyhow::Result<String>> {
-            Box::pin(async { Ok("fake answer".to_string()) })
-        }
-    }
-
     fn test_app_config() -> ClientConfig {
         ClientConfig::new(
             "test://daemon/ws",
@@ -1477,35 +1354,12 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn app_hotkey_press_sends_start_session_message() {
-        let config = test_app_config();
-        let (hotkey_tx, hotkey_rx) = mpsc::unbounded_channel();
-        let (sent_tx, mut sent_rx) = mpsc::unbounded_channel();
-        let (_incoming_tx, incoming_rx) = mpsc::unbounded_channel();
-        let ports = ClientPorts::new(
-            AudioFeedback::new(false, None, 0),
-            Arc::new(FakeDaemonConnector::new(FakeDaemonConnection {
-                sent: sent_tx,
-                incoming: incoming_rx,
-            })),
-            Arc::new(RecordingRunner {
-                seen: Arc::new(Mutex::new(Vec::new())),
-            }),
-            Box::new(NoopOverlaySink),
-            None,
-            Box::new(FakeHotkeySource::new(hotkey_rx)),
-            Arc::new(FakeLlmAnswerer),
-        );
+        let (config, ports, mut runtime) =
+            ClientRuntimeHarness::new(test_app_config()).into_parts();
 
         let app_task = tokio::spawn(run(config, ports));
-        hotkey_tx
-            .send(HotkeyEvent::Down {
-                intent: HotkeyIntent::Dictate,
-            })
-            .expect("fake hotkey event should send");
-        let sent = timeout(Duration::from_millis(250), sent_rx.recv())
-            .await
-            .expect("start_session should be sent")
-            .expect("sent-message channel should stay open");
+        runtime.send_hotkey_down(HotkeyIntent::Dictate);
+        let sent = runtime.next_sent_message(Duration::from_millis(250)).await;
         app_task.abort();
 
         match sent {
@@ -1523,18 +1377,11 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn app_injection_report_error_routes_failure_classification() {
-        let injector = Arc::new(RecordingRunner {
-            seen: Arc::new(Mutex::new(Vec::new())),
-        });
+        let (injector, _seen) = RecordingInjectionRunner::shared();
         let (worker, _reports) = spawn_injector_worker_with_capacity(injector, 4);
         let session_id = Uuid::new_v4();
-        let seen_overlay_events = Arc::new(Mutex::new(Vec::<OverlayEvent>::new()));
-        let mut overlay_router = OverlayRouter::new(
-            RecordingOverlaySink {
-                seen: Arc::clone(&seen_overlay_events),
-            },
-            None,
-        );
+        let (overlay_sink, seen_overlay_events) = RecordingOverlaySink::shared();
+        let mut overlay_router = OverlayRouter::new(overlay_sink, None);
 
         handle_injection_report(
             &worker,
@@ -2065,10 +1912,7 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn injector_worker_preserves_fifo_order() {
-        let seen = Arc::new(Mutex::new(Vec::<String>::new()));
-        let injector = Arc::new(RecordingRunner {
-            seen: Arc::clone(&seen),
-        });
+        let (injector, seen) = RecordingInjectionRunner::shared();
         let (worker, mut reports) = spawn_injector_worker_with_capacity(injector, 4);
 
         worker

--- a/parakeet-ptt/src/app.rs
+++ b/parakeet-ptt/src/app.rs
@@ -1319,10 +1319,10 @@ mod tests {
         file.as_file()
             .sync_all()
             .expect("test script should sync before execution");
-        let path = file
-            .into_temp_path()
+        let (persisted_file, path) = file
             .keep()
             .expect("test script path should persist until test cleanup");
+        drop(persisted_file);
         let mut perms = fs::metadata(&path)
             .expect("test script should exist")
             .permissions();
@@ -1361,6 +1361,15 @@ mod tests {
         runtime.send_hotkey_down(HotkeyIntent::Dictate);
         let sent = runtime.next_sent_message(Duration::from_millis(250)).await;
         app_task.abort();
+
+        assert!(
+            runtime.recorded_injections().is_empty(),
+            "start-session hotkey path should not enqueue Injection"
+        );
+        assert!(
+            runtime.recorded_overlay_events().is_empty(),
+            "start-session hotkey path should not emit Overlay events before Daemon response"
+        );
 
         match sent {
             ClientMessage::StartSession {

--- a/parakeet-ptt/src/client_runtime_fixtures.rs
+++ b/parakeet-ptt/src/client_runtime_fixtures.rs
@@ -15,7 +15,7 @@ use crate::injector_runtime::{
     InjectionJob, InjectionJobRunner, InjectionRunError, InjectionRunOutput,
 };
 use crate::llm::{LlmAnswerer, LlmDelta, LlmDeltaStream, LlmProgress};
-use crate::overlay_router::{NoopOverlaySink, OverlayEvent, OverlaySink};
+use crate::overlay_router::{OverlayEvent, OverlaySink};
 use crate::protocol::{ClientMessage, ServerMessage};
 
 type TestBoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
@@ -31,7 +31,8 @@ impl ClientRuntimeHarness {
         let (hotkey_tx, hotkey_rx) = mpsc::unbounded_channel();
         let (sent_tx, sent_rx) = mpsc::unbounded_channel();
         let (daemon_tx, daemon_rx) = mpsc::unbounded_channel();
-        let (injection_runner, _seen_injections) = RecordingInjectionRunner::shared();
+        let (injection_runner, injections) = RecordingInjectionRunner::shared();
+        let (overlay_sink, overlay_events) = RecordingOverlaySink::shared();
         let ports = ClientPorts::new(
             AudioFeedback::new(false, None, 0),
             Arc::new(TestDaemonConnector::new(TestDaemonConnection {
@@ -39,7 +40,7 @@ impl ClientRuntimeHarness {
                 incoming: daemon_rx,
             })),
             injection_runner,
-            Box::new(NoopOverlaySink),
+            Box::new(overlay_sink),
             None,
             Box::new(TestHotkeySource::new(hotkey_rx)),
             Arc::new(TestLlmAnswerer),
@@ -51,6 +52,8 @@ impl ClientRuntimeHarness {
             controls: ClientRuntimeControls {
                 hotkey_tx,
                 sent_rx,
+                injections,
+                overlay_events,
                 _daemon_tx: daemon_tx,
             },
         }
@@ -64,6 +67,8 @@ impl ClientRuntimeHarness {
 pub(crate) struct ClientRuntimeControls {
     hotkey_tx: mpsc::UnboundedSender<HotkeyEvent>,
     sent_rx: mpsc::UnboundedReceiver<ClientMessage>,
+    injections: Arc<Mutex<Vec<String>>>,
+    overlay_events: Arc<Mutex<Vec<OverlayEvent>>>,
     _daemon_tx: mpsc::UnboundedSender<ServerMessage>,
 }
 
@@ -79,6 +84,20 @@ impl ClientRuntimeControls {
             .await
             .expect("client message should be sent before timeout")
             .expect("sent-message channel should stay open")
+    }
+
+    pub(crate) fn recorded_injections(&self) -> Vec<String> {
+        self.injections
+            .lock()
+            .expect("recorded injection lock should be available")
+            .clone()
+    }
+
+    pub(crate) fn recorded_overlay_events(&self) -> Vec<OverlayEvent> {
+        self.overlay_events
+            .lock()
+            .expect("recorded overlay lock should be available")
+            .clone()
     }
 }
 
@@ -192,11 +211,8 @@ struct TestDaemonConnection {
 impl DaemonConnection for TestDaemonConnection {
     fn send<'a>(&'a mut self, message: &'a ClientMessage) -> TestBoxFuture<'a, anyhow::Result<()>> {
         Box::pin(async move {
-            let payload = serde_json::to_string(message).expect("client message should serialize");
-            let cloned = serde_json::from_str::<ClientMessage>(&payload)
-                .expect("client message should deserialize");
             self.sent
-                .send(cloned)
+                .send(message.clone())
                 .map_err(|_| anyhow!("test sent-message receiver dropped"))
         })
     }

--- a/parakeet-ptt/src/client_runtime_fixtures.rs
+++ b/parakeet-ptt/src/client_runtime_fixtures.rs
@@ -1,0 +1,234 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use anyhow::anyhow;
+use tokio::sync::mpsc;
+use uuid::Uuid;
+
+use crate::app::{ClientPorts, DaemonConnection, DaemonConnector, HotkeyRuntime, HotkeySource};
+use crate::audio_feedback::AudioFeedback;
+use crate::config::ClientConfig;
+use crate::hotkey::{HotkeyEvent, HotkeyIntent};
+use crate::injector_runtime::{
+    InjectionJob, InjectionJobRunner, InjectionRunError, InjectionRunOutput,
+};
+use crate::llm::{LlmAnswerer, LlmDelta, LlmDeltaStream, LlmProgress};
+use crate::overlay_router::{NoopOverlaySink, OverlayEvent, OverlaySink};
+use crate::protocol::{ClientMessage, ServerMessage};
+
+type TestBoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+pub(crate) struct ClientRuntimeHarness {
+    config: ClientConfig,
+    ports: ClientPorts,
+    controls: ClientRuntimeControls,
+}
+
+impl ClientRuntimeHarness {
+    pub(crate) fn new(config: ClientConfig) -> Self {
+        let (hotkey_tx, hotkey_rx) = mpsc::unbounded_channel();
+        let (sent_tx, sent_rx) = mpsc::unbounded_channel();
+        let (daemon_tx, daemon_rx) = mpsc::unbounded_channel();
+        let (injection_runner, _seen_injections) = RecordingInjectionRunner::shared();
+        let ports = ClientPorts::new(
+            AudioFeedback::new(false, None, 0),
+            Arc::new(TestDaemonConnector::new(TestDaemonConnection {
+                sent: sent_tx,
+                incoming: daemon_rx,
+            })),
+            injection_runner,
+            Box::new(NoopOverlaySink),
+            None,
+            Box::new(TestHotkeySource::new(hotkey_rx)),
+            Arc::new(TestLlmAnswerer),
+        );
+
+        Self {
+            config,
+            ports,
+            controls: ClientRuntimeControls {
+                hotkey_tx,
+                sent_rx,
+                _daemon_tx: daemon_tx,
+            },
+        }
+    }
+
+    pub(crate) fn into_parts(self) -> (ClientConfig, ClientPorts, ClientRuntimeControls) {
+        (self.config, self.ports, self.controls)
+    }
+}
+
+pub(crate) struct ClientRuntimeControls {
+    hotkey_tx: mpsc::UnboundedSender<HotkeyEvent>,
+    sent_rx: mpsc::UnboundedReceiver<ClientMessage>,
+    _daemon_tx: mpsc::UnboundedSender<ServerMessage>,
+}
+
+impl ClientRuntimeControls {
+    pub(crate) fn send_hotkey_down(&self, intent: HotkeyIntent) {
+        self.hotkey_tx
+            .send(HotkeyEvent::Down { intent })
+            .expect("test hotkey event should send");
+    }
+
+    pub(crate) async fn next_sent_message(&mut self, wait: Duration) -> ClientMessage {
+        tokio::time::timeout(wait, self.sent_rx.recv())
+            .await
+            .expect("client message should be sent before timeout")
+            .expect("sent-message channel should stay open")
+    }
+}
+
+pub(crate) struct RecordingInjectionRunner {
+    seen: Arc<Mutex<Vec<String>>>,
+}
+
+impl RecordingInjectionRunner {
+    pub(crate) fn shared() -> (Arc<Self>, Arc<Mutex<Vec<String>>>) {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        (
+            Arc::new(Self {
+                seen: Arc::clone(&seen),
+            }),
+            seen,
+        )
+    }
+}
+
+impl InjectionJobRunner for RecordingInjectionRunner {
+    fn run(&self, job: &InjectionJob) -> Result<InjectionRunOutput, InjectionRunError> {
+        self.seen
+            .lock()
+            .expect("recording lock should be available")
+            .push(job.text.to_string());
+        Ok(InjectionRunOutput::default())
+    }
+}
+
+pub(crate) struct RecordingOverlaySink {
+    seen: Arc<Mutex<Vec<OverlayEvent>>>,
+}
+
+impl RecordingOverlaySink {
+    pub(crate) fn shared() -> (Self, Arc<Mutex<Vec<OverlayEvent>>>) {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        (
+            Self {
+                seen: Arc::clone(&seen),
+            },
+            seen,
+        )
+    }
+}
+
+impl OverlaySink for RecordingOverlaySink {
+    fn on_overlay_event(&mut self, event: OverlayEvent) {
+        self.seen
+            .lock()
+            .expect("overlay recording lock should be available")
+            .push(event);
+    }
+}
+
+struct TestHotkeySource {
+    events: Option<mpsc::UnboundedReceiver<HotkeyEvent>>,
+}
+
+impl TestHotkeySource {
+    fn new(events: mpsc::UnboundedReceiver<HotkeyEvent>) -> Self {
+        Self {
+            events: Some(events),
+        }
+    }
+}
+
+impl HotkeySource for TestHotkeySource {
+    fn start(&mut self, _config: &ClientConfig) -> anyhow::Result<HotkeyRuntime> {
+        Ok(HotkeyRuntime::new_for_tests(
+            self.events
+                .take()
+                .expect("test hotkey source should only be started once"),
+        ))
+    }
+}
+
+struct TestDaemonConnector {
+    connection: Mutex<Option<TestDaemonConnection>>,
+}
+
+impl TestDaemonConnector {
+    fn new(connection: TestDaemonConnection) -> Self {
+        Self {
+            connection: Mutex::new(Some(connection)),
+        }
+    }
+}
+
+impl DaemonConnector for TestDaemonConnector {
+    fn connect<'a>(
+        &'a self,
+        _config: &'a ClientConfig,
+    ) -> TestBoxFuture<'a, anyhow::Result<Box<dyn DaemonConnection>>> {
+        Box::pin(async move {
+            let connection = self
+                .connection
+                .lock()
+                .expect("test connection lock should be available")
+                .take()
+                .expect("test connector should only be connected once");
+            Ok(Box::new(connection) as Box<dyn DaemonConnection>)
+        })
+    }
+}
+
+struct TestDaemonConnection {
+    sent: mpsc::UnboundedSender<ClientMessage>,
+    incoming: mpsc::UnboundedReceiver<ServerMessage>,
+}
+
+impl DaemonConnection for TestDaemonConnection {
+    fn send<'a>(&'a mut self, message: &'a ClientMessage) -> TestBoxFuture<'a, anyhow::Result<()>> {
+        Box::pin(async move {
+            let payload = serde_json::to_string(message).expect("client message should serialize");
+            let cloned = serde_json::from_str::<ClientMessage>(&payload)
+                .expect("client message should deserialize");
+            self.sent
+                .send(cloned)
+                .map_err(|_| anyhow!("test sent-message receiver dropped"))
+        })
+    }
+
+    fn next_message<'a>(&'a mut self) -> TestBoxFuture<'a, anyhow::Result<Option<ServerMessage>>> {
+        Box::pin(async move { Ok(self.incoming.recv().await) })
+    }
+}
+
+struct TestLlmAnswerer;
+
+impl LlmAnswerer for TestLlmAnswerer {
+    fn label(&self) -> String {
+        "test-llm".to_string()
+    }
+
+    fn stream_answer<'a>(&'a self, _prompt: &'a str) -> LlmDeltaStream<'a> {
+        Box::pin(futures::stream::iter([Ok(LlmDelta {
+            content: "test answer".to_string(),
+        })]))
+    }
+
+    fn health<'a>(&'a self) -> TestBoxFuture<'a, bool> {
+        Box::pin(async { false })
+    }
+
+    fn answer<'a>(
+        &'a self,
+        _session_id: Uuid,
+        _transcript: String,
+        _progress_tx: mpsc::UnboundedSender<LlmProgress>,
+    ) -> TestBoxFuture<'a, anyhow::Result<String>> {
+        Box::pin(async { Ok("test answer".to_string()) })
+    }
+}

--- a/parakeet-ptt/src/main.rs
+++ b/parakeet-ptt/src/main.rs
@@ -1,6 +1,8 @@
 mod app;
 mod audio_feedback;
 mod client;
+#[cfg(test)]
+mod client_runtime_fixtures;
 mod client_session;
 mod config;
 mod hotkey;

--- a/parakeet-ptt/src/protocol.rs
+++ b/parakeet-ptt/src/protocol.rs
@@ -3,7 +3,7 @@ use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
 use uuid::Uuid;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 #[allow(clippy::enum_variant_names)] // Keep wire-level message names aligned with protocol spec.
 pub enum ClientMessage {


### PR DESCRIPTION
Fixes #79.

## Why

Client runtime tests still carried local inline fakes for Daemon connection, Hotkey source, LLM answerer, Overlay sink, and Injection runner behavior. This PR moves those Adapters into a test-only fixture Module so runtime tests read as orchestration checks instead of setup-heavy copies.

## What Changed

- Added `parakeet-ptt/src/client_runtime_fixtures.rs` under `#[cfg(test)]` from the binary crate.
- Added `ClientRuntimeHarness` for PTT-to-start-Session runtime setup.
- Added reusable `RecordingInjectionRunner` and `RecordingOverlaySink` test Adapters.
- Added a narrow `#[cfg(test)]` `HotkeyRuntime::new_for_tests` constructor so fixtures can build a Hotkey source without exposing runtime fields.
- Updated `app_hotkey_press_sends_start_session_message` to use the shared runtime harness and assert the start path emits no Injection or Overlay events before a Daemon response.
- Derived `Clone` for `ClientMessage` so the test Daemon Adapter can forward messages without a JSON roundtrip.
- Closed persisted temporary script handles before chmod/exec in the test helper, removing repeated `Text file busy` full-suite flakes observed during validation.

## Interface Decision

Full `lib.rs` promotion is deferred. The fixtures only need binary-crate internals today, so exposing Client runtime Modules through the library would widen the public crate shape without improving #79. The new fixture Module is compiled only for tests and does not add broad public crate exports.

## Compatibility

- No user-facing behavior change intended.
- No new production runtime path.
- No broad public crate or `lib.rs` exports were added.
- Remaining inline `app.rs` tests stay focused on Client orchestration, CLI defaults, Injection worker behavior, and helper policy cases that still live in the runtime Module.

## Verification (#79)

- targeted: `cargo test app_hotkey_press_sends_start_session_message --manifest-path parakeet-ptt/Cargo.toml` -> PASSED
- targeted: `cargo test app_injection_report_error_routes_failure_classification --manifest-path parakeet-ptt/Cargo.toml` -> PASSED
- targeted: `cargo test injector_worker_preserves_fifo_order --manifest-path parakeet-ptt/Cargo.toml` -> PASSED
- targeted: `cargo test injector_subprocess_runner_does_not_wait_for_background_grandchild_stderr_close --manifest-path parakeet-ptt/Cargo.toml` -> PASSED
- regression: N/A, test-only refactor with existing behavior assertions preserved
- full suite: `cargo test --manifest-path parakeet-ptt/Cargo.toml` -> PASSED
- lint: `cargo clippy --manifest-path parakeet-ptt/Cargo.toml --all-targets --all-features -- -D warnings` -> PASSED
- types: `cargo check --manifest-path parakeet-ptt/Cargo.toml --all-targets --all-features` -> PASSED
- dead-code: N/A, no repo dead-code gate for Rust discovered
- build: `cargo build --manifest-path parakeet-ptt/Cargo.toml --bins` -> PASSED
- format: `cargo fmt --manifest-path parakeet-ptt/Cargo.toml -- --check` -> PASSED
- pre-commit: `prek run --files parakeet-ptt/src/app.rs parakeet-ptt/src/main.rs parakeet-ptt/src/client_runtime_fixtures.rs parakeet-ptt/src/protocol.rs` -> PASSED
- pre-commit: `prek run --stage pre-push --files parakeet-ptt/src/app.rs parakeet-ptt/src/main.rs parakeet-ptt/src/client_runtime_fixtures.rs parakeet-ptt/src/protocol.rs` -> PASSED
- pre-commit: `prek run --all-files` -> PASSED
- pre-commit: `prek run --stage pre-push --all-files` -> PASSED
- static/security: N/A, no touched security/migration/workflow surface
- migrations: N/A
- CLI/script smoke: N/A
- UI render: N/A
- destructive/negative: N/A
- review: initial `coderabbit_review_watch.py local --fallback-codex-review-args "--base main" -- --base main` -> clean, CodeRabbit backend, `.git/coderabbit-review/20260519T121301Z/status.json`
- review: `coderabbit_review_watch.py gate --pr 82` initially found 2 local findings, both fixed in `a4c7e0f`
- PR gate: `coderabbit_review_watch.py gate --pr 82` -> clean, CodeRabbit backend, `.git/coderabbit-review/20260519T122712Z/gate-summary.json`
- tests added/expanded: existing runtime test now uses shared fixtures and asserts no pre-response Injection/Overlay events
- preexisting failures left: none

## Review Triage

- MUST_FIX: expose Injection and Overlay observers from the runtime harness instead of discarding them. Fixed in `a4c7e0f`.
- MUST_FIX: replace the test Daemon Adapter JSON roundtrip with `ClientMessage::clone()`. Fixed in `a4c7e0f`.
- CodeRabbit PR gate after fixes: clean; no actionable line comments, review threads, or top-level PR findings remain.
- IGNORE: CodeRabbit pre-merge docstring coverage warning. This repo has no docstring coverage gate, the Rust checks (`fmt`, `check`, `clippy -D warnings`, full `cargo test`, `prek`) pass, and adding broad docstrings would not improve the #79 test-fixture acceptance criteria.
- DEFER: none.

## Deferred Follow-Ups

None for this issue.
