### PR TITLE
chore(harness): add code-shape audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,9 +210,10 @@ Hook stages are split for speed:
 Maintenance audits (warned every 10 commits, non-blocking):
 ```bash
 scripts/harness-maintenance.sh check --threshold 10
+scripts/harness-maintenance.sh code-shape
 scripts/harness-maintenance.sh run
 ```
-`run` executes `deptry` and `cargo +nightly udeps`; install `cargo-udeps` first with `cargo install cargo-udeps`.
+`code-shape` reports oversized/mixed-responsibility surfaces and exits 0. `run` executes the warn-only code-shape audit, `deptry`, and `cargo +nightly udeps`; install `cargo-udeps` first with `cargo install cargo-udeps`.
 
 Manual injector validation:
 ```bash

--- a/docs/engineering/harness-engineering-playbook.md
+++ b/docs/engineering/harness-engineering-playbook.md
@@ -1,6 +1,6 @@
 # Harness Engineering Playbook
 
-_Last updated: 2026-02-27_
+_Last updated: 2026-05-19_
 
 ## Purpose
 
@@ -52,6 +52,19 @@ From "Harness engineering: leveraging Codex in an agent-first world" (OpenAI, 20
 - Dead code: Clippy in pre-push (`-D warnings`).
 - Dependency bloat: `cargo-udeps` in maintenance audits (not on every push).
 
+### Code-shape audit
+
+- `scripts/harness-maintenance.sh code-shape` reports oversized/mixed-responsibility risk surfaces.
+- The audit is warn-only: findings guide follow-up issue planning and do not fail the maintenance run.
+- Each finding includes file, LOC, category, threshold, and suggested owner/action.
+- Categories and current thresholds:
+  - `production-rust`: 900 LOC.
+  - `production-python`: 700 LOC.
+  - `shell`: 800 LOC.
+  - `tests`: 700 LOC.
+- Excluded paths: `.git/`, virtualenvs such as `.venv/` and `venv/`, `target/`, `node_modules/`, Python/Rust/tool caches such as `__pycache__/`, `.ruff_cache/`, `.pytest_cache/`, `.mypy_cache/`, `.ty/`, `.cache/`, vendor directories, and `docs/archive/`.
+- Actions are intentionally architectural rather than mechanical: apply the deletion test, deepen Module/Interface seams, improve Locality and test setup, and avoid arbitrary file splitting.
+
 ### Vulture policy
 
 - Vulture is one-off cleanup tooling only (not persistent in hooks).
@@ -65,6 +78,8 @@ From "Harness engineering: leveraging Codex in an agent-first world" (OpenAI, 20
 - Hook reminder: pre-commit runs `scripts/harness-maintenance.sh check --threshold 10`.
 - Full audit command:
   - `scripts/harness-maintenance.sh run`
+- Code-shape-only report:
+  - `scripts/harness-maintenance.sh code-shape`
 - State marker:
   - `.git/harness-maintenance.state` (local-only, untracked)
 
@@ -84,6 +99,7 @@ cargo +nightly udeps --manifest-path parakeet-ptt/Cargo.toml --all-targets
 
 # Maintenance loop
 scripts/harness-maintenance.sh check --threshold 10
+scripts/harness-maintenance.sh code-shape
 scripts/harness-maintenance.sh run
 scripts/harness-maintenance.sh mark
 ```

--- a/scripts/harness-maintenance.sh
+++ b/scripts/harness-maintenance.sh
@@ -12,12 +12,15 @@ usage() {
     cat <<'EOF'
 Usage:
   scripts/harness-maintenance.sh check [--threshold N]
+  scripts/harness-maintenance.sh code-shape
   scripts/harness-maintenance.sh run
   scripts/harness-maintenance.sh mark
 
 Commands:
   check     Warn when maintenance audits are due (non-blocking, exits 0).
-  run       Run maintenance audits (deptry + cargo-udeps), then record current HEAD.
+  code-shape
+            Report oversized/mixed-responsibility surfaces (warn-only).
+  run       Run maintenance audits (code-shape + deptry + cargo-udeps), then record current HEAD.
   mark      Record current HEAD as audited without running checks.
 EOF
 }
@@ -79,8 +82,139 @@ parse_threshold_arg() {
     printf '%s\n' "${threshold}"
 }
 
+code_shape_find_files() {
+    find "${REPO_ROOT}" \
+        \( \
+            -type d \( \
+                -name ".git" -o \
+                -name ".venv" -o \
+                -name "venv" -o \
+                -name "target" -o \
+                -name ".ruff_cache" -o \
+                -name ".pytest_cache" -o \
+                -name ".mypy_cache" -o \
+                -name ".ty" -o \
+                -name "node_modules" -o \
+                -name "__pycache__" -o \
+                -name ".cache" -o \
+                -name "vendor" \
+            \) -o \
+            -path "${REPO_ROOT}/docs/archive" \
+        \) -prune -o \
+        -type f \( -name "*.rs" -o -name "*.py" -o -name "*.sh" \) -print
+}
+
+code_shape_category() {
+    local relative_path="$1"
+
+    case "${relative_path}" in
+        */tests/*|tests/*|test_*.py|*_test.py|*_test.rs|*/test_*.py)
+            printf '%s|%s\n' "tests" "700"
+            ;;
+        scripts/*.sh)
+            printf '%s|%s\n' "shell" "800"
+            ;;
+        parakeet-ptt/src/*.rs)
+            printf '%s|%s\n' "production-rust" "900"
+            ;;
+        parakeet-stt-daemon/src/*.py|parakeet-stt-daemon/check_model.py|parakeet-stt-daemon/check_model_lib/*.py|parakeet-stt-daemon/scripts/*.py)
+            printf '%s|%s\n' "production-python" "700"
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+code_shape_action() {
+    local relative_path="$1"
+    local category="$2"
+
+    case "${relative_path}" in
+        parakeet-ptt/src/app.rs)
+            echo "Client runtime owner: keep extracting deep Session/Overlay/Injection policy Modules with focused tests."
+            ;;
+        parakeet-ptt/src/overlay_renderer.rs)
+            echo "Overlay owner: prefer pure/data-only layout, glyph, animation, or frame-math extractions before Wayland runtime work."
+            ;;
+        parakeet-ptt/src/injector.rs|parakeet-ptt/src/injector_runtime.rs)
+            echo "Injection owner: isolate report, telemetry, subprocess, uinput, or route policy seams without changing #26 timeout policy."
+            ;;
+        scripts/stt-helper.sh)
+            echo "Helper owner: validate source-of-truth rows and env wiring before any split."
+            ;;
+        parakeet-stt-daemon/src/parakeet_stt_daemon/session_orchestrator.py)
+            echo "Daemon owner: extract finalization or Runtime truth seams only when tests need narrower setup."
+            ;;
+        *)
+            case "${category}" in
+                production-rust)
+                    echo "Rust owner: apply the deletion test; deepen Module/Interface seams before splitting by LOC."
+                    ;;
+                production-python)
+                    echo "Python owner: extract cohesive policy seams only when they improve Locality or test setup."
+                    ;;
+                shell)
+                    echo "Shell owner: audit validation/source-of-truth boundaries before splitting functions."
+                    ;;
+                tests)
+                    echo "Test owner: move reusable fixtures/helpers out before splitting scenario coverage."
+                    ;;
+                *)
+                    echo "Owner: inspect for mixed responsibilities and add a focused follow-up before refactoring."
+                    ;;
+            esac
+            ;;
+    esac
+}
+
+code_shape_findings() {
+    local file
+    while IFS= read -r file; do
+        local relative_path="${file#"${REPO_ROOT}/"}"
+        local category_line
+        if ! category_line="$(code_shape_category "${relative_path}")"; then
+            continue
+        fi
+
+        local category
+        local threshold
+        IFS="|" read -r category threshold <<<"${category_line}"
+
+        local loc
+        loc="$(wc -l <"${file}")"
+        loc="${loc//[[:space:]]/}"
+        if (( loc < threshold )); then
+            continue
+        fi
+
+        local action
+        action="$(code_shape_action "${relative_path}" "${category}")"
+        printf '%s\t%s\t%s\t%s\t%s\n' "${category}" "${loc}" "${threshold}" "${relative_path}" "${action}"
+    done < <(code_shape_find_files)
+}
+
+run_code_shape_audit() {
+    echo "Running code-shape audit (warn-only)..."
+    echo "Category | LOC | Threshold | File | Suggested owner/action"
+    echo "--- | ---: | ---: | --- | ---"
+
+    local finding_count=0
+    while IFS=$'\t' read -r category loc threshold relative_path action; do
+        printf '%s | %s | %s | %s | %s\n' "${category}" "${loc}" "${threshold}" "${relative_path}" "${action}"
+        finding_count=$((finding_count + 1))
+    done < <(code_shape_findings | sort -t $'\t' -k1,1 -k2,2nr -k4,4)
+
+    if (( finding_count == 0 )); then
+        echo "No code-shape findings exceeded current warn-only thresholds."
+    fi
+
+    log_line "code-shape audit completed: findings=${finding_count}"
+}
+
 run_checks() {
     echo "Running harness maintenance audits..."
+    run_code_shape_audit
     (
         cd "${REPO_ROOT}/parakeet-stt-daemon"
         uv run deptry .
@@ -135,6 +269,13 @@ main() {
             local threshold
             threshold="$(parse_threshold_arg "$@")"
             check_due "${threshold}"
+            ;;
+        code-shape)
+            if [[ $# -gt 0 ]]; then
+                echo "Unexpected arguments for 'code-shape': $*" >&2
+                exit 2
+            fi
+            run_code_shape_audit
             ;;
         run)
             if [[ $# -gt 0 ]]; then


### PR DESCRIPTION
## Summary

Closes #1.

- Adds `scripts/harness-maintenance.sh code-shape` as a warn-only audit for oversized/mixed-responsibility surfaces.
- Wires the audit into the existing `scripts/harness-maintenance.sh run` flow before deptry/cargo-udeps.
- Reports file, LOC, category, threshold, and suggested owner/action for production Rust, production Python, shell, and tests.
- Documents thresholds, exclusions, and warn-only owner/action guidance in the harness playbook and README.

## Compatibility

No runtime behavior changes. The existing maintenance cadence check remains non-blocking, and code-shape findings are warnings for agent planning rather than gates.

## Verification (#1)

- targeted: `scripts/harness-maintenance.sh code-shape` -> PASSED
- regression: N/A (new warn-only audit guardrail, not a bug fix)
- full suite: `prek run --all-files` -> PASSED; `prek run --stage pre-push --all-files` -> PASSED
- lint: `bash -n scripts/harness-maintenance.sh` -> PASSED; `shellcheck scripts/harness-maintenance.sh` -> PASSED
- types: `prek run --all-files` -> PASSED (ty check)
- dead-code: N/A (no Rust/Python dependency surface changed)
- build: N/A (script/docs only)
- pre-commit: `prek run --files scripts/harness-maintenance.sh docs/engineering/harness-engineering-playbook.md README.md` -> PASSED; `prek run --stage pre-push --files scripts/harness-maintenance.sh docs/engineering/harness-engineering-playbook.md README.md` -> PASSED
- static/security: `shellcheck scripts/harness-maintenance.sh` -> PASSED
- migrations: N/A
- CLI/script smoke: `scripts/harness-maintenance.sh --help` -> PASSED; `scripts/harness-maintenance.sh check --threshold 10` -> PASSED; `scripts/harness-maintenance.sh code-shape --bad` -> PASSED (exit 2)
- UI render: N/A
- destructive/negative: `scripts/harness-maintenance.sh code-shape --bad` -> PASSED (exit 2)
- review: CodeRabbit local watcher -> clean, `.git/coderabbit-review/20260519T144239Z/status.json`
- tests added/expanded: none - shell command smoke covers the new audit surface
- preexisting failures left: none

## CodeRabbit

Local watcher completed with zero findings before commit: `.git/coderabbit-review/20260519T144239Z/status.json`.

PR-side CodeRabbit gate will be run before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a code-shape audit command that identifies code surface quality issues, including oversized modules and mixed-responsibility components. Results are warn-only and non-blocking.

* **Documentation**
  * Updated maintenance audit guides with documentation of the new code-shape audit step and its role in the maintenance command sequence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SystemicVoid/parakeet-stt/pull/83?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->