### PR TITLE
fix(helper): preserve multiline start args

### DIFF
--- a/parakeet-stt-daemon/tests/test_stt_helper_runtime_profiles.py
+++ b/parakeet-stt-daemon/tests/test_stt_helper_runtime_profiles.py
@@ -56,6 +56,40 @@ def _run_runtime_config(*args: str, extra_env: dict[str, str] | None = None) -> 
     return config
 
 
+def _run_get_stt_start_args(
+    *args: str,
+    extra_env: dict[str, str] | None = None,
+) -> list[str]:
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("PARAKEET_") and not key.startswith("_STT_")
+    }
+    env["PARAKEET_ROOT"] = str(REPO_ROOT)
+    env["_STT_SKIP_LOCAL_OVERRIDES"] = "1"
+    if extra_env:
+        env.update(extra_env)
+
+    command_line = " ".join(shlex.quote(arg) for arg in args)
+    command = [
+        "bash",
+        "-lc",
+        (
+            f"source {shlex.quote(str(HELPER_PATH))} && "
+            f"get_stt_start_args start_args {command_line} && "
+            "printf '%s\\0' \"${start_args[@]}\""
+        ),
+    ]
+    completed = subprocess.run(
+        command,
+        check=True,
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+    )
+    return [item.decode() for item in completed.stdout.split(b"\0") if item]
+
+
 def _run_runtime_match(*args: str) -> bool:
     env = {
         key: value
@@ -250,6 +284,30 @@ def test_helper_start_cli_llm_base_url_overrides_env() -> None:
 
     assert config["llm_base_url"] == "http://cli.local:8182/custom"
     assert config["managed_llm_api_base_url"] == "http://127.0.0.1:8080/v1"
+
+
+def test_get_stt_start_args_preserves_multiline_text_with_scalar_option() -> None:
+    prompt = "\n".join(
+        [
+            "Return only final text.",
+            "--unknown-option should remain prompt text.",
+            "Keep shell-sensitive content: $HOME \"quoted\" 'single'.",
+        ]
+    )
+
+    args = _run_get_stt_start_args(
+        "streaming",
+        "--llm-system-prompt",
+        prompt,
+        "--uinput-dwell-ms",
+        "42",
+    )
+
+    prompt_index = args.index("--llm-system-prompt")
+    dwell_index = args.index("--uinput-dwell-ms")
+    assert args[prompt_index + 1] == prompt
+    assert args[dwell_index + 1] == "42"
+    assert "--unknown-option should remain prompt text." not in args
 
 
 def test_runtime_match_accepts_cpu_fallback_for_accelerator_request() -> None:

--- a/parakeet-stt-daemon/tests/test_stt_helper_runtime_profiles.py
+++ b/parakeet-stt-daemon/tests/test_stt_helper_runtime_profiles.py
@@ -90,6 +90,34 @@ def _run_get_stt_start_args(
     return [item.decode() for item in completed.stdout.split(b"\0") if item]
 
 
+def _run_get_stt_start_args_with_malformed_export() -> subprocess.CompletedProcess[str]:
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("PARAKEET_") and not key.startswith("_STT_")
+    }
+    env["PARAKEET_ROOT"] = str(REPO_ROOT)
+    env["_STT_SKIP_LOCAL_OVERRIDES"] = "1"
+
+    command = [
+        "bash",
+        "-lc",
+        (
+            f"source {shlex.quote(str(HELPER_PATH))} && "
+            'stt() { printf "%s\\n" "unterminated\'"; } && '
+            "get_stt_start_args start_args"
+        ),
+    ]
+    return subprocess.run(
+        command,
+        check=False,
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+
+
 def _run_runtime_match(*args: str) -> bool:
     env = {
         key: value
@@ -308,6 +336,13 @@ def test_get_stt_start_args_preserves_multiline_text_with_scalar_option() -> Non
     assert args[prompt_index + 1] == prompt
     assert args[dwell_index + 1] == "42"
     assert "--unknown-option should remain prompt text." not in args
+
+
+def test_get_stt_start_args_fails_on_malformed_shell_export() -> None:
+    completed = _run_get_stt_start_args_with_malformed_export()
+
+    assert completed.returncode != 0
+    assert "get_stt_start_args: failed to parse __start-cli-args-shell output" in completed.stderr
 
 
 def test_runtime_match_accepts_cpu_fallback_for_accelerator_request() -> None:

--- a/scripts/stt-helper.sh
+++ b/scripts/stt-helper.sh
@@ -1998,7 +1998,10 @@ get_stt_start_args() {
     # __start-cli-args-shell emits one printf-%q encoded vector; eval rebuilds
     # the original array without treating embedded newlines as separators.
     local -a parsed_start_args
-    eval "parsed_start_args=($output)"
+    if ! eval "parsed_start_args=($output)"; then
+        echo "get_stt_start_args: failed to parse __start-cli-args-shell output" >&2
+        return 1
+    fi
     local arg
     for arg in "${parsed_start_args[@]}"; do
         start_args_out_ref+=("$arg")

--- a/scripts/stt-helper.sh
+++ b/scripts/stt-helper.sh
@@ -1257,6 +1257,30 @@ CLIENTCMD
             _build_start_cli_args start_cli_args "$launch_profile"
             printf "%s\n" "${start_cli_args[@]}"
             ;;
+        __start-cli-args-shell)
+            local injection_mode paste_backend_failure_policy
+            local uinput_dwell_ms paste_seat paste_write_primary
+            local completion_sound completion_sound_path completion_sound_volume overlay_enabled overlay_adaptive_width
+            local llm_pre_modifier_key llm_base_url llm_model llm_timeout_seconds llm_max_tokens llm_temperature llm_system_prompt llm_overlay_stream
+            local daemon_device daemon_streaming_enabled daemon_chunk_secs daemon_right_context_secs daemon_left_context_secs daemon_batch_size daemon_overlay_events_enabled
+            local -a start_cli_args
+            local launch_profile
+            if _resolve_start_launch_profile launch_profile "${1:-}"; then
+                shift
+            fi
+
+            if ! _resolve_start_runtime_config "$launch_profile" "$@"; then
+                local resolve_status=$?
+                if [ "$resolve_status" -eq 2 ]; then
+                    return 0
+                fi
+                return "$resolve_status"
+            fi
+
+            _build_start_cli_args start_cli_args "$launch_profile"
+            _args_to_shell_words start_cli_args
+            printf "\n"
+            ;;
         __start-runtime-config)
             local injection_mode paste_backend_failure_policy
             local uinput_dwell_ms paste_seat paste_write_primary
@@ -1970,9 +1994,13 @@ get_stt_start_args() {
     local -n start_args_out_ref="$out_name"
     start_args_out_ref=()
     local output
-    output="$(stt __start-cli-args "$@")" || return $?
+    output="$(stt __start-cli-args-shell "$@")" || return $?
+    # __start-cli-args-shell emits one printf-%q encoded vector; eval rebuilds
+    # the original array without treating embedded newlines as separators.
+    local -a parsed_start_args
+    eval "parsed_start_args=($output)"
     local arg
-    while IFS= read -r arg; do
+    for arg in "${parsed_start_args[@]}"; do
         start_args_out_ref+=("$arg")
-    done <<<"$output"
+    done
 }


### PR DESCRIPTION
Fixes #88.

## Summary
- add a shell-quoted Helper start-args export path for callers that need exact round-tripping
- update `get_stt_start_args` to import that shell-quoted vector so newline-containing text options stay single arguments
- add a regression covering multiline `--llm-system-prompt` alongside scalar `--uinput-dwell-ms`, matching the paste-gap harness consumption path

## Verification (#88)
- targeted: `uv run pytest tests/test_stt_helper_runtime_profiles.py::test_get_stt_start_args_preserves_multiline_text_with_scalar_option` -> FAILED before fix (prompt truncated at first newline), then PASSED after fix
- targeted/full helper: `uv run pytest tests/test_stt_helper_runtime_profiles.py` -> PASSED (`24 passed`)
- full suite: `uv run pytest` from `parakeet-stt-daemon/` -> PASSED (`181 passed`)
- lint/format: `uv run ruff check src tests` -> PASSED; `uv run ruff format --check src tests` -> PASSED
- types: `uv run ty check` -> PASSED
- CLI/script smoke: `bash -n scripts/stt-helper.sh`, `shellcheck scripts/stt-helper.sh`, `source scripts/stt-helper.sh && stt help start`, `source scripts/stt-helper.sh && stt help llm` -> PASSED
- pre-commit: `prek run --all-files` -> PASSED; `prek run --stage pre-push --all-files` -> PASSED
- static/security: shellcheck covered touched shell; no security-specific change
- dead-code: N/A, no dedicated dead-code gate for this helper/test slice beyond repo hooks
- migrations: N/A
- UI render: N/A
- destructive/negative: N/A
- review: CodeRabbit local `--base main` clean, summary `.git/coderabbit-review/20260519T185832Z/status.json`
- tests added/expanded: `parakeet-stt-daemon/tests/test_stt_helper_runtime_profiles.py`
- preexisting failures left: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shell-oriented start-args output to reliably emit shell-escaped CLI arguments so multi-line or whitespace-containing values are preserved.

* **Bug Fixes**
  * Improved parsing of CLI arguments to correctly preserve configuration values containing multiple lines and embedded whitespace, ensuring complex options remain intact as single arguments.

* **Tests**
  * Added runtime-profile tests covering preservation of multiline options and behavior when a malformed shell export is emitted.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SystemicVoid/parakeet-stt/pull/100?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->