### PR TITLE
fix(ptt): treat overlay auto mode as probing

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Default `stt` / `stt start` profile:
 
 Overlay backend mode override (both profiles):
 
-- `PARAKEET_OVERLAY_MODE=auto|layer-shell|fallback-window|disabled`
+- `PARAKEET_OVERLAY_MODE=auto|layer-shell|fallback-window|disabled` (`auto` probes Wayland overlay capability)
 
 Local LLM query mode overrides:
 

--- a/parakeet-ptt/src/config.rs
+++ b/parakeet-ptt/src/config.rs
@@ -181,12 +181,14 @@ fn probe_overlay_capability_with_inputs(
         .map(str::trim)
         .filter(|raw| !raw.is_empty())
     {
-        if let Some(capability) = parse_overlay_mode_override(raw_override) {
-            return capability;
+        if !raw_override.eq_ignore_ascii_case("auto") {
+            if let Some(capability) = parse_overlay_mode_override(raw_override) {
+                return capability;
+            }
+            return OverlayCapability::disabled(format!(
+                "overlay_mode_override_invalid:{raw_override}"
+            ));
         }
-        return OverlayCapability::disabled(format!(
-            "overlay_mode_override_invalid:{raw_override}"
-        ));
     }
 
     match probe_signals {
@@ -559,11 +561,28 @@ mod tests {
     }
 
     #[test]
-    fn resolve_overlay_capability_treats_empty_mode_env_as_auto() {
+    fn resolve_overlay_capability_treats_explicit_auto_mode_env_as_probe() {
         let capability = resolve_overlay_capability_with_inputs(
             Some(true),
             None,
-            Some(" "),
+            Some("auto"),
+            Ok(OverlayProbeSignals {
+                has_layer_shell: true,
+                has_wl_compositor: true,
+                has_xdg_wm_base: true,
+            }),
+        );
+
+        assert_eq!(capability.mode, OverlayMode::LayerShell);
+        assert_eq!(capability.reason, "zwlr_layer_shell_v1_available");
+    }
+
+    #[test]
+    fn resolve_overlay_capability_treats_unset_mode_env_as_auto() {
+        let capability = resolve_overlay_capability_with_inputs(
+            Some(true),
+            None,
+            None,
             Ok(OverlayProbeSignals {
                 has_layer_shell: false,
                 has_wl_compositor: true,
@@ -576,6 +595,74 @@ mod tests {
             capability.reason,
             "zwlr_layer_shell_v1_unavailable_using_xdg_toplevel_fallback"
         );
+    }
+
+    #[test]
+    fn resolve_overlay_capability_treats_empty_mode_env_as_auto() {
+        let capability = resolve_overlay_capability_with_inputs(
+            Some(true),
+            None,
+            Some(""),
+            Ok(OverlayProbeSignals {
+                has_layer_shell: false,
+                has_wl_compositor: true,
+                has_xdg_wm_base: true,
+            }),
+        );
+
+        assert_eq!(capability.mode, OverlayMode::FallbackWindow);
+        assert_eq!(
+            capability.reason,
+            "zwlr_layer_shell_v1_unavailable_using_xdg_toplevel_fallback"
+        );
+    }
+
+    #[test]
+    fn resolve_overlay_capability_honors_forced_mode_env_values() {
+        for (raw_mode, expected_mode, expected_reason) in [
+            (
+                "layer-shell",
+                OverlayMode::LayerShell,
+                "overlay_mode_override:layer_shell",
+            ),
+            (
+                "fallback_window",
+                OverlayMode::FallbackWindow,
+                "overlay_mode_override:fallback_window",
+            ),
+            (
+                "disabled",
+                OverlayMode::Disabled,
+                "overlay_mode_override:disabled",
+            ),
+        ] {
+            let capability = resolve_overlay_capability_with_inputs(
+                Some(true),
+                None,
+                Some(raw_mode),
+                Err("probe should not run when mode override is forced".to_string()),
+            );
+
+            assert_eq!(capability.mode, expected_mode);
+            assert_eq!(capability.reason, expected_reason);
+        }
+    }
+
+    #[test]
+    fn resolve_overlay_capability_disables_invalid_non_empty_mode_env() {
+        let capability = resolve_overlay_capability_with_inputs(
+            Some(true),
+            None,
+            Some("bad-value"),
+            Ok(OverlayProbeSignals {
+                has_layer_shell: true,
+                has_wl_compositor: true,
+                has_xdg_wm_base: true,
+            }),
+        );
+
+        assert_eq!(capability.mode, OverlayMode::Disabled);
+        assert_eq!(capability.reason, "overlay_mode_override_invalid:bad-value");
     }
 
     #[test]

--- a/scripts/stt-helper.sh
+++ b/scripts/stt-helper.sh
@@ -1123,7 +1123,7 @@ Other environment overrides:
   PARAKEET_PTT_RUSTFLAGS="$default_ptt_rustflags"
   PARAKEET_PTT_RUNNER_PREFERENCE=$default_ptt_runner_preference
   PARAKEET_OVERLAY_ENABLED=<true|false>
-  PARAKEET_OVERLAY_MODE=<auto|layer-shell|fallback-window|disabled>
+  PARAKEET_OVERLAY_MODE=<auto|layer-shell|fallback-window|disabled> (auto probes Wayland overlay capability)
 EOF
     }
 


### PR DESCRIPTION
Fixes #89.

## Summary
- make explicit `PARAKEET_OVERLAY_MODE=auto` fall through to the same Wayland capability probe as unset or empty mode overrides
- keep valid forced modes (`layer-shell`, `fallback-window`, `disabled`) and invalid non-empty diagnostics unchanged
- update README and `stt help start` wording so the accepted values describe `auto` as probing

## Verification (#89)
- targeted: `cargo test resolve_overlay_capability` from `parakeet-ptt/` -> PASSED
- regression: `cargo test resolve_overlay_capability_treats_explicit_auto_mode_env_as_probe` -> FAILED before fix (`Disabled` vs `LayerShell`), then PASSED after fix
- full suite: `cargo test` from `parakeet-ptt/` -> PASSED (`85` lib, `138` main, `10` protocol conformance)
- lint/format: `cargo fmt -- --check` -> PASSED; `shellcheck scripts/stt-helper.sh` -> PASSED
- types/build: `cargo check` from `parakeet-ptt/` -> PASSED
- helper tests: `uv run pytest tests/test_stt_helper_runtime_profiles.py` from `parakeet-stt-daemon/` -> PASSED (`23 passed`)
- CLI/script smoke: `bash -n scripts/stt-helper.sh`, `source scripts/stt-helper.sh && stt help start`, `source scripts/stt-helper.sh && stt help llm` -> PASSED
- pre-commit: `prek run --all-files` -> PASSED; `prek run --stage pre-push --all-files` -> PASSED
- static/security: shellcheck covered the touched shell surface; no security-specific change
- dead-code: N/A, no dedicated repo dead-code gate for this Rust/helper slice beyond the repo hooks
- migrations: N/A
- UI render: N/A
- destructive/negative: N/A; invalid non-empty mode remains covered by config test
- review: CodeRabbit local `--base main` clean, summary `.git/coderabbit-review/20260519T184342Z/status.json`
- tests added/expanded: `parakeet-ptt/src/config.rs`
- preexisting failures left: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README documentation clarifying that the Wayland overlay configuration environment variable with `auto` value probes overlay capability.
  * Enhanced help text to document overlay mode configuration options and their behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SystemicVoid/parakeet-stt/pull/99?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->