### PR TITLE
fix(ptt): report injection completion latency

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -190,6 +190,8 @@ The canonical machine-checkable contract and fixtures live under [`docs/protocol
       "confidence": 0.91
     }
     ```
+    `latency_ms` is daemon-side final-result latency for the Seal path. It does not include Client
+    queueing, clipboard writes, paste shortcuts, or other Injection work.
   - `error`
     ```json
     {
@@ -261,6 +263,9 @@ Clients must also tolerate unknown error codes and unknown additional fields.
 Fields beyond `state` and `sessions_active` in `status` should be treated as optional.
 `audio_stop_ms`, `finalize_ms`, `infer_ms`, and `send_ms` represent the last completed session's stage
 durations. `last_*` fields are retained for compatibility and will be deprecated after client uptake.
+Client logs expose user-visible Injection completion timings separately with
+`enqueue_to_injection_complete_ms`, `hotkey_up_elapsed_ms_at_completion`, and
+`stop_message_elapsed_ms_at_completion`.
 `gpu_mem_mb` reports CUDA reserved memory for the daemon process when running on a CUDA device.
 
 ---

--- a/docs/stt-troubleshooting.md
+++ b/docs/stt-troubleshooting.md
@@ -79,7 +79,9 @@ the Helper should read those fields from `/status` instead of re-deriving them.
 - Successful runs show `/tmp/parakeet-ptt.log` entries like:
   - “Starting hotkey loop; press Right Ctrl to talk”
   - “Connected to daemon”
-  - Session start/stop and “final result received … latency_ms=xx”
+  - Session start/stop and “final result received … daemon_latency_ms=xx”
+  - Injector completion lines with `enqueue_to_injection_complete_ms`, `hotkey_up_elapsed_ms_at_completion`,
+    and `stop_message_elapsed_ms_at_completion`
 - The daemon log `/tmp/parakeet-daemon.log` consistently shows a healthy startup on `cuda`, audio capture starting, websocket accepted, and session start/stop pairs with reasonable inference times.
 - On failing runs, the client log was empty or missing; the helper reported a rebuild failure. No daemon errors were present during these failures.
 

--- a/parakeet-ptt/src/app.rs
+++ b/parakeet-ptt/src/app.rs
@@ -373,7 +373,7 @@ pub async fn run_demo(
                 let to_inject = override_text.as_deref().unwrap_or(&text).to_string();
                 info!(
                     session = %session_id,
-                    latency_ms,
+                    daemon_latency_ms = latency_ms,
                     audio_ms,
                     "final result received"
                 );
@@ -610,7 +610,7 @@ pub async fn run(config: ClientConfig, ports: ClientPorts) -> Result<()> {
                                             } if active_intent == Some(SessionIntent::LlmQuery) => {
                                                 info!(
                                                     session = %session_id,
-                                                    latency_ms,
+                                                    daemon_latency_ms = latency_ms,
                                                     audio_ms,
                                                     "final result received in llm_query mode"
                                                 );
@@ -870,10 +870,13 @@ fn handle_injection_report(
                 queue_wait_ms = report.queue_wait_ms,
                 run_ms = report.run_ms,
                 total_worker_ms = report.total_worker_ms,
+                enqueue_to_injection_complete_ms = report.enqueue_to_injection_complete_ms,
                 hotkey_up_elapsed_ms_at_enqueue = report.hotkey_up_elapsed_ms_at_enqueue,
                 stop_message_elapsed_ms_at_enqueue = report.stop_message_elapsed_ms_at_enqueue,
                 hotkey_up_elapsed_ms_at_worker_start = report.hotkey_up_elapsed_ms_at_worker_start,
                 stop_message_elapsed_ms_at_worker_start = report.stop_message_elapsed_ms_at_worker_start,
+                hotkey_up_elapsed_ms_at_completion = report.hotkey_up_elapsed_ms_at_completion,
+                stop_message_elapsed_ms_at_completion = report.stop_message_elapsed_ms_at_completion,
                 error = %error,
                 "injector worker reported failure"
             );
@@ -887,10 +890,13 @@ fn handle_injection_report(
                 queue_wait_ms = report.queue_wait_ms,
                 run_ms = report.run_ms,
                 total_worker_ms = report.total_worker_ms,
+                enqueue_to_injection_complete_ms = report.enqueue_to_injection_complete_ms,
                 hotkey_up_elapsed_ms_at_enqueue = report.hotkey_up_elapsed_ms_at_enqueue,
                 stop_message_elapsed_ms_at_enqueue = report.stop_message_elapsed_ms_at_enqueue,
                 hotkey_up_elapsed_ms_at_worker_start = report.hotkey_up_elapsed_ms_at_worker_start,
                 stop_message_elapsed_ms_at_worker_start = report.stop_message_elapsed_ms_at_worker_start,
+                hotkey_up_elapsed_ms_at_completion = report.hotkey_up_elapsed_ms_at_completion,
+                stop_message_elapsed_ms_at_completion = report.stop_message_elapsed_ms_at_completion,
                 "injector worker completed job"
             );
             audio_feedback.play_completion();
@@ -905,10 +911,13 @@ fn handle_injection_report(
                 queue_wait_ms = report.queue_wait_ms,
                 run_ms = report.run_ms,
                 total_worker_ms = report.total_worker_ms,
+                enqueue_to_injection_complete_ms = report.enqueue_to_injection_complete_ms,
                 hotkey_up_elapsed_ms_at_enqueue = report.hotkey_up_elapsed_ms_at_enqueue,
                 stop_message_elapsed_ms_at_enqueue = report.stop_message_elapsed_ms_at_enqueue,
                 hotkey_up_elapsed_ms_at_worker_start = report.hotkey_up_elapsed_ms_at_worker_start,
                 stop_message_elapsed_ms_at_worker_start = report.stop_message_elapsed_ms_at_worker_start,
+                hotkey_up_elapsed_ms_at_completion = report.hotkey_up_elapsed_ms_at_completion,
+                stop_message_elapsed_ms_at_completion = report.stop_message_elapsed_ms_at_completion,
                 error = ?error,
                 "injector worker reported inconsistent error classification"
             );
@@ -1491,10 +1500,13 @@ mod tests {
                 queue_wait_ms: 1,
                 run_ms: 2,
                 total_worker_ms: 3,
+                enqueue_to_injection_complete_ms: 3,
                 hotkey_up_elapsed_ms_at_enqueue: None,
                 stop_message_elapsed_ms_at_enqueue: None,
                 hotkey_up_elapsed_ms_at_worker_start: None,
                 stop_message_elapsed_ms_at_worker_start: None,
+                hotkey_up_elapsed_ms_at_completion: None,
+                stop_message_elapsed_ms_at_completion: None,
                 error_kind: Some(InjectionErrorKind::BackendFailure),
                 error: Some("stage=backend synthetic failure".to_string()),
             },

--- a/parakeet-ptt/src/client_session.rs
+++ b/parakeet-ptt/src/client_session.rs
@@ -59,7 +59,7 @@ pub(crate) async fn handle_server_message<S: OverlaySink>(
             info!(
                 session = %session_id,
                 origin = InjectionOrigin::RawFinalResult.as_str(),
-                latency_ms,
+                daemon_latency_ms = latency_ms,
                 audio_ms,
                 state_at_enqueue = state_label(state),
                 hotkey_up_elapsed_ms_at_enqueue,
@@ -252,7 +252,7 @@ mod tests {
     use crate::state::PttState;
     use anyhow::anyhow;
     use tokio::sync::mpsc;
-    use tokio::time::timeout;
+    use tokio::time::{timeout, Instant as TokioInstant};
     use uuid::Uuid;
 
     use super::handle_server_message;
@@ -363,6 +363,74 @@ mod tests {
                 .expect("recording lock should be available")
                 .as_slice(),
             &["direct final result".to_string()]
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn final_result_report_includes_user_visible_completion_latency() {
+        let seen_injection = Arc::new(Mutex::new(Vec::<String>::new()));
+        let injector = Arc::new(RecordingRunner {
+            seen: Arc::clone(&seen_injection),
+        });
+        let (worker, mut reports) = spawn_injector_worker_with_capacity(injector, 4);
+        let mut state = PttState::new();
+        let session_id = state
+            .begin_listening()
+            .expect("state should begin listening");
+        state.stop_listening();
+        let mut overlay_router = OverlayRouter::new(NoopOverlaySink, None);
+        let mut parent_focus_by_session = HashMap::new();
+        let hotkey_up_at = TokioInstant::now() - Duration::from_millis(50);
+        let stop_message_at = TokioInstant::now() - Duration::from_millis(40);
+
+        handle_server_message(
+            ServerMessage::FinalResult {
+                session_id,
+                text: "timed final result".to_string(),
+                latency_ms: 44,
+                audio_ms: 1200,
+                lang: Some("en".to_string()),
+                confidence: Some(0.92),
+            },
+            &mut state,
+            &mut overlay_router,
+            &worker,
+            &mut parent_focus_by_session,
+            Some(hotkey_up_at),
+            Some((session_id, stop_message_at)),
+        )
+        .await
+        .expect("final result should enqueue");
+
+        let report = timeout(Duration::from_secs(1), reports.recv())
+            .await
+            .expect("injection report should arrive")
+            .expect("report channel should stay open");
+        assert!(report.error.is_none());
+        assert_eq!(report.daemon_latency_ms, 44);
+        assert_eq!(
+            report.enqueue_to_injection_complete_ms,
+            report.total_worker_ms
+        );
+        assert_eq!(
+            report.hotkey_up_elapsed_ms_at_completion,
+            report
+                .hotkey_up_elapsed_ms_at_enqueue
+                .map(|elapsed| elapsed.saturating_add(report.enqueue_to_injection_complete_ms))
+        );
+        assert_eq!(
+            report.stop_message_elapsed_ms_at_completion,
+            report
+                .stop_message_elapsed_ms_at_enqueue
+                .map(|elapsed| elapsed.saturating_add(report.enqueue_to_injection_complete_ms))
+        );
+        assert!(
+            report.hotkey_up_elapsed_ms_at_completion
+                >= report.hotkey_up_elapsed_ms_at_worker_start
+        );
+        assert!(
+            report.stop_message_elapsed_ms_at_completion
+                >= report.stop_message_elapsed_ms_at_worker_start
         );
     }
 

--- a/parakeet-ptt/src/injector_runtime.rs
+++ b/parakeet-ptt/src/injector_runtime.rs
@@ -115,10 +115,13 @@ pub(crate) struct InjectionReport {
     pub(crate) queue_wait_ms: u64,
     pub(crate) run_ms: u64,
     pub(crate) total_worker_ms: u64,
+    pub(crate) enqueue_to_injection_complete_ms: u64,
     pub(crate) hotkey_up_elapsed_ms_at_enqueue: Option<u64>,
     pub(crate) stop_message_elapsed_ms_at_enqueue: Option<u64>,
     pub(crate) hotkey_up_elapsed_ms_at_worker_start: Option<u64>,
     pub(crate) stop_message_elapsed_ms_at_worker_start: Option<u64>,
+    pub(crate) hotkey_up_elapsed_ms_at_completion: Option<u64>,
+    pub(crate) stop_message_elapsed_ms_at_completion: Option<u64>,
     pub(crate) error_kind: Option<InjectionErrorKind>,
     pub(crate) error: Option<String>,
 }
@@ -1262,6 +1265,11 @@ pub(crate) fn spawn_injector_worker_with_capacity(
                 tokio::task::spawn_blocking(move || runner_for_job.run(&job_for_runner)).await;
             let run_ms = worker_started.elapsed().as_millis() as u64;
             let total_worker_ms = queue_wait_ms.saturating_add(run_ms);
+            let enqueue_to_injection_complete_ms = total_worker_ms;
+            let hotkey_up_elapsed_ms_at_completion = hotkey_up_elapsed_ms_at_enqueue
+                .map(|elapsed| elapsed.saturating_add(enqueue_to_injection_complete_ms));
+            let stop_message_elapsed_ms_at_completion = stop_message_elapsed_ms_at_enqueue
+                .map(|elapsed| elapsed.saturating_add(enqueue_to_injection_complete_ms));
 
             let mut run_output: Option<InjectionRunOutput> = None;
             let (error_kind, error) = match result {
@@ -1294,10 +1302,13 @@ pub(crate) fn spawn_injector_worker_with_capacity(
                 queue_wait_ms,
                 run_ms,
                 total_worker_ms,
+                enqueue_to_injection_complete_ms,
                 hotkey_up_elapsed_ms_at_enqueue,
                 stop_message_elapsed_ms_at_enqueue,
                 hotkey_up_elapsed_ms_at_worker_start,
                 stop_message_elapsed_ms_at_worker_start,
+                hotkey_up_elapsed_ms_at_completion,
+                stop_message_elapsed_ms_at_completion,
                 error_kind,
                 error,
             };


### PR DESCRIPTION
## Summary
- expose explicit injector completion timing fields: enqueue-to-complete plus hotkey-up/stop-message elapsed-at-completion
- keep daemon final-result latency distinct in client logs with daemon_latency_ms naming
- document the daemon Seal-path latency versus user-visible injection completion metrics

## Regression proof
- Before fix: cargo test final_result_report_includes_user_visible_completion_latency failed to compile because InjectionReport did not expose completion timing fields.
- After fix: cargo test final_result_report_includes_user_visible_completion_latency passed.

## Validation
- cargo test final_result_report_includes_user_visible_completion_latency
- cargo test -q
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- prek run --files docs/SPEC.md docs/stt-troubleshooting.md parakeet-ptt/src/app.rs parakeet-ptt/src/client_session.rs parakeet-ptt/src/injector_runtime.rs
- prek run --stage pre-push --files parakeet-ptt/src/app.rs parakeet-ptt/src/client_session.rs parakeet-ptt/src/injector_runtime.rs
- CodeRabbit local review clean: .git/coderabbit-review/20260519T200817Z/status.json

Fixes #90

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified latency measurement definitions in protocol specification.
  * Updated troubleshooting guide with current log format examples.

* **New Features**
  * Added injection completion timing metrics to reports: end-to-end injection duration, hotkey elapsed time, and stop-message elapsed time.

* **Tests**
  * Added coverage for injection completion latency reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SystemicVoid/parakeet-stt/pull/103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->