### PR TITLE
fix(helper): tolerate optional status runtime fields

### DIFF
--- a/parakeet-stt-daemon/tests/test_stt_helper_runtime_profiles.py
+++ b/parakeet-stt-daemon/tests/test_stt_helper_runtime_profiles.py
@@ -175,6 +175,9 @@ def _run_status_runtime_truth(payload_path: Path) -> dict[str, str]:
 
 def _status_payload(**overrides: object) -> dict[str, object]:
     payload: dict[str, object] = {
+        "type": "status",
+        "state": "idle",
+        "sessions_active": 0,
         "device": "cuda",
         "effective_device": "cpu",
         "streaming_enabled": True,
@@ -353,6 +356,14 @@ def test_runtime_match_rejects_accelerator_when_cpu_requested() -> None:
     assert _run_runtime_match("cpu", "false", "false", "cuda", "false", "false") is False
 
 
+def test_runtime_match_accepts_missing_optional_overlay_truth() -> None:
+    assert _run_runtime_match("cuda", "true", "true", "cuda", "true", "") is True
+
+
+def test_runtime_match_rejects_present_overlay_mismatch() -> None:
+    assert _run_runtime_match("cuda", "true", "true", "cuda", "true", "false") is False
+
+
 def test_client_ready_once_rejects_pid_without_current_readiness_logs(tmp_path: Path) -> None:
     marker = "current-client-start"
     log_path = tmp_path / "client.log"
@@ -404,26 +415,7 @@ def test_client_ready_once_requires_current_hotkey_and_connection_logs(tmp_path:
 def test_daemon_status_runtime_truth_reads_status_fields_unchanged(tmp_path: Path) -> None:
     payload_path = tmp_path / "status.json"
     payload_path.write_text(
-        json.dumps(
-            {
-                "device": "cuda",
-                "effective_device": "cpu",
-                "streaming_enabled": True,
-                "stream_helper_active": False,
-                "stream_helper_scope": "live_session_only",
-                "stream_fallback_reason": None,
-                "stream_path_executed": False,
-                "stream_chunks_processed": 0,
-                "chunk_secs": 2.4,
-                "finalization_mode": "offline_seal",
-                "final_audio_source": "canonical_session_audio",
-                "tail_trim_mode": "rms",
-                "vad_enabled": True,
-                "vad_active": False,
-                "vad_fallback_reason": "load_failed:missing_dependency:onnxruntime",
-                "overlay_events_enabled": True,
-            }
-        ),
+        json.dumps(_status_payload()),
         encoding="utf-8",
     )
 
@@ -449,29 +441,41 @@ def test_daemon_status_runtime_truth_reads_status_fields_unchanged(tmp_path: Pat
     }
 
 
+def test_daemon_status_runtime_truth_accepts_minimal_protocol_status(
+    tmp_path: Path,
+) -> None:
+    payload_path = tmp_path / "status.json"
+    payload_path.write_text(
+        json.dumps({"type": "status", "state": "idle", "sessions_active": 0}),
+        encoding="utf-8",
+    )
+
+    truth = _run_status_runtime_truth(payload_path)
+
+    assert truth == {
+        "device": "",
+        "effective_device": "",
+        "streaming_enabled": "",
+        "stream_helper_active": "",
+        "stream_helper_scope": "",
+        "stream_fallback_reason": "",
+        "stream_path_executed": "",
+        "stream_chunks_processed": "",
+        "chunk_secs": "",
+        "finalization_mode": "",
+        "final_audio_source": "",
+        "tail_trim_mode": "",
+        "vad_enabled": "",
+        "vad_active": "",
+        "vad_fallback_reason": "",
+        "overlay_events_enabled": "",
+    }
+
+
 def test_daemon_status_runtime_truth_normalizes_numeric_string(tmp_path: Path) -> None:
     payload_path = tmp_path / "status.json"
     payload_path.write_text(
-        json.dumps(
-            {
-                "device": "cuda",
-                "effective_device": "cpu",
-                "streaming_enabled": True,
-                "stream_helper_active": False,
-                "stream_helper_scope": "live_session_only",
-                "stream_fallback_reason": None,
-                "stream_path_executed": False,
-                "stream_chunks_processed": 0,
-                "chunk_secs": "2.4000",
-                "finalization_mode": "offline_seal",
-                "final_audio_source": "canonical_session_audio",
-                "tail_trim_mode": "rms",
-                "vad_enabled": True,
-                "vad_active": False,
-                "vad_fallback_reason": "load_failed:missing_dependency:onnxruntime",
-                "overlay_events_enabled": True,
-            }
-        ),
+        json.dumps(_status_payload(chunk_secs="2.4000")),
         encoding="utf-8",
     )
 
@@ -512,26 +516,7 @@ def test_daemon_status_runtime_truth_rejects_invalid_stream_chunk_count(
 def test_daemon_status_runtime_truth_rejects_non_finite_numeric_string(tmp_path: Path) -> None:
     payload_path = tmp_path / "status.json"
     payload_path.write_text(
-        json.dumps(
-            {
-                "device": "cuda",
-                "effective_device": "cpu",
-                "streaming_enabled": True,
-                "stream_helper_active": False,
-                "stream_helper_scope": "live_session_only",
-                "stream_fallback_reason": None,
-                "stream_path_executed": False,
-                "stream_chunks_processed": 0,
-                "chunk_secs": "inf",
-                "finalization_mode": "offline_seal",
-                "final_audio_source": "canonical_session_audio",
-                "tail_trim_mode": "rms",
-                "vad_enabled": True,
-                "vad_active": False,
-                "vad_fallback_reason": "load_failed:missing_dependency:onnxruntime",
-                "overlay_events_enabled": True,
-            }
-        ),
+        json.dumps(_status_payload(chunk_secs="inf")),
         encoding="utf-8",
     )
 
@@ -543,26 +528,7 @@ def test_status_runtime_truth_rejects_non_finite_numeric_tokens(tmp_path: Path) 
     for index, chunk_secs in enumerate((float("inf"), float("-inf"), float("nan"))):
         payload_path = tmp_path / f"status-{index}.json"
         payload_path.write_text(
-            json.dumps(
-                {
-                    "device": "cuda",
-                    "effective_device": "cpu",
-                    "streaming_enabled": True,
-                    "stream_helper_active": False,
-                    "stream_helper_scope": "live_session_only",
-                    "stream_fallback_reason": None,
-                    "stream_path_executed": False,
-                    "stream_chunks_processed": 0,
-                    "chunk_secs": chunk_secs,
-                    "finalization_mode": "offline_seal",
-                    "final_audio_source": "canonical_session_audio",
-                    "tail_trim_mode": "rms",
-                    "vad_enabled": True,
-                    "vad_active": False,
-                    "vad_fallback_reason": "load_failed:missing_dependency:onnxruntime",
-                    "overlay_events_enabled": True,
-                }
-            ),
+            json.dumps(_status_payload(chunk_secs=chunk_secs)),
             encoding="utf-8",
         )
 

--- a/scripts/stt-helper.sh
+++ b/scripts/stt-helper.sh
@@ -518,7 +518,9 @@ stt() {
 
         _daemon_effective_device_matches_request "$requested_device" "$current_effective_device" || return 1
         [ "$current_streaming_enabled" = "$requested_streaming_enabled" ] || return 1
-        [ "$current_overlay_events_enabled" = "$requested_overlay_events_enabled" ] || return 1
+        if [ -n "$current_overlay_events_enabled" ] && [ "$current_overlay_events_enabled" != "$requested_overlay_events_enabled" ]; then
+            return 1
+        fi
         return 0
     }
 
@@ -757,6 +759,19 @@ try:
 except Exception:
     sys.exit(1)
 
+if not isinstance(payload, dict):
+    sys.exit(1)
+
+if payload.get("type") != "status":
+    sys.exit(1)
+
+if payload.get("state") not in {"idle", "listening", "processing"}:
+    sys.exit(1)
+
+sessions_active = payload.get("sessions_active")
+if isinstance(sessions_active, bool) or not isinstance(sessions_active, int) or sessions_active < 0:
+    sys.exit(1)
+
 fields = (
     "device",
     "effective_device",
@@ -789,20 +804,19 @@ numeric_fields = {
 non_negative_int_fields = {
     "stream_chunks_processed",
 }
-for key in fields:
-    if key not in payload:
-        sys.exit(1)
 
 for key in fields:
-    value = payload[key]
+    value = payload.get(key)
+    if value is None:
+        print(f"{key}=")
+        continue
+
     if key in bool_fields:
         if not isinstance(value, bool):
             sys.exit(1)
         print(f"{key}={'true' if value else 'false'}")
     elif key in non_negative_int_fields:
-        if value is None:
-            print(f"{key}=")
-        elif isinstance(value, bool):
+        if isinstance(value, bool):
             sys.exit(1)
         elif isinstance(value, int):
             if value < 0:
@@ -815,9 +829,7 @@ for key in fields:
         else:
             sys.exit(1)
     elif key in numeric_fields:
-        if value is None:
-            print(f"{key}=")
-        elif isinstance(value, bool):
+        if isinstance(value, bool):
             sys.exit(1)
         elif isinstance(value, (int, float)):
             if not math.isfinite(float(value)):
@@ -834,12 +846,9 @@ for key in fields:
         else:
             sys.exit(1)
     else:
-        if value is not None and not isinstance(value, str):
+        if not isinstance(value, str):
             sys.exit(1)
-        if value is None:
-            print(f"{key}=")
-        else:
-            print(f"{key}={value}")
+        print(f"{key}={value}")
 PY
     }
 
@@ -1448,6 +1457,9 @@ EOF
                                 overlay_events_enabled) current_overlay_events_enabled="$value" ;;
                             esac
                         done <<< "$runtime_truth"
+                        if [ -z "$current_effective_device" ]; then
+                            current_effective_device="$current_device"
+                        fi
                         echo "   - Existing daemon runtime: device=$current_device, effective_device=$current_effective_device, streaming_enabled=$current_streaming_enabled, overlay_events_enabled=$current_overlay_events_enabled"
                         if _daemon_runtime_matches_request \
                             "$daemon_device" \


### PR DESCRIPTION
## Summary

- validate only the protocol-mandated status envelope before parsing helper runtime truth
- emit blank values for absent optional runtime fields instead of treating the status as unparseable
- avoid daemon restarts when optional overlay status truth is absent, while still rejecting a reported overlay mismatch

Fixes #92.

## Verification

- parent/head regression: `uv run pytest tests/test_stt_helper_runtime_profiles.py -q` failed before the helper fix on the new minimal-status and missing-overlay tests, then passed after the fix
- `uv run pytest tests/test_stt_helper_runtime_profiles.py -q`
- `bash -n scripts/stt-helper.sh`
- `source scripts/stt-helper.sh && stt help start`
- `source scripts/stt-helper.sh && stt help llm`
- `uv run ruff check tests/test_stt_helper_runtime_profiles.py`
- `prek run --files scripts/stt-helper.sh parakeet-stt-daemon/tests/test_stt_helper_runtime_profiles.py`
- `prek run --stage pre-push --files parakeet-stt-daemon/tests/test_stt_helper_runtime_profiles.py`
- CodeRabbit local: `.git/coderabbit-review/20260519T192022Z/status.json` (`findings_count: 0`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daemon reuse logic to avoid unnecessary restarts when overlay events state is unset
  * Enhanced status payload validation with stricter structural checks
  * Improved field extraction handling for missing or null values
  * Better device selection logic during start operations

* **Tests**
  * Added comprehensive test coverage for runtime matching overlay truth scenarios
  * Enhanced test infrastructure for status payload generation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SystemicVoid/parakeet-stt/pull/101?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->