### PR TITLE
feat(daemon): encapsulate interim transcript sessions

### DIFF
--- a/parakeet-stt-daemon/src/parakeet_stt_daemon/overlay_interim.py
+++ b/parakeet-stt-daemon/src/parakeet_stt_daemon/overlay_interim.py
@@ -10,11 +10,16 @@ from __future__ import annotations
 
 import json
 import os
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
+from typing import Literal
 from uuid import UUID
 
 import numpy as np
 from loguru import logger
+
+InterimTranscriptSource = Literal["live", "stop_replay"]
+InterimTranscriber = Callable[[np.ndarray], Awaitable[str]]
 
 
 @dataclass(frozen=True)
@@ -22,6 +27,19 @@ class OverlayInterimTranscriptContext:
     session_id: UUID
     context_samples: int
     sample_rate: int
+
+
+@dataclass(frozen=True)
+class InterimTranscriptRuntimeFacts:
+    enabled: bool
+    last_source: InterimTranscriptSource | None
+    live_chunks_processed: int
+    live_updates_emitted: int
+    live_failed: bool
+    stop_replay_chunks_processed: int
+    stop_replay_updates_emitted: int
+    stop_replay_failed: bool
+    source_fallback_reason: str | None
 
 
 @dataclass(frozen=True)
@@ -33,6 +51,15 @@ class StabilizedInterimText:
 class _OverlayInterimTranscriptState:
     committed_tokens: list[str] = field(default_factory=list)
     draft_tokens: list[str] = field(default_factory=list)
+
+
+@dataclass
+class _InterimTranscriptSourceState:
+    rolling_audio: np.ndarray = field(default_factory=lambda: np.zeros((0,), dtype=np.float32))
+    chunks_processed: int = 0
+    updates_emitted: int = 0
+    failed: bool = False
+    fallback_reason: str | None = None
 
 
 class OverlayInterimTranscriptStabilizer:
@@ -213,6 +240,142 @@ class OverlayInterimTranscriptStabilizer:
         )
 
 
+class OverlayInterimTranscriptSession:
+    """Own one Session's user-visible interim transcript production."""
+
+    def __init__(
+        self,
+        *,
+        session_id: UUID,
+        sample_rate: int,
+        enabled: bool,
+    ) -> None:
+        self._session_id = session_id
+        self._sample_rate = int(sample_rate)
+        self._enabled = bool(enabled)
+        self._stabilizer = OverlayInterimTranscriptStabilizer()
+        self._source_state: dict[InterimTranscriptSource, _InterimTranscriptSourceState] = {
+            "live": _InterimTranscriptSourceState(),
+            "stop_replay": _InterimTranscriptSourceState(),
+        }
+        self._last_source: InterimTranscriptSource | None = None
+        self._source_fallback_reason: str | None = None
+
+    @property
+    def runtime_facts(self) -> InterimTranscriptRuntimeFacts:
+        live = self._source_state["live"]
+        stop_replay = self._source_state["stop_replay"]
+        return InterimTranscriptRuntimeFacts(
+            enabled=self._enabled,
+            last_source=self._last_source,
+            live_chunks_processed=live.chunks_processed,
+            live_updates_emitted=live.updates_emitted,
+            live_failed=live.failed,
+            stop_replay_chunks_processed=stop_replay.chunks_processed,
+            stop_replay_updates_emitted=stop_replay.updates_emitted,
+            stop_replay_failed=stop_replay.failed,
+            source_fallback_reason=self._source_fallback_reason,
+        )
+
+    async def accept_live_chunk(
+        self,
+        chunk: np.ndarray,
+        transcribe: InterimTranscriber,
+    ) -> str | None:
+        """Return the next visible live interim text update for a chunk, if any."""
+        return await self._accept_source_chunk("live", chunk, transcribe)
+
+    async def collect_stop_replay_updates(
+        self,
+        ready_chunks: list[np.ndarray],
+        transcribe: InterimTranscriber,
+    ) -> list[str]:
+        """Return stop-replay interim updates plus the final pending-tail flush."""
+        updates: list[str] = []
+        state = self._source_state["stop_replay"]
+        for chunk in ready_chunks:
+            if state.failed:
+                break
+            update = await self._accept_source_chunk("stop_replay", chunk, transcribe)
+            if update is not None:
+                updates.append(update)
+        flushed = self.flush_pending_tail()
+        if flushed is not None:
+            updates.append(flushed)
+        return updates
+
+    def flush_pending_tail(self) -> str | None:
+        flushed = self._stabilizer.flush_pending_tail()
+        return flushed.text if flushed is not None else None
+
+    async def _accept_source_chunk(
+        self,
+        source: InterimTranscriptSource,
+        chunk: np.ndarray,
+        transcribe: InterimTranscriber,
+    ) -> str | None:
+        if not self._enabled:
+            return None
+
+        state = self._source_state[source]
+        if state.failed:
+            return None
+
+        chunk_audio = np.asarray(chunk, dtype=np.float32).reshape(-1)
+        if chunk_audio.size == 0:
+            return None
+
+        state.chunks_processed += 1
+        state.rolling_audio = append_overlay_interim_context(state.rolling_audio, chunk_audio)
+        source_seq = self._stabilizer.next_source_seq(source)
+        context = self._context(int(state.rolling_audio.size))
+        try:
+            candidate = await transcribe(state.rolling_audio)
+        except Exception as exc:  # noqa: BLE001
+            self._record_source_failure(source, source_seq, context, exc.__class__.__name__)
+            return None
+
+        stabilized = self._stabilizer.accept(source, source_seq, candidate, context)
+        if stabilized is None:
+            return None
+
+        state.updates_emitted += 1
+        self._last_source = source
+        return stabilized.text
+
+    def _context(self, context_samples: int) -> OverlayInterimTranscriptContext:
+        return OverlayInterimTranscriptContext(
+            session_id=self._session_id,
+            context_samples=context_samples,
+            sample_rate=self._sample_rate,
+        )
+
+    def _record_source_failure(
+        self,
+        source: InterimTranscriptSource,
+        source_seq: int,
+        context: OverlayInterimTranscriptContext,
+        error_class: str,
+    ) -> None:
+        state = self._source_state[source]
+        state.failed = True
+        state.fallback_reason = f"{source}_transcribe_error:{error_class}"
+        self._source_fallback_reason = state.fallback_reason
+        logger.debug(
+            "Interim transcript source {} unavailable for session {}: {}",
+            source,
+            self._session_id,
+            error_class,
+        )
+        self._stabilizer.record_skip(
+            source=source,
+            source_seq=source_seq,
+            context=context,
+            reason="transcribe_error",
+            error_class=error_class,
+        )
+
+
 def append_overlay_interim_context(existing: np.ndarray, chunk_audio: np.ndarray) -> np.ndarray:
     if existing.size == 0:
         return np.array(chunk_audio, copy=True)
@@ -236,7 +399,11 @@ def _longest_casefold_suffix_prefix_overlap(existing: list[str], current: list[s
 
 
 __all__ = [
+    "InterimTranscriptRuntimeFacts",
+    "InterimTranscriptSource",
+    "InterimTranscriber",
     "OverlayInterimTranscriptContext",
+    "OverlayInterimTranscriptSession",
     "OverlayInterimTranscriptStabilizer",
     "StabilizedInterimText",
     "append_overlay_interim_context",

--- a/parakeet-stt-daemon/src/parakeet_stt_daemon/session_orchestrator.py
+++ b/parakeet-stt-daemon/src/parakeet_stt_daemon/session_orchestrator.py
@@ -46,9 +46,8 @@ from .model import (
     load_parakeet_model,
 )
 from .overlay_interim import (
-    OverlayInterimTranscriptContext,
-    OverlayInterimTranscriptStabilizer,
-    append_overlay_interim_context,
+    InterimTranscriptRuntimeFacts,
+    OverlayInterimTranscriptSession,
 )
 from .runtime_truth_snapshot import (
     RuntimeTruth,
@@ -147,8 +146,6 @@ class SessionOrchestrator:
         self._last_finalize_ms: int | None = None
         self._last_infer_ms: int | None = None
         self._last_send_ms: int | None = None
-        self._live_interim_audio = np.zeros((0,), dtype=np.float32)
-        self._live_interim_failed = False
         self._vad_enabled = bool(settings.vad_enabled)
         self.tail_trimmer = SealPathTailTrimmer(
             vad_enabled=self._vad_enabled,
@@ -158,9 +155,7 @@ class SessionOrchestrator:
         if settings.streaming_enabled:
             chunk_samples = int(settings.chunk_secs * self.audio.sample_rate)
             self.audio.configure_stream_chunk_size(chunk_samples)
-        self._overlay_interim_stabilizer_by_session: dict[
-            UUID, OverlayInterimTranscriptStabilizer
-        ] = {}
+        self._interim_transcript_by_session: dict[UUID, OverlayInterimTranscriptSession] = {}
 
     async def start(self, intent: StartSessionIntent) -> None:
         await self._handle_start(intent)
@@ -183,10 +178,8 @@ class SessionOrchestrator:
             )
             return
         try:
-            self._live_interim_audio = np.zeros((0,), dtype=np.float32)
-            self._live_interim_failed = False
+            self._reset_interim_transcript_session(message.session_id)
             self._reset_current_stream_runtime()
-            self._clear_overlay_session_runtime(message.session_id)
             self.audio.start_session()
             streaming_transcriber = self.streaming_transcriber
             if streaming_transcriber is not None or bool(
@@ -302,8 +295,6 @@ class SessionOrchestrator:
                 )
                 await self.sessions.clear(session.session_id, owner_token=owner_token)
                 self._clear_overlay_session_runtime(session.session_id)
-                self._live_interim_audio = np.zeros((0,), dtype=np.float32)
-                self._live_interim_failed = False
                 return
 
             finalize_ms: int | None = None
@@ -313,11 +304,6 @@ class SessionOrchestrator:
                     session.session_id,
                     ready_chunks,
                 )
-                flushed_interim = self._overlay_interim_stabilizer(
-                    session.session_id
-                ).flush_pending_tail()
-                if flushed_interim is not None:
-                    interim_updates.append(flushed_interim.text)
                 if interim_updates:
                     await self._emit_interim_state(
                         event_sink,
@@ -348,8 +334,6 @@ class SessionOrchestrator:
                 )
                 await self.sessions.clear(session.session_id, owner_token=owner_token)
                 self._clear_overlay_session_runtime(session.session_id)
-                self._live_interim_audio = np.zeros((0,), dtype=np.float32)
-                self._live_interim_failed = False
                 return
 
             latency_ms = int((datetime.now(tz=UTC) - session.last_updated).total_seconds() * 1000)
@@ -376,8 +360,6 @@ class SessionOrchestrator:
             )
             await self.sessions.clear(session.session_id, owner_token=owner_token)
             self._clear_overlay_session_runtime(session.session_id)
-            self._live_interim_audio = np.zeros((0,), dtype=np.float32)
-            self._live_interim_failed = False
             self._last_audio_ms = audio_ms
             self._last_audio_stop_ms = audio_stop_ms
             self._last_finalize_ms = finalize_ms
@@ -507,8 +489,6 @@ class SessionOrchestrator:
                 self._clear_overlay_session_runtime(active_session_id)
             self._active_stream = None
             self._reset_current_stream_runtime()
-            self._live_interim_audio = np.zeros((0,), dtype=np.float32)
-            self._live_interim_failed = False
             if active_session_id is not None and event_sink is not None and session_end_reason:
                 await self._emit_session_ended(
                     event_sink, active_session_id, reason=session_end_reason
@@ -690,34 +670,44 @@ class SessionOrchestrator:
                 raise
 
     def _clear_overlay_session_runtime(self, session_id: UUID) -> None:
-        overlay_stabilizers = getattr(self, "_overlay_interim_stabilizer_by_session", None)
-        if isinstance(overlay_stabilizers, dict):
-            overlay_stabilizers.pop(session_id, None)
+        interim_sessions = getattr(self, "_interim_transcript_by_session", None)
+        if isinstance(interim_sessions, dict):
+            interim_sessions.pop(session_id, None)
 
-    def _overlay_interim_stabilizer(
-        self,
-        session_id: UUID,
-    ) -> OverlayInterimTranscriptStabilizer:
-        overlay_stabilizers = getattr(self, "_overlay_interim_stabilizer_by_session", None)
-        if not isinstance(overlay_stabilizers, dict):
-            overlay_stabilizers = {}
-            self._overlay_interim_stabilizer_by_session = overlay_stabilizers
-        stabilizer = overlay_stabilizers.get(session_id)
-        if stabilizer is None:
-            stabilizer = OverlayInterimTranscriptStabilizer()
-            overlay_stabilizers[session_id] = stabilizer
-        return stabilizer
-
-    def _overlay_interim_context(
-        self,
-        session_id: UUID,
-        context_samples: int,
-    ) -> OverlayInterimTranscriptContext:
-        return OverlayInterimTranscriptContext(
+    def _reset_interim_transcript_session(self, session_id: UUID) -> None:
+        interim_sessions = self._interim_transcript_sessions_for_runtime()
+        interim_sessions[session_id] = OverlayInterimTranscriptSession(
             session_id=session_id,
-            context_samples=context_samples,
             sample_rate=int(self.audio.sample_rate),
+            enabled=bool(self.settings.overlay_events_enabled),
         )
+
+    def _interim_transcript_sessions_for_runtime(
+        self,
+    ) -> dict[UUID, OverlayInterimTranscriptSession]:
+        interim_sessions = getattr(self, "_interim_transcript_by_session", None)
+        if not isinstance(interim_sessions, dict):
+            interim_sessions = {}
+            self._interim_transcript_by_session = interim_sessions
+        return interim_sessions
+
+    def _interim_transcript_session(self, session_id: UUID) -> OverlayInterimTranscriptSession:
+        interim_sessions = self._interim_transcript_sessions_for_runtime()
+        interim_session = interim_sessions.get(session_id)
+        if interim_session is None:
+            interim_session = OverlayInterimTranscriptSession(
+                session_id=session_id,
+                sample_rate=int(self.audio.sample_rate),
+                enabled=bool(self.settings.overlay_events_enabled),
+            )
+            interim_sessions[session_id] = interim_session
+        return interim_session
+
+    def interim_transcript_runtime_facts(
+        self,
+        session_id: UUID,
+    ) -> InterimTranscriptRuntimeFacts:
+        return self._interim_transcript_session(session_id).runtime_facts
 
     async def _emit_interim_state(
         self,
@@ -741,46 +731,10 @@ class SessionOrchestrator:
         session_id: UUID,
         ready_chunks: list[np.ndarray],
     ) -> list[str]:
-        if not self.settings.overlay_events_enabled:
-            return []
-        if not ready_chunks:
-            return []
-
-        rolling_audio = np.zeros((0,), dtype=np.float32)
-        updates: list[str] = []
-
-        for chunk in ready_chunks:
-            chunk_audio = np.asarray(chunk, dtype=np.float32).reshape(-1)
-            if chunk_audio.size == 0:
-                continue
-            rolling_audio = append_overlay_interim_context(rolling_audio, chunk_audio)
-            stabilizer = self._overlay_interim_stabilizer(session_id)
-            source_seq = stabilizer.next_source_seq("stop_replay")
-            context = self._overlay_interim_context(session_id, int(rolling_audio.size))
-            try:
-                candidate = await self._transcribe_samples_serialized(rolling_audio)
-            except Exception as exc:  # noqa: BLE001
-                logger.debug(
-                    "Incremental interim source unavailable for this session: {}",
-                    exc.__class__.__name__,
-                )
-                stabilizer.record_skip(
-                    source="stop_replay",
-                    source_seq=source_seq,
-                    context=context,
-                    reason="transcribe_error",
-                    error_class=exc.__class__.__name__,
-                )
-                break
-            stabilized = stabilizer.accept(
-                "stop_replay",
-                source_seq,
-                candidate,
-                context,
-            )
-            if stabilized is not None:
-                updates.append(stabilized.text)
-        return updates
+        return await self._interim_transcript_session(session_id).collect_stop_replay_updates(
+            ready_chunks,
+            self._transcribe_samples_serialized,
+        )
 
     async def _emit_interim_text(
         self,
@@ -822,44 +776,12 @@ class SessionOrchestrator:
         session_id: UUID,
         chunk: np.ndarray,
     ) -> None:
-        if not self.settings.overlay_events_enabled:
-            return
-        if self._live_interim_failed:
-            return
-        chunk_audio = np.asarray(chunk, dtype=np.float32).reshape(-1)
-        if chunk_audio.size == 0:
-            return
-        self._live_interim_audio = append_overlay_interim_context(
-            self._live_interim_audio,
-            chunk_audio,
+        update = await self._interim_transcript_session(session_id).accept_live_chunk(
+            chunk,
+            self._transcribe_samples_serialized,
         )
-        stabilizer = self._overlay_interim_stabilizer(session_id)
-        source_seq = stabilizer.next_source_seq("live")
-        context = self._overlay_interim_context(session_id, int(self._live_interim_audio.size))
-        try:
-            candidate = await self._transcribe_samples_serialized(self._live_interim_audio)
-        except Exception as exc:  # noqa: BLE001
-            logger.debug(
-                "Live incremental interim source unavailable for this session: {}",
-                exc.__class__.__name__,
-            )
-            stabilizer.record_skip(
-                source="live",
-                source_seq=source_seq,
-                context=context,
-                reason="transcribe_error",
-                error_class=exc.__class__.__name__,
-            )
-            self._live_interim_failed = True
-            return
-        stabilized = stabilizer.accept(
-            "live",
-            source_seq,
-            candidate,
-            context,
-        )
-        if stabilized is not None:
-            await self._emit_interim_text(event_sink, session_id, text=stabilized.text)
+        if update is not None:
+            await self._emit_interim_text(event_sink, session_id, text=update)
 
     def runtime_truth(self, *, overlay_events_enabled: bool) -> RuntimeTruth:
         return runtime_truth_snapshot(

--- a/parakeet-stt-daemon/tests/test_overlay_event_stream.py
+++ b/parakeet-stt-daemon/tests/test_overlay_event_stream.py
@@ -183,9 +183,7 @@ def _build_server(
     orchestrator._last_finalize_ms = None
     orchestrator._last_infer_ms = None
     orchestrator._last_send_ms = None
-    orchestrator._live_interim_audio = np.zeros((0,), dtype=np.float32)
-    orchestrator._live_interim_failed = False
-    orchestrator._overlay_interim_stabilizer_by_session = {}
+    orchestrator._interim_transcript_by_session = {}
 
     async def fake_finalize(_audio_samples: np.ndarray) -> tuple[str, int]:
         return "overlay test text", 7

--- a/parakeet-stt-daemon/tests/test_overlay_interim_stabilizer.py
+++ b/parakeet-stt-daemon/tests/test_overlay_interim_stabilizer.py
@@ -2,15 +2,18 @@
 
 from __future__ import annotations
 
+import asyncio
 import io
 from contextlib import contextmanager
 from typing import Any
 from uuid import uuid4
 
+import numpy as np
 from loguru import logger
 
 from parakeet_stt_daemon.overlay_interim import (
     OverlayInterimTranscriptContext,
+    OverlayInterimTranscriptSession,
     OverlayInterimTranscriptStabilizer,
     StabilizedInterimText,
 )
@@ -119,3 +122,113 @@ def test_debug_log_records_skipped_transcription_source(monkeypatch) -> None:
     assert "source=stop_replay source_seq=0" in messages
     assert "reason=transcribe_error" in messages
     assert "error_class=RuntimeError" in messages
+
+
+def test_session_module_owns_live_and_stop_replay_updates() -> None:
+    async def scenario() -> None:
+        outputs = iter(["alpha", "alpha beta", "beta gamma"])
+        sample_sizes: list[int] = []
+
+        async def transcribe(samples: np.ndarray) -> str:
+            sample_sizes.append(int(samples.size))
+            return next(outputs)
+
+        session = OverlayInterimTranscriptSession(
+            session_id=uuid4(),
+            sample_rate=16_000,
+            enabled=True,
+        )
+
+        assert (
+            await session.accept_live_chunk(
+                np.full((400,), 0.1, dtype=np.float32),
+                transcribe,
+            )
+            == "alpha"
+        )
+        assert (
+            await session.accept_live_chunk(
+                np.full((400,), 0.2, dtype=np.float32),
+                transcribe,
+            )
+            == "alpha beta"
+        )
+        assert await session.collect_stop_replay_updates(
+            [np.full((400,), 0.3, dtype=np.float32)],
+            transcribe,
+        ) == ["alpha beta gamma", "alpha beta gamma"]
+
+        facts = session.runtime_facts
+        assert facts.enabled is True
+        assert facts.last_source == "stop_replay"
+        assert facts.live_chunks_processed == 2
+        assert facts.live_updates_emitted == 2
+        assert facts.stop_replay_chunks_processed == 1
+        assert facts.stop_replay_updates_emitted == 1
+        assert facts.source_fallback_reason is None
+        assert sample_sizes == [400, 800, 400]
+
+    asyncio.run(scenario())
+
+
+def test_session_module_records_source_failure_and_stops_that_source() -> None:
+    async def scenario() -> None:
+        calls = 0
+
+        async def transcribe(_samples: np.ndarray) -> str:
+            nonlocal calls
+            calls += 1
+            raise RuntimeError("source unavailable")
+
+        session = OverlayInterimTranscriptSession(
+            session_id=uuid4(),
+            sample_rate=16_000,
+            enabled=True,
+        )
+
+        assert (
+            await session.accept_live_chunk(
+                np.full((400,), 0.1, dtype=np.float32),
+                transcribe,
+            )
+            is None
+        )
+        assert (
+            await session.accept_live_chunk(
+                np.full((400,), 0.2, dtype=np.float32),
+                transcribe,
+            )
+            is None
+        )
+
+        facts = session.runtime_facts
+        assert calls == 1
+        assert facts.live_failed is True
+        assert facts.live_chunks_processed == 1
+        assert facts.live_updates_emitted == 0
+        assert facts.source_fallback_reason == "live_transcribe_error:RuntimeError"
+
+    asyncio.run(scenario())
+
+
+def test_session_module_flushes_pending_tail_without_stop_replay_chunks() -> None:
+    async def scenario() -> None:
+        async def transcribe(_samples: np.ndarray) -> str:
+            return "phase one"
+
+        session = OverlayInterimTranscriptSession(
+            session_id=uuid4(),
+            sample_rate=16_000,
+            enabled=True,
+        )
+
+        assert (
+            await session.accept_live_chunk(
+                np.full((400,), 0.1, dtype=np.float32),
+                transcribe,
+            )
+            == "phase one"
+        )
+        assert await session.collect_stop_replay_updates([], transcribe) == ["phase one"]
+
+    asyncio.run(scenario())

--- a/parakeet-stt-daemon/tests/test_session_cleanup.py
+++ b/parakeet-stt-daemon/tests/test_session_cleanup.py
@@ -166,9 +166,7 @@ def _build_server() -> DaemonServer:
     orchestrator._last_finalize_ms = None
     orchestrator._last_infer_ms = None
     orchestrator._last_send_ms = None
-    orchestrator._live_interim_audio = np.zeros((0,), dtype=np.float32)
-    orchestrator._live_interim_failed = False
-    orchestrator._overlay_interim_stabilizer_by_session = {}
+    orchestrator._interim_transcript_by_session = {}
 
     async def fake_collect_interim_text_updates(
         _session_id: UUID, _ready_chunks: list[object]

--- a/parakeet-stt-daemon/tests/test_session_orchestrator.py
+++ b/parakeet-stt-daemon/tests/test_session_orchestrator.py
@@ -139,9 +139,7 @@ def _build_orchestrator(
     orchestrator._last_finalize_ms = None
     orchestrator._last_infer_ms = None
     orchestrator._last_send_ms = None
-    orchestrator._live_interim_audio = np.zeros((0,), dtype=np.float32)
-    orchestrator._live_interim_failed = False
-    orchestrator._overlay_interim_stabilizer_by_session = {}
+    orchestrator._interim_transcript_by_session = {}
     orchestrator._vad_enabled = False
 
     async def fake_collect_interim_text_updates(

--- a/parakeet-stt-daemon/tests/test_streaming_truth.py
+++ b/parakeet-stt-daemon/tests/test_streaming_truth.py
@@ -98,9 +98,7 @@ def _build_server(
     orchestrator._last_finalize_ms = None
     orchestrator._last_infer_ms = None
     orchestrator._last_send_ms = None
-    orchestrator._live_interim_audio = np.zeros((0,), dtype=np.float32)
-    orchestrator._live_interim_failed = False
-    orchestrator._overlay_interim_stabilizer_by_session = {}
+    orchestrator._interim_transcript_by_session = {}
     orchestrator._vad_enabled = vad_enabled
     orchestrator.tail_trimmer = SealPathTailTrimmer(
         vad_enabled=vad_enabled,


### PR DESCRIPTION
Closes #106

## Summary
- Added a Session-scoped `OverlayInterimTranscriptSession` module that owns live and stop-replay interim transcript state, rolling audio context, source sequencing, source failure bookkeeping, pending-tail flush behavior, and interim runtime facts.
- Updated `SessionOrchestrator` to delegate interim text production through that interface while preserving existing Overlay wire events and keeping the Seal path as final transcript authority.
- Expanded tests for the new module and cleaned stale fixture state from the old orchestrator-owned interim fields.

## Verification (#106)
- targeted: `uv run --project parakeet-stt-daemon pytest parakeet-stt-daemon/tests/test_overlay_interim_stabilizer.py parakeet-stt-daemon/tests/test_overlay_event_stream.py parakeet-stt-daemon/tests/test_session_orchestrator.py parakeet-stt-daemon/tests/test_streaming_truth.py parakeet-stt-daemon/tests/test_session_cleanup.py -q` -> PASSED (85 passed)
- regression: N/A - enhancement/refactor slice; new tests pin live chunk updates, stop-replay updates, source failure bookkeeping, pending-tail flush, and existing finalization ordering/no-regression behavior.
- full suite: `uv run --project parakeet-stt-daemon pytest -q` -> PASSED (191 passed)
- lint: `uv run --project parakeet-stt-daemon ruff check --config parakeet-stt-daemon/pyproject.toml <touched python files>` and `prek run --files <touched python files>` -> PASSED
- types: `ty check --project parakeet-stt-daemon --error-on-warning` -> PASSED
- dead-code: N/A - no dead-code gate discovered for this repo surface.
- build: `uv build parakeet-stt-daemon --out-dir .git/issue-106-build --clear` -> PASSED
- pre-commit: `prek run --all-files` -> PASSED; `prek run --stage pre-push --all-files` -> PASSED on rerun; push-time pre-push hook also passed Python pytest.
- static/security: N/A - no separate static/security hook discovered for this repo surface.
- migrations: N/A
- CLI/script smoke: N/A - no CLI/helper/script behavior changed.
- UI render: N/A
- destructive/negative: N/A
- review: `coderabbit_review_watch.py local --fallback-codex-review-args "--base main" -- --base main` -> clean (codex-fallback: no, summary: `.git/coderabbit-review/20260520T130555Z/status.json`, findings_count=0)
- tests added/expanded: `parakeet-stt-daemon/tests/test_overlay_interim_stabilizer.py`; fixture cleanup in `test_overlay_event_stream.py`, `test_session_cleanup.py`, `test_session_orchestrator.py`, and `test_streaming_truth.py`
- preexisting failures left: first `prek run --stage pre-push --all-files` failed in unrelated Rust test `injector_runtime::tests::subprocess_timeout_kills_child_tree_before_next_job_runs` with `WorkerTaskFailed` vs `ExecutionTimeout`; exact targeted retry passed, and the full pre-push gate passed on rerun.

## Compatibility
- No Daemon protocol fields or Client behavior changed in this slice.
- Existing duplicate/empty interim suppression and final-result ordering remain covered by existing Overlay event stream tests.

## Deferrals
- None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Refactored interim transcript handling to use per-session state management, improving isolation and tracking across processing sources.
  * Introduced runtime facts exposure to provide visibility into interim transcript processing metrics and fallback behavior.

* **Tests**
  * Added comprehensive test coverage for interim transcript session functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SystemicVoid/parakeet-stt/pull/112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->