### PR TITLE
fix(stt): fail closed readiness checks

### DIFF
--- a/parakeet-stt-daemon/src/parakeet_stt_daemon/__main__.py
+++ b/parakeet-stt-daemon/src/parakeet_stt_daemon/__main__.py
@@ -151,7 +151,11 @@ def main(argv: Sequence[str] | None = None) -> None:
             settings.batch_size,
         )
     if args.check:
-        run_checks(settings)
+        try:
+            run_checks(settings)
+        except Exception as exc:  # noqa: BLE001 - CLI check should fail without traceback noise
+            logger.error("Startup checks failed: {}", exc)
+            raise SystemExit(1) from None
         return
 
     app = create_app(settings)
@@ -160,6 +164,7 @@ def main(argv: Sequence[str] | None = None) -> None:
 
 def run_checks(settings: ServerSettings) -> None:
     logger.info("Running startup checks with settings: {}", settings)
+    failures: list[str] = []
     try:
         server = DaemonServer(settings)
     except Exception as exc:  # noqa: BLE001
@@ -173,12 +178,14 @@ def run_checks(settings: ServerSettings) -> None:
         orchestrator.audio.stop()
     except Exception as exc:  # noqa: BLE001
         logger.error("Audio stream check failed: {}", exc)
+        failures.append(f"audio stream check failed: {exc}")
 
     try:
         orchestrator.transcriber.warmup()
         logger.info("Model warmup completed")
     except Exception as exc:  # noqa: BLE001
-        logger.warning("Model warmup skipped/failed: {}", exc)
+        logger.error("Model warmup check failed: {}", exc)
+        failures.append(f"model warmup check failed: {exc}")
     if settings.vad_enabled:
         orchestrator.prepare_vad()
 
@@ -245,6 +252,9 @@ def run_checks(settings: ServerSettings) -> None:
             )
     else:
         logger.info("VAD trim: DISABLED")
+
+    if failures:
+        raise RuntimeError("; ".join(failures))
 
 
 if __name__ == "__main__":

--- a/parakeet-stt-daemon/src/parakeet_stt_daemon/model.py
+++ b/parakeet-stt-daemon/src/parakeet_stt_daemon/model.py
@@ -262,13 +262,10 @@ class ParakeetTranscriber:
 
     def warmup(self) -> None:
         """Run a trivial forward pass to pay the first-use cost."""
-        try:
-            cfg = getattr(self.model, "_cfg", None)
-            sample_rate = getattr(cfg, "sample_rate", 16_000)
-            silence = np.zeros((sample_rate,), dtype=np.float32)
-            _ = self.transcribe_samples(silence, sample_rate=sample_rate)
-        except (AttributeError, RuntimeError, TypeError, ValueError) as exc:  # pragma: no cover
-            logger.debug("Warmup skipped: {}", exc)
+        cfg = getattr(self.model, "_cfg", None)
+        sample_rate = getattr(cfg, "sample_rate", 16_000)
+        silence = np.zeros((sample_rate,), dtype=np.float32)
+        _ = self.transcribe_samples(silence, sample_rate=sample_rate)
 
     def transcribe_files(self, paths: Sequence[str], *, timestamps: bool = False) -> list[str]:
         if not paths:

--- a/parakeet-stt-daemon/src/parakeet_stt_daemon/server.py
+++ b/parakeet-stt-daemon/src/parakeet_stt_daemon/server.py
@@ -178,28 +178,31 @@ def create_app(settings: ServerSettings) -> FastAPI:
     async def lifespan(app: FastAPI):
         del app
         orchestrator = server.orchestrator
-        logger.info("Starting audio capture")
-        orchestrator.audio.start()
-        logger.info("Warming Parakeet model on {}", settings.device)
+        audio_started = False
         try:
+            logger.info("Starting audio capture")
+            orchestrator.audio.start()
+            audio_started = True
+            logger.info("Warming Parakeet model on {}", settings.device)
             await asyncio.to_thread(orchestrator.transcriber.warmup)
-        except Exception as exc:  # noqa: BLE001
-            logger.warning("Model warmup skipped: {}", exc)
-        _release_cuda_cache(settings.device)
-        if orchestrator._vad_enabled:
-            await asyncio.to_thread(orchestrator.prepare_vad)
-        runtime_truth = orchestrator.runtime_truth(
-            overlay_events_enabled=server.event_sinks.overlay_events_enabled
-        )
-        runtime_degraded = runtime_truth.degraded
-        _log = logger.warning if runtime_degraded else logger.info
-        _log(
-            "Runtime truth: {}",
-            format_log_record(runtime_truth.to_log_record()),
-        )
-        yield
-        logger.info("Stopping audio capture")
-        orchestrator.audio.stop()
+            logger.info("Model warmup completed")
+            _release_cuda_cache(settings.device)
+            if orchestrator._vad_enabled:
+                await asyncio.to_thread(orchestrator.prepare_vad)
+            runtime_truth = orchestrator.runtime_truth(
+                overlay_events_enabled=server.event_sinks.overlay_events_enabled
+            )
+            runtime_degraded = runtime_truth.degraded
+            _log = logger.warning if runtime_degraded else logger.info
+            _log(
+                "Runtime truth: {}",
+                format_log_record(runtime_truth.to_log_record()),
+            )
+            yield
+        finally:
+            if audio_started:
+                logger.info("Stopping audio capture")
+                orchestrator.audio.stop()
 
     app = FastAPI(title="Parakeet STT Daemon", version="0.2.0", lifespan=lifespan)
 

--- a/parakeet-stt-daemon/tests/test_cli_precedence.py
+++ b/parakeet-stt-daemon/tests/test_cli_precedence.py
@@ -1,13 +1,100 @@
-"""Tests for CLI/environment precedence when building daemon settings."""
+"""Tests for CLI settings and startup checks."""
 
 from __future__ import annotations
 
-from parakeet_stt_daemon.__main__ import _build_settings, _parse_args
+from typing import Any
+
+import pytest
+
+from parakeet_stt_daemon import __main__ as daemon_main
 from parakeet_stt_daemon.config import DEFAULT_DAEMON_HOST, DEFAULT_DAEMON_PORT
 
 
+class _FakeAudio:
+    def __init__(self, start_error: Exception | None = None) -> None:
+        self._start_error = start_error
+        self.start_calls = 0
+        self.stop_calls = 0
+
+    def start(self) -> None:
+        self.start_calls += 1
+        if self._start_error is not None:
+            raise self._start_error
+
+    def stop(self) -> None:
+        self.stop_calls += 1
+
+
+class _FakeTranscriber:
+    def __init__(self, warmup_error: Exception | None = None) -> None:
+        self._warmup_error = warmup_error
+        self.warmup_calls = 0
+
+    def warmup(self) -> None:
+        self.warmup_calls += 1
+        if self._warmup_error is not None:
+            raise self._warmup_error
+
+
+class _FakeRuntimeTruth:
+    stream_helper_active = True
+    stream_helper_class_name = "FakeStreamingHelper"
+    stream_helper_scope = "live_session_only"
+    stream_fallback_reason = None
+    finalization_mode = "offline_seal"
+    final_audio_source = "canonical_session_audio"
+    tail_trim_mode = "rms"
+    vad_active = True
+    vad_fallback_reason = None
+
+    def to_log_record(self) -> dict[str, str]:
+        return {"runtime": "test"}
+
+
+class _FakeOrchestrator:
+    def __init__(
+        self,
+        audio: _FakeAudio,
+        transcriber: _FakeTranscriber,
+    ) -> None:
+        self.audio = audio
+        self.transcriber = transcriber
+
+    def prepare_vad(self) -> None:
+        return None
+
+    def runtime_truth(self, *, overlay_events_enabled: bool) -> _FakeRuntimeTruth:
+        del overlay_events_enabled
+        return _FakeRuntimeTruth()
+
+
+def _install_fake_daemon_server(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    audio_start_error: Exception | None = None,
+    warmup_error: Exception | None = None,
+) -> _FakeOrchestrator:
+    orchestrator = _FakeOrchestrator(
+        _FakeAudio(audio_start_error),
+        _FakeTranscriber(warmup_error),
+    )
+
+    class FakeDaemonServer:
+        def __init__(self, settings: Any) -> None:
+            del settings
+            self.orchestrator = orchestrator
+
+    monkeypatch.setattr(daemon_main, "DaemonServer", FakeDaemonServer)
+    monkeypatch.setattr(
+        daemon_main.sd,
+        "query_devices",
+        lambda: [{"name": "Fake microphone", "max_input_channels": 1}],
+    )
+    return orchestrator
+
+
 def test_parse_args_boolean_flags_default_to_none() -> None:
-    args = _parse_args([])
+    args = daemon_main._parse_args([])
 
     assert args.status_enabled is None
     assert args.streaming_enabled is None
@@ -20,7 +107,7 @@ def test_env_values_apply_when_cli_flags_absent(monkeypatch) -> None:
     monkeypatch.setenv("PARAKEET_STREAMING_ENABLED", "true")
     monkeypatch.setenv("PARAKEET_OVERLAY_EVENTS_ENABLED", "true")
 
-    settings = _build_settings(_parse_args([]))
+    settings = daemon_main._build_settings(daemon_main._parse_args([]))
 
     assert settings.host == "0.0.0.0"
     assert settings.port == 9876
@@ -33,7 +120,9 @@ def test_cli_explicit_disable_overrides_env_true(monkeypatch) -> None:
     monkeypatch.setenv("PARAKEET_STATUS_ENABLED", "true")
     monkeypatch.setenv("PARAKEET_STREAMING_ENABLED", "true")
 
-    settings = _build_settings(_parse_args(["--no-status", "--no-streaming"]))
+    settings = daemon_main._build_settings(
+        daemon_main._parse_args(["--no-status", "--no-streaming"])
+    )
 
     assert settings.status_enabled is False
     assert settings.streaming_enabled is False
@@ -43,7 +132,9 @@ def test_unrelated_cli_args_do_not_override_env_booleans(monkeypatch) -> None:
     monkeypatch.setenv("PARAKEET_STATUS_ENABLED", "false")
     monkeypatch.setenv("PARAKEET_STREAMING_ENABLED", "false")
 
-    settings = _build_settings(_parse_args(["--host", "0.0.0.0", "--port", "9000"]))
+    settings = daemon_main._build_settings(
+        daemon_main._parse_args(["--host", "0.0.0.0", "--port", "9000"])
+    )
 
     assert settings.host == "0.0.0.0"
     assert settings.port == 9000
@@ -55,7 +146,9 @@ def test_cli_host_port_override_env(monkeypatch) -> None:
     monkeypatch.setenv("PARAKEET_HOST", "0.0.0.0")
     monkeypatch.setenv("PARAKEET_PORT", "7000")
 
-    settings = _build_settings(_parse_args(["--host", "127.0.0.2", "--port", "9001"]))
+    settings = daemon_main._build_settings(
+        daemon_main._parse_args(["--host", "127.0.0.2", "--port", "9001"])
+    )
 
     assert settings.host == "127.0.0.2"
     assert settings.port == 9001
@@ -68,7 +161,7 @@ def test_defaults_apply_without_env_or_cli(monkeypatch) -> None:
     monkeypatch.delenv("PARAKEET_STREAMING_ENABLED", raising=False)
     monkeypatch.delenv("PARAKEET_OVERLAY_EVENTS_ENABLED", raising=False)
 
-    settings = _build_settings(_parse_args([]))
+    settings = daemon_main._build_settings(daemon_main._parse_args([]))
 
     assert settings.host == DEFAULT_DAEMON_HOST
     assert settings.port == DEFAULT_DAEMON_PORT
@@ -83,7 +176,7 @@ def test_env_session_limits_apply_when_cli_absent(monkeypatch) -> None:
     monkeypatch.setenv("PARAKEET_MAX_SESSION_SECONDS", "45")
     monkeypatch.setenv("PARAKEET_MAX_SESSION_SAMPLES", "12345")
 
-    settings = _build_settings(_parse_args([]))
+    settings = daemon_main._build_settings(daemon_main._parse_args([]))
 
     assert settings.max_session_seconds == 45.0
     assert settings.max_session_samples == 12_345
@@ -93,9 +186,53 @@ def test_cli_session_limits_override_env(monkeypatch) -> None:
     monkeypatch.setenv("PARAKEET_MAX_SESSION_SECONDS", "30")
     monkeypatch.setenv("PARAKEET_MAX_SESSION_SAMPLES", "1000")
 
-    settings = _build_settings(
-        _parse_args(["--max-session-seconds", "12", "--max-session-samples", "2048"])
+    settings = daemon_main._build_settings(
+        daemon_main._parse_args(["--max-session-seconds", "12", "--max-session-samples", "2048"])
     )
 
     assert settings.max_session_seconds == 12.0
     assert settings.max_session_samples == 2_048
+
+
+def test_run_checks_fails_when_audio_startup_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    orchestrator = _install_fake_daemon_server(
+        monkeypatch,
+        audio_start_error=RuntimeError("audio device unavailable"),
+    )
+
+    with pytest.raises(RuntimeError, match="audio stream check failed: audio device unavailable"):
+        daemon_main.run_checks(
+            daemon_main._build_settings(daemon_main._parse_args(["--device", "cpu"]))
+        )
+
+    assert orchestrator.audio.start_calls == 1
+    assert orchestrator.audio.stop_calls == 0
+
+
+def test_run_checks_fails_when_model_warmup_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    orchestrator = _install_fake_daemon_server(
+        monkeypatch,
+        warmup_error=RuntimeError("decoder unavailable"),
+    )
+
+    with pytest.raises(RuntimeError, match="model warmup check failed: decoder unavailable"):
+        daemon_main.run_checks(
+            daemon_main._build_settings(daemon_main._parse_args(["--device", "cpu"]))
+        )
+
+    assert orchestrator.transcriber.warmup_calls == 1
+
+
+def test_main_check_exits_nonzero_when_startup_checks_fail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_checks(settings: object) -> None:
+        del settings
+        raise RuntimeError("startup gate failed")
+
+    monkeypatch.setattr(daemon_main, "run_checks", fail_checks)
+
+    with pytest.raises(SystemExit) as exc_info:
+        daemon_main.main(["--check", "--device", "cpu"])
+
+    assert exc_info.value.code == 1

--- a/parakeet-stt-daemon/tests/test_stt_helper_runtime_profiles.py
+++ b/parakeet-stt-daemon/tests/test_stt_helper_runtime_profiles.py
@@ -111,6 +111,45 @@ def _run_status_runtime_truth(payload_path: Path) -> dict[str, str]:
     return truth
 
 
+def _run_client_ready_once(
+    log_path: Path,
+    pid_file: Path,
+    marker: str,
+    pid: int,
+) -> dict[str, str]:
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("PARAKEET_") and not key.startswith("_STT_")
+    }
+    env["PARAKEET_ROOT"] = str(REPO_ROOT)
+    env["_STT_SKIP_LOCAL_OVERRIDES"] = "1"
+    command = [
+        "bash",
+        "-lc",
+        f"source {shlex.quote(str(HELPER_PATH))} && "
+        "stt __client-ready-once "
+        f"{shlex.quote(str(log_path))} "
+        f"{shlex.quote(str(pid_file))} "
+        f"{shlex.quote(marker)} "
+        f"{pid}",
+    ]
+    completed = subprocess.run(
+        command,
+        check=True,
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+
+    result: dict[str, str] = {}
+    for line in completed.stdout.splitlines():
+        key, value = line.split("=", 1)
+        result[key] = value
+    return result
+
+
 def test_cpu_profile_resolves_offline_cpu_runtime() -> None:
     config = _run_runtime_config("cpu")
 
@@ -153,6 +192,7 @@ def test_helper_endpoint_defaults_match_daemon_settings() -> None:
     assert config["daemon_port"] == str(DEFAULT_DAEMON_PORT)
     assert config["daemon_websocket_endpoint"] == daemon_websocket_endpoint()
     assert config["daemon_status_url"] == daemon_status_url()
+    assert config["daemon_health_url"] == "http://127.0.0.1:8765/healthz"
     assert config["llm_base_url"] == "http://127.0.0.1:8080/v1"
     assert config["managed_llm_api_base_url"] == "http://127.0.0.1:8080/v1"
     assert config["llm_health_url"] == "http://127.0.0.1:8080/health"
@@ -172,6 +212,7 @@ def test_helper_endpoint_env_overrides_resolve_consistently() -> None:
     assert config["daemon_port"] == "9001"
     assert config["daemon_websocket_endpoint"] == daemon_websocket_endpoint("0.0.0.0", 9001)
     assert config["daemon_status_url"] == daemon_status_url("0.0.0.0", 9001)
+    assert config["daemon_health_url"] == "http://0.0.0.0:9001/healthz"
     assert config["llm_base_url"] == "http://llm.local:8181/v1"
     assert config["managed_llm_api_base_url"] == "http://llm.local:8181/v1"
     assert config["llm_health_url"] == "http://llm.local:8181/health"
@@ -194,6 +235,54 @@ def test_runtime_match_accepts_cpu_fallback_for_accelerator_request() -> None:
 
 def test_runtime_match_rejects_accelerator_when_cpu_requested() -> None:
     assert _run_runtime_match("cpu", "false", "false", "cuda", "false", "false") is False
+
+
+def test_client_ready_once_rejects_pid_without_current_readiness_logs(tmp_path: Path) -> None:
+    marker = "current-client-start"
+    log_path = tmp_path / "client.log"
+    pid_file = tmp_path / "client.pid"
+    log_path.write_text(f"{marker}\n", encoding="utf-8")
+
+    result = _run_client_ready_once(log_path, pid_file, marker, os.getpid())
+
+    assert result == {"ready": "false"}
+    assert not pid_file.exists()
+
+
+def test_client_ready_once_requires_current_hotkey_and_connection_logs(tmp_path: Path) -> None:
+    marker = "current-client-start"
+    log_path = tmp_path / "client.log"
+    pid_file = tmp_path / "client.pid"
+    log_path.write_text(
+        "\n".join(
+            [
+                "Hotkey listeners started",
+                "Connected to daemon",
+                marker,
+                "Hotkey listeners started",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    stale_result = _run_client_ready_once(log_path, pid_file, marker, os.getpid())
+    assert stale_result == {"ready": "false"}
+
+    log_path.write_text(
+        "\n".join(
+            [
+                marker,
+                "Hotkey listeners started",
+                "Connected to daemon",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    ready_result = _run_client_ready_once(log_path, pid_file, marker, os.getpid())
+
+    assert ready_result == {"ready": "true"}
+    assert pid_file.read_text(encoding="utf-8").strip() == str(os.getpid())
 
 
 def test_daemon_status_runtime_truth_reads_status_fields_unchanged(tmp_path: Path) -> None:

--- a/scripts/stt-helper.sh
+++ b/scripts/stt-helper.sh
@@ -73,6 +73,7 @@ stt() {
     local DEFAULT_DAEMON_PORT="8765"
     local DAEMON_WS_PATH="/ws"
     local DAEMON_STATUS_PATH="/status"
+    local DAEMON_HEALTH_PATH="/healthz"
     local DEFAULT_LLM_SERVER_HOST="127.0.0.1"
     local DEFAULT_LLM_SERVER_PORT="8080"
     local LLM_API_PATH="/v1"
@@ -92,6 +93,10 @@ stt() {
 
     _daemon_status_url() {
         _endpoint_url "http" "$HOST" "$PORT" "$DAEMON_STATUS_PATH"
+    }
+
+    _daemon_health_url() {
+        _endpoint_url "http" "$HOST" "$PORT" "$DAEMON_HEALTH_PATH"
     }
 
     _daemon_ws_endpoint_from_authority() {
@@ -545,23 +550,6 @@ PY
         return $?
     }
 
-    _wait_for_socket() {
-        local pid_file="$1"
-        local tries="${2:-60}" # 30s with 0.5s sleep
-        local ready=0
-        for _ in $(seq 1 "$tries"); do
-            if _socket_ready_once; then
-                ready=1
-                break
-            fi
-            if [ -n "$pid_file" ] && [ -f "$pid_file" ] && ! ps -p "$(cat "$pid_file")" >/dev/null 2>&1; then
-                break
-            fi
-            sleep 0.5
-        done
-        [ "$ready" -eq 1 ]
-    }
-
     _http_ok_once() {
         local url="$1"
         if command -v curl >/dev/null 2>&1; then
@@ -634,25 +622,47 @@ PY
         return 0
     }
 
+    _client_log_has_after_marker() {
+        local marker="$1"
+        local needle="$2"
+        [ -f "$LOG_CLIENT" ] || return 1
+
+        if [ -n "$marker" ]; then
+            awk -v marker="$marker" 'seen { print } index($0, marker) { seen = 1 }' "$LOG_CLIENT" | grep -Fq "$needle"
+            return $?
+        fi
+
+        grep -Fq "$needle" "$LOG_CLIENT"
+    }
+
+    _client_log_has_readiness_signal() {
+        local marker="$1"
+        _client_log_has_after_marker "$marker" "Hotkey listeners started" || return 1
+        _client_log_has_after_marker "$marker" "Connected to daemon" || return 1
+    }
+
+    _client_ready_once() {
+        local marker="$1"
+        local pid="${2:-}"
+        if [ -z "$pid" ]; then
+            pid=$(pgrep -n "[p]arakeet-ptt" || true)
+        fi
+
+        [ -n "$pid" ] || return 1
+        ps -p "$pid" >/dev/null 2>&1 || return 1
+        _client_log_has_readiness_signal "$marker" || return 1
+        echo "$pid" >| "$CLIENT_PID_FILE"
+    }
+
     _wait_for_client_ready() {
         local timeout_seconds="${1:-30}"
+        local readiness_marker="${2:-}"
         local started_at="$SECONDS"
         local max_wait="$timeout_seconds"
-        local pid
 
         while true; do
-            pid=$(pgrep -n "[p]arakeet-ptt" || true)
-            if [ -n "$pid" ]; then
-                echo "$pid" >| "$CLIENT_PID_FILE"
+            if _client_ready_once "$readiness_marker"; then
                 return 0
-            fi
-
-            if [ -f "$LOG_CLIENT" ] && grep -Eq "Starting hotkey loop; press Right Ctrl to talk|Hotkey listeners started for KEY_RIGHTCTRL|Connected to daemon" "$LOG_CLIENT"; then
-                pid=$(pgrep -n "[p]arakeet-ptt" || true)
-                if [ -n "$pid" ]; then
-                    echo "$pid" >| "$CLIENT_PID_FILE"
-                    return 0
-                fi
             fi
 
             if [ $((SECONDS - started_at)) -ge "$max_wait" ]; then
@@ -1258,6 +1268,7 @@ daemon_host=$HOST
 daemon_port=$PORT
 daemon_websocket_endpoint=$(_daemon_ws_endpoint)
 daemon_status_url=$(_daemon_status_url)
+daemon_health_url=$(_daemon_health_url)
 llm_base_url=$llm_base_url
 managed_llm_api_base_url=$(_llm_api_base_url)
 llm_health_url=$(_llm_health_url)
@@ -1282,6 +1293,20 @@ EOF
             fi
 
             _daemon_status_runtime_truth "$1"
+            ;;
+        __client-ready-once)
+            if [ "$#" -ne 4 ]; then
+                echo "usage: stt __client-ready-once <client-log> <pid-file> <readiness-marker> <pid>" >&2
+                return 2
+            fi
+
+            LOG_CLIENT="$1"
+            CLIENT_PID_FILE="$2"
+            if _client_ready_once "$3" "$4"; then
+                echo "ready=true"
+            else
+                echo "ready=false"
+            fi
             ;;
         start)
             local injection_mode paste_backend_failure_policy
@@ -1348,8 +1373,9 @@ EOF
             fi
 
             local daemon_reused=0
-            local daemon_status_url
+            local daemon_status_url daemon_health_url
             daemon_status_url="$(_daemon_status_url)"
+            daemon_health_url="$(_daemon_health_url)"
             if _socket_ready_once; then
                 local current_device=""
                 local current_effective_device=""
@@ -1358,40 +1384,48 @@ EOF
                 local runtime_truth
 
                 _refresh_daemon_pid_file_from_listener >/dev/null 2>&1 || true
-                runtime_truth="$(_daemon_status_runtime_truth "$daemon_status_url" 2>/dev/null)" || runtime_truth=""
+                if ! _http_ok_once "$daemon_health_url"; then
+                    echo "   - Existing daemon health check failed ($daemon_health_url); restarting."
+                    if ! _stop_running_daemon; then
+                        echo "   - Failed to stop the running daemon before relaunch."
+                        return 1
+                    fi
+                else
+                    runtime_truth="$(_daemon_status_runtime_truth "$daemon_status_url" 2>/dev/null)" || runtime_truth=""
 
-                echo "   - Requested daemon runtime: device=$daemon_device, streaming_enabled=$daemon_streaming_enabled, overlay_events_enabled=$daemon_overlay_events_enabled"
-                if [ -n "$runtime_truth" ]; then
-                    while IFS='=' read -r key value; do
-                        case "$key" in
-                            device) current_device="$value" ;;
-                            effective_device) current_effective_device="$value" ;;
-                            streaming_enabled) current_streaming_enabled="$value" ;;
-                            overlay_events_enabled) current_overlay_events_enabled="$value" ;;
-                        esac
-                    done <<< "$runtime_truth"
-                    echo "   - Existing daemon runtime: device=$current_device, effective_device=$current_effective_device, streaming_enabled=$current_streaming_enabled, overlay_events_enabled=$current_overlay_events_enabled"
-                    if _daemon_runtime_matches_request \
-                        "$daemon_device" \
-                        "$daemon_streaming_enabled" \
-                        "$daemon_overlay_events_enabled" \
-                        "$current_effective_device" \
-                        "$current_streaming_enabled" \
-                        "$current_overlay_events_enabled"; then
-                        echo "   - Reusing existing daemon (pid $(cat "$DAEMON_PID_FILE" 2>/dev/null))."
-                        daemon_reused=1
+                    echo "   - Requested daemon runtime: device=$daemon_device, streaming_enabled=$daemon_streaming_enabled, overlay_events_enabled=$daemon_overlay_events_enabled"
+                    if [ -n "$runtime_truth" ]; then
+                        while IFS='=' read -r key value; do
+                            case "$key" in
+                                device) current_device="$value" ;;
+                                effective_device) current_effective_device="$value" ;;
+                                streaming_enabled) current_streaming_enabled="$value" ;;
+                                overlay_events_enabled) current_overlay_events_enabled="$value" ;;
+                            esac
+                        done <<< "$runtime_truth"
+                        echo "   - Existing daemon runtime: device=$current_device, effective_device=$current_effective_device, streaming_enabled=$current_streaming_enabled, overlay_events_enabled=$current_overlay_events_enabled"
+                        if _daemon_runtime_matches_request \
+                            "$daemon_device" \
+                            "$daemon_streaming_enabled" \
+                            "$daemon_overlay_events_enabled" \
+                            "$current_effective_device" \
+                            "$current_streaming_enabled" \
+                            "$current_overlay_events_enabled"; then
+                            echo "   - Reusing existing daemon (pid $(cat "$DAEMON_PID_FILE" 2>/dev/null))."
+                            daemon_reused=1
+                        else
+                            echo "   - Existing daemon runtime does not match request; restarting."
+                            if ! _stop_running_daemon; then
+                                echo "   - Failed to stop the running daemon before relaunch."
+                                return 1
+                            fi
+                        fi
                     else
-                        echo "   - Existing daemon runtime does not match request; restarting."
+                        echo "   - Existing daemon status missing or unparseable; restarting to enforce requested runtime."
                         if ! _stop_running_daemon; then
                             echo "   - Failed to stop the running daemon before relaunch."
                             return 1
                         fi
-                    fi
-                else
-                    echo "   - Existing daemon status missing or unparseable; restarting to enforce requested runtime."
-                    if ! _stop_running_daemon; then
-                        echo "   - Failed to stop the running daemon before relaunch."
-                        return 1
                     fi
                 fi
             elif _pid_alive "$DAEMON_PID_FILE"; then
@@ -1417,14 +1451,15 @@ EOF
                 )
             fi
 
-            echo -n "   - Waiting for socket..."
-            if _wait_for_socket "$DAEMON_PID_FILE" 60; then
+            echo -n "   - Waiting for daemon health..."
+            if _wait_for_http "$daemon_health_url" "$DAEMON_PID_FILE" 120; then
                 _refresh_daemon_pid_file_from_listener >/dev/null 2>&1 || true
                 echo " OK"
                 echo "${HOST}:${PORT}" >| "$PORT_FILE"
             else
-                echo " not ready; last daemon log lines:"
+                echo " not healthy; last daemon log lines:"
                 tail -n 80 "$LOG_DAEMON"
+                echo "   - Daemon health URL: $daemon_health_url"
                 return 1
             fi
 
@@ -1439,7 +1474,10 @@ EOF
                 pkill -f "[p]arakeet-ptt" >/dev/null 2>&1 || true
             fi
 
+            local client_readiness_marker
+            client_readiness_marker="[helper] client readiness marker: $(date +%s)-$$-${RANDOM:-0}"
             echo "--- Session Start: $(date) ---" >> "$LOG_CLIENT"
+            echo "$client_readiness_marker" >> "$LOG_CLIENT"
             _log_client "start client in tmux (mode: $injection_mode)"
 
             _tmux_kill_session "$TMUX_SESSION"
@@ -1468,7 +1506,7 @@ EOF
                 tmux select-pane -t "$primary_pane"
             fi
 
-            if ! _wait_for_client_ready "$client_ready_timeout_seconds"; then
+            if ! _wait_for_client_ready "$client_ready_timeout_seconds" "$client_readiness_marker"; then
                 if _client_build_in_progress; then
                     echo "   - Client compile still in progress after timeout window; recent client log:"
                 else


### PR DESCRIPTION
## Summary
- Make daemon startup checks fail closed for audio startup and model warmup failures.
- Stop serving daemon health after model warmup failure; failed startup still closes audio capture.
- Make helper `stt start` wait on daemon `/healthz` and current client-log evidence of both hotkey listeners and daemon connection before printing ready.
- Add regression tests for false-green daemon checks and client readiness.

## Validation
- uv run pytest tests/test_cli_precedence.py tests/test_stt_helper_runtime_profiles.py
- uv run pytest
- uv run ruff check tests/test_cli_precedence.py tests/test_stt_helper_runtime_profiles.py src/parakeet_stt_daemon/__main__.py src/parakeet_stt_daemon/model.py src/parakeet_stt_daemon/server.py
- uv run ty check
- shellcheck scripts/stt-helper.sh
- bash -n scripts/stt-helper.sh
- source scripts/stt-helper.sh && stt help start
- source scripts/stt-helper.sh && stt help llm
- git diff --check
- prek run --all-files
- prek run --stage pre-push --all-files
- push pre-push hooks passed
- Regression worktree against origin/main failed the new false-green tests as expected.
- CodeRabbit local review: .git/coderabbit-review/20260519T172537Z/coderabbit-review.log, findings=0

Fixes #87


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CLI `--check` now fails and exits with status 1 on audio or model startup failures
  * Model warmup errors now surface instead of being silently skipped
  * Audio capture shutdown is ensured during startup even on errors

* **New Features**
  * Daemon HTTP health endpoint added for monitoring and reuse gating
  * Per-session, marker-scoped readiness detection and one-shot readiness probe

* **Tests**
  * Added tests for startup gate behavior and client-ready checks

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SystemicVoid/parakeet-stt/pull/97?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->