### PR TITLE
fix(daemon): reject mismatched in-memory sample rates

### DIFF
--- a/parakeet-stt-daemon/src/parakeet_stt_daemon/model.py
+++ b/parakeet-stt-daemon/src/parakeet_stt_daemon/model.py
@@ -119,6 +119,40 @@ def _model_stride_secs(model: ASRModel) -> float:
     return max(window_stride * max(1, subsampling), 0.001)
 
 
+def _model_sample_rate(model: ASRModel) -> int:
+    cfg = getattr(model, "_cfg", None) or getattr(model, "cfg", None)
+    preprocessor_cfg = _get_cfg_value(cfg, "preprocessor")
+    raw_sample_rate = _get_cfg_value(cfg, "sample_rate")
+    if raw_sample_rate is None:
+        raw_sample_rate = _get_cfg_value(preprocessor_cfg, "sample_rate")
+    try:
+        sample_rate = int(raw_sample_rate or 16_000)
+    except (TypeError, ValueError):
+        sample_rate = 16_000
+    return sample_rate if sample_rate > 0 else 16_000
+
+
+def _validate_in_memory_sample_rate(model: ASRModel, sample_rate: int) -> int:
+    try:
+        provided_sample_rate = int(sample_rate)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"In-memory transcription sample rate must be a positive integer, got {sample_rate!r}"
+        ) from exc
+    if provided_sample_rate <= 0:
+        raise ValueError(
+            f"In-memory transcription sample rate must be a positive integer, got {sample_rate!r}"
+        )
+    expected_sample_rate = _model_sample_rate(model)
+    if provided_sample_rate != expected_sample_rate:
+        raise ValueError(
+            "In-memory transcription sample rate mismatch: "
+            f"received {provided_sample_rate} Hz but model expects {expected_sample_rate} Hz. "
+            "Resample audio before calling transcribe_samples."
+        )
+    return provided_sample_rate
+
+
 def _disable_cuda_graph_decoder_config(decoding_cfg: Any) -> bool:
     """Disable NeMo CUDA graph decoder flags before decoding objects are built."""
     changed = False
@@ -282,8 +316,7 @@ class ParakeetTranscriber:
 
     def warmup(self) -> None:
         """Run a trivial forward pass to pay the first-use cost."""
-        cfg = getattr(self.model, "_cfg", None)
-        sample_rate = getattr(cfg, "sample_rate", 16_000)
+        sample_rate = _model_sample_rate(self.model)
         silence = np.zeros((sample_rate,), dtype=np.float32)
         _ = self.transcribe_samples(silence, sample_rate=sample_rate)
 
@@ -305,6 +338,7 @@ class ParakeetTranscriber:
 
     def transcribe_samples(self, samples: np.ndarray, *, sample_rate: int = 16_000) -> str:
         """Transcribe in-memory audio and fall back to a temp wav on API mismatch."""
+        sample_rate = _validate_in_memory_sample_rate(self.model, sample_rate)
         audio = np.asarray(samples, dtype=np.float32).reshape(-1)
         if audio.size == 0:
             logger.debug("Skipping transcription for empty audio buffer")

--- a/parakeet-stt-daemon/tests/test_offline_benchmark_harness.py
+++ b/parakeet-stt-daemon/tests/test_offline_benchmark_harness.py
@@ -8,9 +8,12 @@ import importlib.util
 import sys
 import wave
 from pathlib import Path
+from typing import Any, cast
 
 import numpy as np
 import pytest
+
+from parakeet_stt_daemon.model import ParakeetTranscriber
 
 _CHECK_MODEL_PATH = Path(__file__).resolve().parents[1] / "check_model.py"
 _SPEC = importlib.util.spec_from_file_location("check_model", _CHECK_MODEL_PATH)
@@ -21,15 +24,18 @@ sys.modules[_SPEC.name] = _CHECK_MODEL
 _SPEC.loader.exec_module(_CHECK_MODEL)
 
 _CONSTANTS = importlib.import_module("check_model_lib.constants")
+_CORPUS = importlib.import_module("check_model_lib.corpus")
 _RUNNER = importlib.import_module("check_model_lib.runner")
 _RUNTIME = importlib.import_module("check_model_lib.runtime")
 
+BenchmarkCase = _CORPUS.BenchmarkCase
 PROBE_STREAM_BATCH_SIZE = _CONSTANTS.PROBE_STREAM_BATCH_SIZE
 PROBE_STREAM_CHUNK_SECS = _CONSTANTS.PROBE_STREAM_CHUNK_SECS
 PROBE_STREAM_LEFT_CONTEXT_SECS = _CONSTANTS.PROBE_STREAM_LEFT_CONTEXT_SECS
 PROBE_STREAM_RIGHT_CONTEXT_SECS = _CONSTANTS.PROBE_STREAM_RIGHT_CONTEXT_SECS
 SAMPLE_RATE = _CONSTANTS.SAMPLE_RATE
 read_wav_samples = _RUNTIME._read_wav_samples
+run_benchmark_once = _RUNNER._run_benchmark_once
 run_streaming_probe = _RUNNER.run_streaming_probe
 split_chunks = _RUNTIME.split_chunks
 write_wav = _RUNTIME.write_wav
@@ -583,6 +589,43 @@ def test_read_wav_samples_falls_back_on_expected_soundfile_read_errors(
 
     assert sample_rate == SAMPLE_RATE
     np.testing.assert_allclose(samples, np.array([0.0, 0.5], dtype=np.float32))
+
+
+def test_offline_benchmark_surfaces_non_16khz_transcribe_error(tmp_path: Path, monkeypatch) -> None:
+    class _ArrayOnlyModel:
+        def __init__(self) -> None:
+            self.cfg = argparse.Namespace(sample_rate=SAMPLE_RATE)
+
+        def transcribe(self, audio, **_kwargs):  # noqa: ANN001, ANN003
+            if isinstance(audio, list) and audio and isinstance(audio[0], np.ndarray):
+                return ["ok"]
+            raise AssertionError("unexpected benchmark transcription input")
+
+    audio_path = tmp_path / "sample_01.wav"
+    audio_path.write_bytes(b"not used because read is patched")
+    monkeypatch.setattr(
+        _RUNNER,
+        "_read_wav_samples",
+        lambda _path: (np.array([0.1, 0.2, 0.3], dtype=np.float32), 8_000),
+    )
+
+    with pytest.raises(ValueError, match=r"sample rate.*8000.*16000"):
+        run_benchmark_once(
+            cases=[
+                BenchmarkCase(
+                    sample_id="sample_01",
+                    audio_path=audio_path,
+                    reference="ok",
+                )
+            ],
+            transcriber=ParakeetTranscriber(model=cast(Any, _ArrayOnlyModel())),
+            streaming_transcriber=None,
+            bench_runtime="offline",
+            stream_silence_floor_db=-40.0,
+            stream_max_tail_trim_secs=0.35,
+            warmup_samples=0,
+            run_index=0,
+        )
 
 
 def test_split_chunks_rejects_non_positive_chunk_size() -> None:

--- a/parakeet-stt-daemon/tests/test_offline_in_memory_transcription.py
+++ b/parakeet-stt-daemon/tests/test_offline_in_memory_transcription.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 from typing import Any, cast
 
 import numpy as np
+import pytest
 
 from parakeet_stt_daemon import session_orchestrator as orchestrator_module
 from parakeet_stt_daemon.config import ServerSettings
@@ -19,8 +20,9 @@ from parakeet_stt_daemon.tail_trim import SealPathTailTrimmer, TailTrimOutcome
 
 
 class _ArrayModel:
-    def __init__(self) -> None:
+    def __init__(self, sample_rate: int = 16_000) -> None:
         self.calls: list[object] = []
+        self.cfg = SimpleNamespace(sample_rate=sample_rate)
 
     def transcribe(self, audio, **_kwargs):  # noqa: ANN001, ANN003
         self.calls.append(audio)
@@ -86,6 +88,28 @@ def test_transcribe_samples_uses_array_path_when_supported() -> None:
     first_call = model.calls[0]
     assert isinstance(first_call, list)
     assert isinstance(first_call[0], np.ndarray)
+
+
+def test_transcribe_samples_rejects_sample_rate_mismatch_without_model_call() -> None:
+    model = _ArrayModel()
+    transcriber = ParakeetTranscriber(model=cast(Any, model))
+    samples = np.array([0.1, -0.2, 0.3], dtype=np.float32)
+
+    with pytest.raises(ValueError, match=r"sample rate.*8000.*16000"):
+        transcriber.transcribe_samples(samples, sample_rate=8_000)
+
+    assert model.calls == []
+
+
+def test_transcribe_samples_accepts_configured_model_sample_rate() -> None:
+    model = _ArrayModel(sample_rate=8_000)
+    transcriber = ParakeetTranscriber(model=cast(Any, model))
+    samples = np.array([0.1, -0.2, 0.3], dtype=np.float32)
+
+    result = transcriber.transcribe_samples(samples, sample_rate=8_000)
+
+    assert result == "in memory text"
+    assert len(model.calls) == 1
 
 
 def test_transcribe_samples_falls_back_to_file_when_array_path_fails(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- validate in-memory transcription sample rates against the loaded model configuration before using NeMo's raw-array path
- keep configured non-16 kHz model rates valid while rejecting mismatched input rates with a clear error
- cover direct transcriber calls and offline benchmark runs so eval evidence surfaces the same behavior

## Regression proof
- Before fix: uv run pytest tests/test_offline_in_memory_transcription.py::test_transcribe_samples_rejects_sample_rate_mismatch_without_model_call tests/test_offline_benchmark_harness.py::test_offline_benchmark_surfaces_non_16khz_transcribe_error -q failed because both paths completed instead of raising.
- After fix: the same targeted tests pass.

## Validation
- uv run pytest tests/test_offline_in_memory_transcription.py::test_transcribe_samples_uses_array_path_when_supported tests/test_offline_in_memory_transcription.py::test_transcribe_samples_rejects_sample_rate_mismatch_without_model_call tests/test_offline_in_memory_transcription.py::test_transcribe_samples_accepts_configured_model_sample_rate tests/test_offline_benchmark_harness.py::test_offline_benchmark_surfaces_non_16khz_transcribe_error -q
- uv run pytest -q
- uv run ruff format --check src tests check_model.py check_model_lib
- uv run ruff check src tests check_model.py check_model_lib
- uv run ty check
- prek run --files parakeet-stt-daemon/src/parakeet_stt_daemon/model.py parakeet-stt-daemon/tests/test_offline_in_memory_transcription.py parakeet-stt-daemon/tests/test_offline_benchmark_harness.py
- prek run --stage pre-push --files parakeet-stt-daemon/src/parakeet_stt_daemon/model.py parakeet-stt-daemon/tests/test_offline_in_memory_transcription.py parakeet-stt-daemon/tests/test_offline_benchmark_harness.py
- CodeRabbit local review clean: .git/coderabbit-review/20260519T203216Z/status.json

Fixes #93

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to ensure audio sample rates match model expectations during transcription; raises errors for mismatches.

* **Tests**
  * Added regression tests for sample rate validation scenarios in offline and in-memory transcription modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SystemicVoid/parakeet-stt/pull/104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->