### PR TITLE
refactor(config): consolidate endpoint defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ PARAKEET_STREAMING_ENABLED=true uv run parakeet-stt-daemon
 
 # Terminal B
 cd parakeet-ptt
-cargo run --release -- --endpoint ws://127.0.0.1:8765/ws --overlay-enabled true
+cargo run --release -- --overlay-enabled true
 ```
-Use `PARAKEET_STREAMING_ENABLED=false` plus `--overlay-enabled false` to mirror `stt off`.
+The Client default endpoint matches the Daemon default; pass `--endpoint` only for a custom host/port. Use `PARAKEET_STREAMING_ENABLED=false` plus `--overlay-enabled false` to mirror `stt off`.
 
 ## Helper Profiles (`stt start` / `stt off`)
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -99,7 +99,7 @@ This document is the single source of truth for the local, push-to-talk Parakeet
   - Quick smoke (from any directory):
     - `repo=/path/to/parakeet-stt`
     - `(cd "$repo/parakeet-stt-daemon" && uv run parakeet-stt-daemon --check)`
-    - `(cd "$repo/parakeet-stt-daemon" && uv run parakeet-stt-daemon --host 127.0.0.1 --port 8765)`  # requires inference extra
+    - `(cd "$repo/parakeet-stt-daemon" && uv run parakeet-stt-daemon)`  # requires inference extra
     - In another shell: `(cd "$repo/parakeet-ptt" && cargo run --release)` (or `cargo run --manifest-path "$repo/parakeet-ptt/Cargo.toml" --release`)
     - Watch logs for `start_session`/`final_result`.
 

--- a/parakeet-ptt/src/app.rs
+++ b/parakeet-ptt/src/app.rs
@@ -1519,7 +1519,7 @@ mod tests {
             cli.llm_pre_modifier_key,
             crate::DEFAULT_LLM_PRE_MODIFIER_KEY
         );
-        assert_eq!(cli.llm_base_url, crate::DEFAULT_LLM_BASE_URL);
+        assert_eq!(cli.llm_base_url, crate::llm::default_llm_base_url());
         assert_eq!(cli.llm_model, crate::DEFAULT_LLM_MODEL);
         assert!(cli.llm_overlay_stream);
     }

--- a/parakeet-ptt/src/config.rs
+++ b/parakeet-ptt/src/config.rs
@@ -8,10 +8,26 @@ use url::Url;
 use wayland_client::protocol::wl_registry;
 use wayland_client::{Connection, Dispatch, QueueHandle};
 
-pub const DEFAULT_ENDPOINT: &str = "ws://127.0.0.1:8765/ws";
+pub(crate) const DEFAULT_DAEMON_HOST: &str = "127.0.0.1";
+pub(crate) const DEFAULT_DAEMON_PORT: u16 = 8765;
+const DAEMON_WS_PATH: &str = "/ws";
+const DAEMON_STATUS_PATH: &str = "/status";
 const OVERLAY_ENABLED_ENV: &str = "PARAKEET_OVERLAY_ENABLED";
 const OVERLAY_MODE_ENV: &str = "PARAKEET_OVERLAY_MODE";
 const OVERLAY_ADAPTIVE_WIDTH_ENV: &str = "PARAKEET_OVERLAY_ADAPTIVE_WIDTH";
+
+pub(crate) fn daemon_websocket_endpoint(host: &str, port: u16) -> String {
+    format!("ws://{host}:{port}{DAEMON_WS_PATH}")
+}
+
+pub(crate) fn default_daemon_websocket_endpoint() -> String {
+    daemon_websocket_endpoint(DEFAULT_DAEMON_HOST, DEFAULT_DAEMON_PORT)
+}
+
+#[cfg(test)]
+pub(crate) fn default_daemon_status_url() -> String {
+    format!("http://{DEFAULT_DAEMON_HOST}:{DEFAULT_DAEMON_PORT}{DAEMON_STATUS_PATH}")
+}
 
 #[derive(Clone, Debug, Copy, PartialEq, Eq)]
 pub enum OverlayMode {
@@ -342,8 +358,7 @@ impl ClientConfig {
             "http" | "https" => {}
             _ => return None,
         }
-        // Replace path with /status
-        url.set_path("/status");
+        url.set_path(DAEMON_STATUS_PATH);
         Some(url)
     }
 
@@ -369,8 +384,54 @@ mod tests {
     use super::{
         classify_overlay_capability, parse_overlay_enabled_override, parse_overlay_mode_override,
         resolve_overlay_adaptive_width_with_env, resolve_overlay_capability_with_inputs,
-        resolve_overlay_enable_gate, OverlayEnableGate, OverlayMode, OverlayProbeSignals,
+        resolve_overlay_enable_gate, ClientConfig, ClipboardOptions, InjectionConfig,
+        InjectionMode, OverlayEnableGate, OverlayMode, OverlayProbeSignals,
+        PasteBackendFailurePolicy, PasteKeyBackend,
     };
+    use std::time::Duration;
+
+    fn minimal_injection_config() -> InjectionConfig {
+        InjectionConfig {
+            uinput_dwell_ms: 18,
+            injection_mode: InjectionMode::Paste,
+            clipboard: ClipboardOptions {
+                key_backend: PasteKeyBackend::Uinput,
+                backend_failure_policy: PasteBackendFailurePolicy::CopyOnly,
+                post_chord_hold_ms: 700,
+                seat: None,
+                write_primary: false,
+            },
+        }
+    }
+
+    #[test]
+    fn daemon_endpoint_defaults_are_derived_from_named_parts() {
+        assert_eq!(
+            super::default_daemon_websocket_endpoint(),
+            "ws://127.0.0.1:8765/ws"
+        );
+        assert_eq!(
+            super::default_daemon_status_url(),
+            "http://127.0.0.1:8765/status"
+        );
+
+        let config = ClientConfig::new(
+            &super::default_daemon_websocket_endpoint(),
+            None,
+            "KEY_RIGHTCTRL".to_string(),
+            minimal_injection_config(),
+            Duration::from_secs(5),
+        )
+        .expect("default endpoint should parse");
+
+        assert_eq!(
+            config
+                .status_url()
+                .expect("default endpoint should have status URL")
+                .as_str(),
+            super::default_daemon_status_url()
+        );
+    }
 
     #[test]
     fn classify_overlay_prefers_layer_shell_when_available() {

--- a/parakeet-ptt/src/llm.rs
+++ b/parakeet-ptt/src/llm.rs
@@ -15,6 +15,12 @@ use serde_json::json;
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
+pub(crate) const DEFAULT_LLM_HOST: &str = "127.0.0.1";
+pub(crate) const DEFAULT_LLM_PORT: u16 = 8080;
+const LLM_API_PATH: &str = "/v1";
+#[cfg(test)]
+const MANAGED_LLM_HEALTH_PATH: &str = "/health";
+
 pub(crate) type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 #[allow(dead_code)]
 pub type LlmDeltaStream<'a> = BoxStream<'a, Result<LlmDelta>>;
@@ -134,6 +140,19 @@ pub enum LlmProgress {
 
 pub fn build_http_llm_answerer(config: LlmRuntimeConfig) -> Arc<dyn LlmAnswerer> {
     Arc::new(HttpLlmAnswerer::new(config))
+}
+
+pub(crate) fn llm_api_base_url(host: &str, port: u16) -> String {
+    format!("http://{host}:{port}{LLM_API_PATH}")
+}
+
+pub(crate) fn default_llm_base_url() -> String {
+    llm_api_base_url(DEFAULT_LLM_HOST, DEFAULT_LLM_PORT)
+}
+
+#[cfg(test)]
+pub(crate) fn default_managed_llm_health_url() -> String {
+    format!("http://{DEFAULT_LLM_HOST}:{DEFAULT_LLM_PORT}{MANAGED_LLM_HEALTH_PATH}")
 }
 
 fn receiver_delta_stream(
@@ -455,6 +474,15 @@ mod tests {
                 .expect("health URL should build")
                 .as_str(),
             "http://127.0.0.1:8080/api/v1/health"
+        );
+    }
+
+    #[test]
+    fn managed_llm_endpoint_defaults_are_derived_from_named_parts() {
+        assert_eq!(default_llm_base_url(), "http://127.0.0.1:8080/v1");
+        assert_eq!(
+            default_managed_llm_health_url(),
+            "http://127.0.0.1:8080/health"
         );
     }
 

--- a/parakeet-ptt/src/main.rs
+++ b/parakeet-ptt/src/main.rs
@@ -28,15 +28,14 @@ use tracing_subscriber::EnvFilter;
 
 use crate::audio_feedback::AudioFeedback;
 use crate::config::{
-    resolve_overlay_adaptive_width, resolve_overlay_capability, ClientConfig, ClipboardOptions,
-    InjectionConfig, OverlayMode, DEFAULT_ENDPOINT,
+    default_daemon_websocket_endpoint, resolve_overlay_adaptive_width, resolve_overlay_capability,
+    ClientConfig, ClipboardOptions, InjectionConfig, OverlayMode,
 };
 use crate::injector::{InjectorContext, INJECTOR_CONTEXT_ENV};
 use crate::surface_focus::WaylandFocusCache;
 use parakeet_ptt::overlay_renderer::INTERNAL_OVERLAY_MODE_ARG;
 
 const DEFAULT_LLM_PRE_MODIFIER_KEY: &str = "KEY_SHIFT";
-const DEFAULT_LLM_BASE_URL: &str = "http://127.0.0.1:8080/v1";
 const DEFAULT_LLM_MODEL: &str = "local";
 const DEFAULT_LLM_SYSTEM_PROMPT: &str =
     "You are a concise assistant. Return only the final answer text for direct insertion.";
@@ -49,7 +48,7 @@ const DEFAULT_LLM_SYSTEM_PROMPT: &str =
 )]
 struct Cli {
     /// WebSocket endpoint exposed by parakeet-stt-daemon
-    #[arg(long, default_value = DEFAULT_ENDPOINT)]
+    #[arg(long, default_value_t = default_daemon_websocket_endpoint())]
     endpoint: String,
 
     /// Optional shared secret to send as x-parakeet-secret
@@ -149,7 +148,7 @@ struct Cli {
     overlay_adaptive_width: Option<bool>,
 
     /// Base URL for llama-server OpenAI-compatible API.
-    #[arg(long, default_value = DEFAULT_LLM_BASE_URL)]
+    #[arg(long, default_value_t = llm::default_llm_base_url())]
     llm_base_url: String,
 
     /// Model name passed to llama-server.
@@ -426,4 +425,77 @@ async fn run_client_app(
 fn init_tracing() {
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
     let _ = tracing_subscriber::fmt().with_env_filter(filter).try_init();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+    use std::process::Command;
+
+    fn helper_runtime_config() -> BTreeMap<String, String> {
+        let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("manifest dir should have repo parent");
+        let helper_path = repo_root.join("scripts/stt-helper.sh");
+        let mut command = Command::new("bash");
+        command
+            .arg("-lc")
+            .arg("source \"$1\" && stt __start-runtime-config")
+            .arg("bash")
+            .arg(helper_path)
+            .current_dir(repo_root)
+            .env_clear()
+            .env("PATH", std::env::var("PATH").unwrap_or_default())
+            .env("HOME", std::env::var("HOME").unwrap_or_default())
+            .env("PARAKEET_ROOT", repo_root)
+            .env("_STT_SKIP_LOCAL_OVERRIDES", "1");
+
+        let output = command
+            .output()
+            .expect("helper runtime config command should run");
+        assert!(
+            output.status.success(),
+            "helper runtime config failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        String::from_utf8(output.stdout)
+            .expect("helper output should be UTF-8")
+            .lines()
+            .map(|line| {
+                let (key, value) = line
+                    .split_once('=')
+                    .expect("helper runtime config lines should be key=value");
+                (key.to_string(), value.to_string())
+            })
+            .collect()
+    }
+
+    #[test]
+    fn client_endpoint_defaults_match_helper_runtime_config() {
+        let cli = Cli::try_parse_from(["parakeet-ptt"]).expect("default CLI should parse");
+        let helper = helper_runtime_config();
+        let default_status_url = crate::config::default_daemon_status_url();
+        let default_llm_health_url = llm::default_managed_llm_health_url();
+
+        assert_eq!(cli.endpoint, default_daemon_websocket_endpoint());
+        assert_eq!(
+            helper.get("daemon_websocket_endpoint").map(String::as_str),
+            Some(cli.endpoint.as_str())
+        );
+        assert_eq!(
+            helper.get("daemon_status_url").map(String::as_str),
+            Some(default_status_url.as_str())
+        );
+        assert_eq!(cli.llm_base_url, llm::default_llm_base_url());
+        assert_eq!(
+            helper.get("llm_base_url").map(String::as_str),
+            Some(cli.llm_base_url.as_str())
+        );
+        assert_eq!(
+            helper.get("llm_health_url").map(String::as_str),
+            Some(default_llm_health_url.as_str())
+        );
+    }
 }

--- a/parakeet-stt-daemon/README.md
+++ b/parakeet-stt-daemon/README.md
@@ -2,9 +2,9 @@
 
 Canonical usage and commands live in the top-level `README.md`. Use this file only for daemon-specific notes.
 
-- Run the server for default online profile parity (`stt` / `stt start`): `PARAKEET_STREAMING_ENABLED=true uv run parakeet-stt-daemon --host 127.0.0.1 --port 8765`
-- Run the server for offline profile parity (`stt off`): `PARAKEET_STREAMING_ENABLED=false uv run parakeet-stt-daemon --host 127.0.0.1 --port 8765`
-- Enable neural tail trim explicitly: `PARAKEET_VAD_ENABLED=true uv run parakeet-stt-daemon --host 127.0.0.1 --port 8765`
+- Run the server for default online profile parity (`stt` / `stt start`): `PARAKEET_STREAMING_ENABLED=true uv run parakeet-stt-daemon`
+- Run the server for offline profile parity (`stt off`): `PARAKEET_STREAMING_ENABLED=false uv run parakeet-stt-daemon`
+- Enable neural tail trim explicitly: `PARAKEET_VAD_ENABLED=true uv run parakeet-stt-daemon`
 - Install deps: `uv sync --dev` (add `--extra inference --prerelease allow --index https://download.pytorch.org/whl/nightly/cu130 --index-strategy unsafe-best-match` for GPU inference)
 - Offline benchmark harness (legacy transcripts mode): `uv run python check_model.py --bench-offline --bench-output bench_audio/latest-benchmark.json --max-avg-wer 0.45 --max-p95-infer-ms 1800 --max-p95-finalize-ms 2200`
 - Local eval tooling (git-ignored corpus): use repo-root `just eval` for run/compare/calibrate on the existing unified corpus (`just eval`, `just eval offline`, `just eval stream`, `just eval compare`, `just eval calibrate-offline`, `just eval calibrate-stream`). Use `just eval-dataset ...` only when intentionally refreshing prompts/audio. Recorder defaults remain `bench_audio/personal/manifest.jsonl` -> `bench_audio/personal/audio` with key controls `s`, `r`, `n/p`, `q`.

--- a/parakeet-stt-daemon/src/parakeet_stt_daemon/config.py
+++ b/parakeet-stt-daemon/src/parakeet_stt_daemon/config.py
@@ -8,12 +8,33 @@ from typing import Literal
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+DEFAULT_DAEMON_HOST = "127.0.0.1"
+DEFAULT_DAEMON_PORT = 8765
+DAEMON_WS_PATH = "/ws"
+DAEMON_STATUS_PATH = "/status"
+
+
+def daemon_websocket_endpoint(
+    host: str = DEFAULT_DAEMON_HOST, port: int = DEFAULT_DAEMON_PORT
+) -> str:
+    """Return the Client WebSocket endpoint for a Daemon host/port pair."""
+
+    return f"ws://{host}:{port}{DAEMON_WS_PATH}"
+
+
+def daemon_status_url(host: str = DEFAULT_DAEMON_HOST, port: int = DEFAULT_DAEMON_PORT) -> str:
+    """Return the Daemon status endpoint for a host/port pair."""
+
+    return f"http://{host}:{port}{DAEMON_STATUS_PATH}"
+
 
 class ServerSettings(BaseSettings):
     """Runtime settings loaded from env vars or CLI overrides."""
 
-    host: str = Field(default="127.0.0.1", description="Host the WebSocket/HTTP server binds to")
-    port: int = Field(default=8765, ge=1, le=65535)
+    host: str = Field(
+        default=DEFAULT_DAEMON_HOST, description="Host the WebSocket/HTTP server binds to"
+    )
+    port: int = Field(default=DEFAULT_DAEMON_PORT, ge=1, le=65535)
     shared_secret: str | None = Field(
         default=None,
         description="Optional shared secret required on the WebSocket connection.",
@@ -96,4 +117,12 @@ class ServerSettings(BaseSettings):
     )
 
 
-__all__ = ["ServerSettings"]
+__all__ = [
+    "DAEMON_STATUS_PATH",
+    "DAEMON_WS_PATH",
+    "DEFAULT_DAEMON_HOST",
+    "DEFAULT_DAEMON_PORT",
+    "ServerSettings",
+    "daemon_status_url",
+    "daemon_websocket_endpoint",
+]

--- a/parakeet-stt-daemon/tests/test_cli_precedence.py
+++ b/parakeet-stt-daemon/tests/test_cli_precedence.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from parakeet_stt_daemon.__main__ import _build_settings, _parse_args
+from parakeet_stt_daemon.config import DEFAULT_DAEMON_HOST, DEFAULT_DAEMON_PORT
 
 
 def test_parse_args_boolean_flags_default_to_none() -> None:
@@ -13,12 +14,16 @@ def test_parse_args_boolean_flags_default_to_none() -> None:
 
 
 def test_env_values_apply_when_cli_flags_absent(monkeypatch) -> None:
+    monkeypatch.setenv("PARAKEET_HOST", "0.0.0.0")
+    monkeypatch.setenv("PARAKEET_PORT", "9876")
     monkeypatch.setenv("PARAKEET_STATUS_ENABLED", "false")
     monkeypatch.setenv("PARAKEET_STREAMING_ENABLED", "true")
     monkeypatch.setenv("PARAKEET_OVERLAY_EVENTS_ENABLED", "true")
 
     settings = _build_settings(_parse_args([]))
 
+    assert settings.host == "0.0.0.0"
+    assert settings.port == 9876
     assert settings.status_enabled is False
     assert settings.streaming_enabled is True
     assert settings.overlay_events_enabled is True
@@ -46,13 +51,27 @@ def test_unrelated_cli_args_do_not_override_env_booleans(monkeypatch) -> None:
     assert settings.streaming_enabled is False
 
 
+def test_cli_host_port_override_env(monkeypatch) -> None:
+    monkeypatch.setenv("PARAKEET_HOST", "0.0.0.0")
+    monkeypatch.setenv("PARAKEET_PORT", "7000")
+
+    settings = _build_settings(_parse_args(["--host", "127.0.0.2", "--port", "9001"]))
+
+    assert settings.host == "127.0.0.2"
+    assert settings.port == 9001
+
+
 def test_defaults_apply_without_env_or_cli(monkeypatch) -> None:
+    monkeypatch.delenv("PARAKEET_HOST", raising=False)
+    monkeypatch.delenv("PARAKEET_PORT", raising=False)
     monkeypatch.delenv("PARAKEET_STATUS_ENABLED", raising=False)
     monkeypatch.delenv("PARAKEET_STREAMING_ENABLED", raising=False)
     monkeypatch.delenv("PARAKEET_OVERLAY_EVENTS_ENABLED", raising=False)
 
     settings = _build_settings(_parse_args([]))
 
+    assert settings.host == DEFAULT_DAEMON_HOST
+    assert settings.port == DEFAULT_DAEMON_PORT
     assert settings.status_enabled is True
     assert settings.streaming_enabled is False
     assert settings.overlay_events_enabled is False

--- a/parakeet-stt-daemon/tests/test_stt_helper_runtime_profiles.py
+++ b/parakeet-stt-daemon/tests/test_stt_helper_runtime_profiles.py
@@ -10,6 +10,13 @@ from pathlib import Path
 
 import pytest
 
+from parakeet_stt_daemon.config import (
+    DEFAULT_DAEMON_HOST,
+    DEFAULT_DAEMON_PORT,
+    daemon_status_url,
+    daemon_websocket_endpoint,
+)
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 HELPER_PATH = REPO_ROOT / "scripts" / "stt-helper.sh"
 
@@ -137,6 +144,48 @@ def test_offline_profile_resolves_cuda_without_streaming() -> None:
     assert config["daemon_device"] == "cuda"
     assert config["daemon_streaming_enabled"] == "false"
     assert config["daemon_overlay_events_enabled"] == "false"
+
+
+def test_helper_endpoint_defaults_match_daemon_settings() -> None:
+    config = _run_runtime_config()
+
+    assert config["daemon_host"] == DEFAULT_DAEMON_HOST
+    assert config["daemon_port"] == str(DEFAULT_DAEMON_PORT)
+    assert config["daemon_websocket_endpoint"] == daemon_websocket_endpoint()
+    assert config["daemon_status_url"] == daemon_status_url()
+    assert config["llm_base_url"] == "http://127.0.0.1:8080/v1"
+    assert config["managed_llm_api_base_url"] == "http://127.0.0.1:8080/v1"
+    assert config["llm_health_url"] == "http://127.0.0.1:8080/health"
+
+
+def test_helper_endpoint_env_overrides_resolve_consistently() -> None:
+    config = _run_runtime_config(
+        extra_env={
+            "PARAKEET_HOST": "0.0.0.0",
+            "PARAKEET_PORT": "9001",
+            "PARAKEET_LLM_SERVER_HOST": "llm.local",
+            "PARAKEET_LLM_SERVER_PORT": "8181",
+        }
+    )
+
+    assert config["daemon_host"] == "0.0.0.0"
+    assert config["daemon_port"] == "9001"
+    assert config["daemon_websocket_endpoint"] == daemon_websocket_endpoint("0.0.0.0", 9001)
+    assert config["daemon_status_url"] == daemon_status_url("0.0.0.0", 9001)
+    assert config["llm_base_url"] == "http://llm.local:8181/v1"
+    assert config["managed_llm_api_base_url"] == "http://llm.local:8181/v1"
+    assert config["llm_health_url"] == "http://llm.local:8181/health"
+
+
+def test_helper_start_cli_llm_base_url_overrides_env() -> None:
+    config = _run_runtime_config(
+        "--llm-base-url",
+        "http://cli.local:8182/custom",
+        extra_env={"PARAKEET_LLM_BASE_URL": "http://env.local:8181/v1"},
+    )
+
+    assert config["llm_base_url"] == "http://cli.local:8182/custom"
+    assert config["managed_llm_api_base_url"] == "http://127.0.0.1:8080/v1"
 
 
 def test_runtime_match_accepts_cpu_fallback_for_accelerator_request() -> None:

--- a/scripts/stt-helper.sh
+++ b/scripts/stt-helper.sh
@@ -67,9 +67,47 @@ stt() {
         fi
     fi
 
-    local HOST="${PARAKEET_HOST:-127.0.0.1}"
-    local PORT="${PARAKEET_PORT:-8765}"
-    local DEFAULT_ENDPOINT="ws://${HOST}:${PORT}/ws"
+    local DEFAULT_DAEMON_HOST="127.0.0.1"
+    local DEFAULT_DAEMON_PORT="8765"
+    local DAEMON_WS_PATH="/ws"
+    local DAEMON_STATUS_PATH="/status"
+    local DEFAULT_LLM_SERVER_HOST="127.0.0.1"
+    local DEFAULT_LLM_SERVER_PORT="8080"
+    local LLM_API_PATH="/v1"
+    local LLM_HEALTH_PATH="/health"
+
+    _endpoint_url() {
+        local scheme="$1"
+        local host="$2"
+        local port="$3"
+        local path="$4"
+        printf "%s://%s:%s%s" "$scheme" "$host" "$port" "$path"
+    }
+
+    _daemon_ws_endpoint() {
+        _endpoint_url "ws" "$HOST" "$PORT" "$DAEMON_WS_PATH"
+    }
+
+    _daemon_status_url() {
+        _endpoint_url "http" "$HOST" "$PORT" "$DAEMON_STATUS_PATH"
+    }
+
+    _daemon_ws_endpoint_from_authority() {
+        printf "ws://%s%s" "$1" "$DAEMON_WS_PATH"
+    }
+
+    _llm_api_base_url() {
+        _endpoint_url "http" "$default_llm_server_host" "$default_llm_server_port" "$LLM_API_PATH"
+    }
+
+    _llm_health_url() {
+        _endpoint_url "http" "$default_llm_server_host" "$default_llm_server_port" "$LLM_HEALTH_PATH"
+    }
+
+    local HOST="${PARAKEET_HOST:-$DEFAULT_DAEMON_HOST}"
+    local PORT="${PARAKEET_PORT:-$DEFAULT_DAEMON_PORT}"
+    local DEFAULT_ENDPOINT
+    DEFAULT_ENDPOINT="$(_daemon_ws_endpoint)"
     local default_injection_mode="${PARAKEET_INJECTION_MODE:-paste}"
     local default_paste_backend_failure_policy="${PARAKEET_PASTE_BACKEND_FAILURE_POLICY:-copy-only}"
     local default_uinput_dwell_ms="${PARAKEET_UINPUT_DWELL_MS:-18}"
@@ -81,8 +119,8 @@ stt() {
     local default_overlay_enabled="${PARAKEET_OVERLAY_ENABLED:-false}"
     local default_overlay_adaptive_width="${PARAKEET_OVERLAY_ADAPTIVE_WIDTH:-true}"
     local default_llm_pre_modifier_key="${PARAKEET_LLM_PRE_MODIFIER_KEY:-KEY_SHIFT}"
-    local default_llm_server_host="${PARAKEET_LLM_SERVER_HOST:-127.0.0.1}"
-    local default_llm_server_port="${PARAKEET_LLM_SERVER_PORT:-8080}"
+    local default_llm_server_host="${PARAKEET_LLM_SERVER_HOST:-$DEFAULT_LLM_SERVER_HOST}"
+    local default_llm_server_port="${PARAKEET_LLM_SERVER_PORT:-$DEFAULT_LLM_SERVER_PORT}"
     local default_llm_server_bin="${PARAKEET_LLM_SERVER_BIN:-llama-server}"
     local default_llm_server_model_path="${PARAKEET_LLM_SERVER_MODEL_PATH:-}"
     local default_llm_server_model_alias="${PARAKEET_LLM_SERVER_MODEL_ALIAS:-${PARAKEET_LLM_MODEL:-local}}"
@@ -91,7 +129,7 @@ stt() {
     local default_llm_server_parallel="${PARAKEET_LLM_SERVER_PARALLEL:-2}"
     local default_llm_server_metrics="${PARAKEET_LLM_SERVER_METRICS:-true}"
     local default_llm_server_extra_args="${PARAKEET_LLM_SERVER_EXTRA_ARGS:-}"
-    local default_llm_base_url="${PARAKEET_LLM_BASE_URL:-http://${default_llm_server_host}:${default_llm_server_port}/v1}"
+    local default_llm_base_url="${PARAKEET_LLM_BASE_URL:-$(_llm_api_base_url)}"
     local default_llm_model="${PARAKEET_LLM_MODEL:-$default_llm_server_model_alias}"
     local default_llm_timeout_seconds="${PARAKEET_LLM_TIMEOUT_SECONDS:-20}"
     local default_llm_max_tokens="${PARAKEET_LLM_MAX_TOKENS:-512}"
@@ -121,7 +159,7 @@ stt() {
         "overlay-enabled|overlay_enabled|default_overlay_enabled|PARAKEET_OVERLAY_ENABLED|Stable controls|<v>|false|always|false"
         "overlay-adaptive-width|overlay_adaptive_width|default_overlay_adaptive_width|PARAKEET_OVERLAY_ADAPTIVE_WIDTH|Stable controls|<v>|true|always|true"
         "llm-pre-modifier-key|llm_pre_modifier_key|default_llm_pre_modifier_key|PARAKEET_LLM_PRE_MODIFIER_KEY|Stable controls|<key>|KEY_SHIFT|always|KEY_SHIFT"
-        "llm-base-url|llm_base_url|default_llm_base_url|PARAKEET_LLM_BASE_URL|Stable controls|<url>|http://127.0.0.1:8080/v1|always|http://127.0.0.1:8080/v1"
+        "llm-base-url|llm_base_url|default_llm_base_url|PARAKEET_LLM_BASE_URL|Stable controls|<url>|<managed LLM API base URL>|always|derived"
         "llm-model|llm_model|default_llm_model|PARAKEET_LLM_MODEL|Stable controls|<name>|local|always|local"
         "llm-timeout-seconds|llm_timeout_seconds|default_llm_timeout_seconds|PARAKEET_LLM_TIMEOUT_SECONDS|Stable controls|<n>|20|always|20"
         "llm-max-tokens|llm_max_tokens|default_llm_max_tokens|PARAKEET_LLM_MAX_TOKENS|Stable controls|<n>|512|always|512"
@@ -825,14 +863,6 @@ PY
         fi
     }
 
-    _llm_health_url() {
-        printf "http://%s:%s/health" "$default_llm_server_host" "$default_llm_server_port"
-    }
-
-    _llm_api_base_url() {
-        printf "http://%s:%s/v1" "$default_llm_server_host" "$default_llm_server_port"
-    }
-
     _build_llm_server_args() {
         local -n out_ref="$1"
         out_ref=("$default_llm_server_bin")
@@ -997,7 +1027,7 @@ PY
             echo "   - Port $PORT busy (owner: $owner); switching to $next_port."
             PORT="$next_port"
         fi
-        DEFAULT_ENDPOINT="ws://${HOST}:${PORT}/ws"
+        DEFAULT_ENDPOINT="$(_daemon_ws_endpoint)"
         export PARAKEET_HOST="$HOST"
         export PARAKEET_PORT="$PORT"
         return 0
@@ -1233,6 +1263,13 @@ daemon_chunk_secs=$daemon_chunk_secs
 daemon_right_context_secs=$daemon_right_context_secs
 daemon_left_context_secs=$daemon_left_context_secs
 daemon_batch_size=$daemon_batch_size
+daemon_host=$HOST
+daemon_port=$PORT
+daemon_websocket_endpoint=$(_daemon_ws_endpoint)
+daemon_status_url=$(_daemon_status_url)
+llm_base_url=$llm_base_url
+managed_llm_api_base_url=$(_llm_api_base_url)
+llm_health_url=$(_llm_health_url)
 EOF
             ;;
         __daemon-runtime-matches)
@@ -1320,7 +1357,8 @@ EOF
             fi
 
             local daemon_reused=0
-            local daemon_status_url="http://${HOST}:${PORT}/status"
+            local daemon_status_url
+            daemon_status_url="$(_daemon_status_url)"
             if _socket_ready_once; then
                 local current_device=""
                 local current_effective_device=""
@@ -1637,7 +1675,7 @@ EOF
                 echo "   - Client not running"
             fi
             if [ -f "$PORT_FILE" ]; then
-                echo "   - Endpoint: ws://$(cat "$PORT_FILE")/ws"
+                echo "   - Endpoint: $(_daemon_ws_endpoint_from_authority "$(cat "$PORT_FILE")")"
             else
                 echo "   - Endpoint: $DEFAULT_ENDPOINT"
             fi


### PR DESCRIPTION
## Summary

Closes #30.

- Consolidates Daemon WebSocket/status and managed local LLM API/health endpoint construction through named Helper, Client, and Daemon helpers while keeping the existing defaults.
- Adds conformance coverage tying Helper runtime output to Daemon settings and Client defaults, including env/CLI precedence checks.
- Removes duplicate manual endpoint flags from docs where component defaults already apply.

## Compatibility

No default host, port, path, Profile, startup, Overlay, Injection, or local LLM server policy changes. Env/CLI precedence remains `CLI explicit > ENV > defaults`.

## Verification (#30)

- targeted: `uv run pytest -q tests/test_cli_precedence.py tests/test_stt_helper_runtime_profiles.py` (from `parakeet-stt-daemon/`) -> PASSED; `cargo test endpoint_defaults` -> PASSED; `cargo test llm_endpoint_urls_preserve_configured_base_path` -> PASSED
- regression: N/A - refactor/conformance issue, not a bug-fix reproduction; new conformance tests pin endpoint agreement.
- full suite: `prek run --stage pre-push --all-files` -> PASSED (python pytest, rust cargo clippy, rust cargo test); `uv run --project parakeet-stt-daemon pytest -q` -> PASSED (159 passed)
- lint: `prek run --files <touched files>` -> PASSED after Ruff import-order fix; `prek run --all-files` -> PASSED
- types: `ty` via `prek run --all-files` -> PASSED; `cargo clippy --manifest-path parakeet-ptt/Cargo.toml --all-targets --all-features -- -D warnings` -> PASSED
- dead-code: N/A - no repo dead-code gate configured for these touched surfaces.
- build: `cargo build --bins` (from `parakeet-ptt/`) -> PASSED; Python package build N/A
- pre-commit: `prek run --files <touched files>` -> PASSED; `prek run --all-files` -> PASSED
- static/security: `shellcheck scripts/stt-helper.sh` -> FAILED with preexisting dynamic-helper warnings; `git show origin/main:scripts/stt-helper.sh | shellcheck -` fails with the same warning classes (`SC1090`, `SC2034`, `SC2178`, `SC2317`, `SC2016`). `bash -n scripts/stt-helper.sh` -> PASSED.
- migrations: N/A
- CLI/script smoke: `bash -lc 'source scripts/stt-helper.sh && stt help start >/tmp/parakeet-issue30-help-start.txt && stt help llm >/tmp/parakeet-issue30-help-llm.txt && stt __start-runtime-config >/tmp/parakeet-issue30-runtime-config.txt && stt __start-args >/tmp/parakeet-issue30-start-args.txt'` -> PASSED
- UI render: N/A
- destructive/negative: N/A - no destructive operations, auth, or schema changes.
- review: CodeRabbit local watcher clean, findings=0; `.git/coderabbit-review/20260519T154157Z/coderabbit-review.log`. CodeRabbit PR gate clean; `.git/coderabbit-review/20260519T154839Z/gate-summary.json`.
- tests added/expanded: `parakeet-ptt/src/config.rs`, `parakeet-ptt/src/llm.rs`, `parakeet-ptt/src/main.rs`, `parakeet-stt-daemon/tests/test_cli_precedence.py`, `parakeet-stt-daemon/tests/test_stt_helper_runtime_profiles.py`
- preexisting failures left: shellcheck warnings listed above; not part of repo `prek` gates and confirmed on `origin/main`.

## Review Triage

- CodeRabbit local review before PR: CLEAN, findings=0, codex fallback=no.
- CodeRabbit PR gate: CLEAN, remote check passed, no actionable findings, codex fallback=no.
- CodeRabbit pre-merge docstring coverage warning: IGNORE for #30 because it is a repo-wide coverage metric unrelated to the endpoint/source-of-truth slice; the canonical gate reported no actionable findings.

## Follow-ups

None from this slice.