### PR TITLE
fix(ptt): reject stale final transcripts

### DIFF
--- a/parakeet-ptt/src/app.rs
+++ b/parakeet-ptt/src/app.rs
@@ -22,8 +22,9 @@ use uuid::Uuid;
 use crate::audio_feedback::AudioFeedback;
 use crate::client::WsClient;
 use crate::client_session::{
-    classify_error_code, elapsed_ms_since, handle_server_message, session_id_from_state,
-    state_label, take_parent_focus_for_enqueue, CapturedParentFocus,
+    classify_error_code, elapsed_ms_since, final_result_belongs_to_active_session,
+    handle_server_message, log_rejected_final_result, session_id_from_state, state_label,
+    take_parent_focus_for_enqueue, CapturedParentFocus,
 };
 use crate::config::ClientConfig;
 use crate::hotkey::{
@@ -364,6 +365,11 @@ pub async fn run_demo(
                 audio_ms,
                 ..
             } => {
+                if !final_result_belongs_to_active_session(&state, session_id) {
+                    log_rejected_final_result(session_id, &state, InjectionOrigin::Demo);
+                    continue;
+                }
+
                 let to_inject = override_text.as_deref().unwrap_or(&text).to_string();
                 info!(
                     session = %session_id,
@@ -578,6 +584,20 @@ pub async fn run(config: ClientConfig, ports: ClientPorts) -> Result<()> {
                                                 "deferring daemon session_ended until llm answer injection"
                                             );
                                             continue;
+                                        }
+
+                                        if let ServerMessage::FinalResult { session_id, .. } = &message {
+                                            if !final_result_belongs_to_active_session(&state, *session_id) {
+                                                log_rejected_final_result(
+                                                    *session_id,
+                                                    &state,
+                                                    match active_intent {
+                                                        Some(SessionIntent::LlmQuery) => InjectionOrigin::LlmAnswer,
+                                                        _ => InjectionOrigin::RawFinalResult,
+                                                    },
+                                                );
+                                                continue;
+                                            }
                                         }
 
                                         match message {
@@ -1382,6 +1402,70 @@ mod tests {
             }
             other => panic!("expected start_session, got {other:?}"),
         }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn app_llm_query_ignores_stale_final_before_answer_generation() {
+        let (config, ports, mut runtime) =
+            ClientRuntimeHarness::new(test_app_config()).into_parts();
+
+        let app_task = tokio::spawn(run(config, ports));
+        runtime.send_hotkey_down(HotkeyIntent::LlmQuery);
+        let start = runtime.next_sent_message(Duration::from_millis(250)).await;
+        let active_session_id = match start {
+            ClientMessage::StartSession { session_id, .. } => session_id,
+            other => panic!("expected start_session, got {other:?}"),
+        };
+        runtime.send_hotkey_up();
+        let stop = runtime.next_sent_message(Duration::from_millis(250)).await;
+        match stop {
+            ClientMessage::StopSession { session_id, .. } => {
+                assert_eq!(session_id, active_session_id);
+            }
+            other => panic!("expected stop_session, got {other:?}"),
+        }
+
+        runtime.send_daemon_message(ServerMessage::FinalResult {
+            session_id: Uuid::new_v4(),
+            text: "stale private transcript".to_string(),
+            latency_ms: 44,
+            audio_ms: 1200,
+            lang: Some("en".to_string()),
+            confidence: Some(0.92),
+        });
+        tokio::time::sleep(Duration::from_millis(75)).await;
+
+        assert!(runtime.recorded_llm_requests().is_empty());
+        assert!(runtime.recorded_injections().is_empty());
+
+        runtime.send_daemon_message(ServerMessage::FinalResult {
+            session_id: active_session_id,
+            text: "current private transcript".to_string(),
+            latency_ms: 55,
+            audio_ms: 1500,
+            lang: Some("en".to_string()),
+            confidence: Some(0.95),
+        });
+        timeout(Duration::from_secs(1), async {
+            loop {
+                if !runtime.recorded_injections().is_empty() {
+                    break;
+                }
+                yield_now().await;
+            }
+        })
+        .await
+        .expect("valid final result should produce an LLM answer injection");
+        app_task.abort();
+
+        assert_eq!(
+            runtime.recorded_llm_requests(),
+            vec![(active_session_id, "current private transcript".to_string())]
+        );
+        assert_eq!(
+            runtime.recorded_injections(),
+            vec!["test answer".to_string()]
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/parakeet-ptt/src/client_runtime_fixtures.rs
+++ b/parakeet-ptt/src/client_runtime_fixtures.rs
@@ -19,6 +19,7 @@ use crate::overlay_router::{OverlayEvent, OverlaySink};
 use crate::protocol::{ClientMessage, ServerMessage};
 
 type TestBoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+type RecordedLlmRequests = Arc<Mutex<Vec<(Uuid, String)>>>;
 
 pub(crate) struct ClientRuntimeHarness {
     config: ClientConfig,
@@ -33,6 +34,7 @@ impl ClientRuntimeHarness {
         let (daemon_tx, daemon_rx) = mpsc::unbounded_channel();
         let (injection_runner, injections) = RecordingInjectionRunner::shared();
         let (overlay_sink, overlay_events) = RecordingOverlaySink::shared();
+        let (llm_answerer, llm_requests) = TestLlmAnswerer::shared();
         let ports = ClientPorts::new(
             AudioFeedback::new(false, None, 0),
             Arc::new(TestDaemonConnector::new(TestDaemonConnection {
@@ -43,7 +45,7 @@ impl ClientRuntimeHarness {
             Box::new(overlay_sink),
             None,
             Box::new(TestHotkeySource::new(hotkey_rx)),
-            Arc::new(TestLlmAnswerer),
+            llm_answerer,
         );
 
         Self {
@@ -54,7 +56,8 @@ impl ClientRuntimeHarness {
                 sent_rx,
                 injections,
                 overlay_events,
-                _daemon_tx: daemon_tx,
+                daemon_tx,
+                llm_requests,
             },
         }
     }
@@ -69,7 +72,8 @@ pub(crate) struct ClientRuntimeControls {
     sent_rx: mpsc::UnboundedReceiver<ClientMessage>,
     injections: Arc<Mutex<Vec<String>>>,
     overlay_events: Arc<Mutex<Vec<OverlayEvent>>>,
-    _daemon_tx: mpsc::UnboundedSender<ServerMessage>,
+    daemon_tx: mpsc::UnboundedSender<ServerMessage>,
+    llm_requests: RecordedLlmRequests,
 }
 
 impl ClientRuntimeControls {
@@ -77,6 +81,18 @@ impl ClientRuntimeControls {
         self.hotkey_tx
             .send(HotkeyEvent::Down { intent })
             .expect("test hotkey event should send");
+    }
+
+    pub(crate) fn send_hotkey_up(&self) {
+        self.hotkey_tx
+            .send(HotkeyEvent::Up)
+            .expect("test hotkey event should send");
+    }
+
+    pub(crate) fn send_daemon_message(&self, message: ServerMessage) {
+        self.daemon_tx
+            .send(message)
+            .expect("test daemon message should send");
     }
 
     pub(crate) async fn next_sent_message(&mut self, wait: Duration) -> ClientMessage {
@@ -97,6 +113,13 @@ impl ClientRuntimeControls {
         self.overlay_events
             .lock()
             .expect("recorded overlay lock should be available")
+            .clone()
+    }
+
+    pub(crate) fn recorded_llm_requests(&self) -> Vec<(Uuid, String)> {
+        self.llm_requests
+            .lock()
+            .expect("recorded LLM request lock should be available")
             .clone()
     }
 }
@@ -222,7 +245,21 @@ impl DaemonConnection for TestDaemonConnection {
     }
 }
 
-struct TestLlmAnswerer;
+struct TestLlmAnswerer {
+    requests: RecordedLlmRequests,
+}
+
+impl TestLlmAnswerer {
+    fn shared() -> (Arc<Self>, RecordedLlmRequests) {
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        (
+            Arc::new(Self {
+                requests: Arc::clone(&requests),
+            }),
+            requests,
+        )
+    }
+}
 
 impl LlmAnswerer for TestLlmAnswerer {
     fn label(&self) -> String {
@@ -241,10 +278,16 @@ impl LlmAnswerer for TestLlmAnswerer {
 
     fn answer<'a>(
         &'a self,
-        _session_id: Uuid,
-        _transcript: String,
+        session_id: Uuid,
+        transcript: String,
         _progress_tx: mpsc::UnboundedSender<LlmProgress>,
     ) -> TestBoxFuture<'a, anyhow::Result<String>> {
-        Box::pin(async { Ok("test answer".to_string()) })
+        Box::pin(async move {
+            self.requests
+                .lock()
+                .expect("recorded LLM request lock should be available")
+                .push((session_id, transcript));
+            Ok("test answer".to_string())
+        })
     }
 }

--- a/parakeet-ptt/src/client_session.rs
+++ b/parakeet-ptt/src/client_session.rs
@@ -46,6 +46,11 @@ pub(crate) async fn handle_server_message<S: OverlaySink>(
             audio_ms,
             ..
         } => {
+            if !final_result_belongs_to_active_session(state, session_id) {
+                log_rejected_final_result(session_id, state, InjectionOrigin::RawFinalResult);
+                return Ok(());
+            }
+
             let hotkey_up_elapsed_ms_at_enqueue = elapsed_ms_since(last_hotkey_up_at);
             let stop_message_elapsed_ms_at_enqueue =
                 last_stop_message.and_then(|(stopped_session_id, instant)| {
@@ -182,6 +187,24 @@ pub(crate) fn session_id_from_state(state: &PttState) -> Option<Uuid> {
     }
 }
 
+pub(crate) fn final_result_belongs_to_active_session(state: &PttState, session_id: Uuid) -> bool {
+    session_id_from_state(state) == Some(session_id)
+}
+
+pub(crate) fn log_rejected_final_result(
+    session_id: Uuid,
+    state: &PttState,
+    origin: InjectionOrigin,
+) {
+    warn!(
+        session = %session_id,
+        active_session = ?session_id_from_state(state),
+        origin = origin.as_str(),
+        state_at_receive = state_label(state),
+        "ignoring final result for non-active session"
+    );
+}
+
 pub(crate) fn state_label(state: &PttState) -> &'static str {
     match state {
         PttState::Idle => "idle",
@@ -230,6 +253,7 @@ mod tests {
     use anyhow::anyhow;
     use tokio::sync::mpsc;
     use tokio::time::timeout;
+    use uuid::Uuid;
 
     use super::handle_server_message;
 
@@ -340,6 +364,50 @@ mod tests {
                 .as_slice(),
             &["direct final result".to_string()]
         );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn stale_final_result_does_not_enqueue_injection_job() {
+        let seen_injection = Arc::new(Mutex::new(Vec::<String>::new()));
+        let injector = Arc::new(RecordingRunner {
+            seen: Arc::clone(&seen_injection),
+        });
+        let (worker, mut reports) = spawn_injector_worker_with_capacity(injector, 4);
+        let mut state = PttState::new();
+        let active_session_id = state
+            .begin_listening()
+            .expect("state should begin listening");
+        state.stop_listening();
+        let stale_session_id = Uuid::new_v4();
+        let mut overlay_router = OverlayRouter::new(NoopOverlaySink, None);
+
+        handle_server_message_for_tests(
+            ServerMessage::FinalResult {
+                session_id: stale_session_id,
+                text: "stale private transcript".to_string(),
+                latency_ms: 44,
+                audio_ms: 1200,
+                lang: Some("en".to_string()),
+                confidence: Some(0.92),
+            },
+            &mut state,
+            &mut overlay_router,
+            &worker,
+        )
+        .await
+        .expect("stale final result should be ignored without failing dispatch");
+
+        assert!(
+            matches!(state, PttState::WaitingResult { session_id } if session_id == active_session_id)
+        );
+        assert_eq!(worker.metrics().queued_total.load(Ordering::Relaxed), 0);
+        assert!(seen_injection
+            .lock()
+            .expect("recording lock should be available")
+            .is_empty());
+        assert!(timeout(Duration::from_millis(100), reports.recv())
+            .await
+            .is_err());
     }
 
     #[tokio::test(flavor = "current_thread")]


### PR DESCRIPTION
## Summary

Fixes #84.

Rejects final_result messages whose session_id does not match the active or waiting client session before raw injection, demo injection, or LLM answer generation. Rejected finals log session metadata only; transcript text is not included in the diagnostic.

## Verification (#84)

- targeted: `cargo test --manifest-path parakeet-ptt/Cargo.toml stale_final_result_does_not_enqueue_injection_job` -> PASSED
- targeted: `cargo test --manifest-path parakeet-ptt/Cargo.toml app_llm_query_ignores_stale_final_before_answer_generation` -> PASSED
- regression: throwaway `origin/main` worktree with tests and fix removed: both targeted tests FAILED, then PASS on this branch
- full suite: `cargo test --manifest-path parakeet-ptt/Cargo.toml -q` -> PASSED
- lint: `cargo clippy --manifest-path parakeet-ptt/Cargo.toml --all-targets --all-features -- -D warnings` -> PASSED
- types: `cargo clippy --manifest-path parakeet-ptt/Cargo.toml --all-targets --all-features -- -D warnings` -> PASSED
- dead-code: N/A (no repo dead-code gate for touched Rust surface)
- build: `cargo test --manifest-path parakeet-ptt/Cargo.toml -q` -> PASSED
- pre-commit: `prek run --all-files` -> PASSED; `prek run --stage pre-push --all-files` -> PASSED; push pre-push hooks -> PASSED
- static/security: `git diff --check` -> PASSED
- migrations: N/A
- CLI/script smoke: N/A
- UI render: N/A
- destructive/negative: stale final tests assert no injection/LLM request and valid final still works -> PASSED
- review: `coderabbit_review_watch.py local -- --base main` -> clean, findings=0 (`.git/coderabbit-review/20260519T165549Z/coderabbit-review.log`)
- tests added/expanded: `parakeet-ptt/src/client_session.rs`, `parakeet-ptt/src/app.rs`, `parakeet-ptt/src/client_runtime_fixtures.rs`
- preexisting failures left: none

## Review notes

CodeRabbit local watcher completed with findings=0 before push. PR gate will be run after PR creation.

## Residual risk

No known residual risk for #84; change is scoped to rejecting mismatched final-result session IDs before work is queued.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of outdated messages to prevent incorrect session processing
  * Improved validation to ensure messages are correctly matched to their corresponding sessions

* **Tests**
  * Enhanced test infrastructure to support LLM request recording and message injection
  * Added test coverage for stale message filtering behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SystemicVoid/parakeet-stt/pull/95?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->