### PR TITLE
docs(runtime): explain overlay interim runtime truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ stt status
 stt show
 stt logs both
 ```
+`stt status` reports Helper process health. Runtime truth for Stream path,
+Seal path, Daemon interim transcript sources, and Overlay event transport lives
+in the Daemon `/status` payload and the Client startup status log line. See
+[`docs/stt-troubleshooting.md`](docs/stt-troubleshooting.md) for the field guide.
 
 4. Stop:
 ```bash

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1,6 +1,6 @@
 # Parakeet STT – Canonical Specification (Living Document)
 
-_Last updated: 2026-03-06_
+_Last updated: 2026-05-20_
 
 This document is the single source of truth for the local, push-to-talk Parakeet speech-to-text solution on Pop!\_OS 24.04 (Wayland). Update it whenever significant design, implementation, or operational decisions are made so every agent and developer can stay in sync.
 
@@ -43,12 +43,23 @@ This document is the single source of truth for the local, push-to-talk Parakeet
 
 - **Control flow**
   1. User presses Right Ctrl → `parakeet-ptt` sends `start_session` to daemon.
-  2. Daemon begins session capture; streaming engine activation is tracked as runtime truth for diagnostics.
+  2. Daemon begins session capture; NeMo Stream path execution, Daemon interim transcript sources, and Overlay event transport are tracked as separate runtime truth dimensions.
   3. User releases Right Ctrl → `parakeet-ptt` issues `stop_session`.
-  4. Daemon finalizes with the offline seal path and returns final transcription via WebSocket.
+  4. Daemon finalizes with the offline Seal path and returns final transcription via WebSocket.
   5. `parakeet-ptt` writes transcript text to the clipboard and executes configured injection behavior (`paste` or `copy-only`), with adaptive shortcut routing available in paste mode.
 
 - **Networking**: localhost WebSocket (JSON frames). No audio leaves the daemon process; control messages only.
+
+### Runtime Truth And User-Visible Text Surfaces
+
+The two-process architecture keeps inference and desktop presentation separate. When diagnosing visible text, treat these surfaces independently:
+
+- **NeMo Stream path execution**: daemon-side chunked ASR work for the Stream path. Runtime truth lives in `streaming_enabled`, `stream_helper_active`, `stream_helper_scope`, `stream_fallback_reason`, `stream_path_executed`, and `stream_chunks_processed`. `stream_path_executed=false` means the Stream path did not process chunks for the current or last Session; it does not prove no interim text was shown.
+- **Seal path finalization**: daemon-side offline final transcription after stop. Runtime truth lives in `finalization_mode`, `final_audio_source`, `tail_trim_mode`, `vad_*`, and finalization timing fields. This is the only path that produces `final_result` for Injection.
+- **Daemon interim transcript sources**: daemon-side display-only interim text production for the Overlay. The `live` source consumes arriving audio chunks during a Session; the `stop_replay` source replays ready chunks while stopping. Runtime truth lives in `interim_transcript_*` fields, including per-source chunks processed, updates emitted, failures, and fallback reason. These sources can emit Overlay text even when `stream_path_executed=false`.
+- **Overlay event transport**: daemon-to-Client display messages such as `interim_state`, `interim_text`, `audio_level`, and `session_ended`. Runtime truth lives in `overlay_events_enabled`, `overlay_events_emitted`, and `overlay_events_dropped`. Transport counters show whether display events were published or dropped; they do not identify which inference path produced text.
+- **Client-side LLM answer deltas**: in LLM query mode, the Client may stream local LLM answer deltas into the Overlay while answer generation is running. These deltas are Client-owned, are not Daemon interim transcript updates, and do not change Stream path or Seal path runtime truth.
+- **Renderer animation**: the Overlay renderer may animate listening text, interim text, finalizing state, width, opacity, or character transitions. Animation is local presentation only; it is not evidence of Stream path execution, Seal path progress, event delivery, or LLM generation.
 
 ---
 
@@ -76,9 +87,9 @@ This document is the single source of truth for the local, push-to-talk Parakeet
 - **Streaming inference**
   - Target documented NeMo streaming APIs for RNNT/conformer flows (cache-aware per-session stepping), not brittle internal helper imports.
   - On session start: allocate streaming state transactionally; if any downstream setup fails, rollback to idle.
-  - Feed chunked frames continuously while the session is active; preserve room for future partials without requiring protocol churn in v1.
+  - Feed chunked frames continuously while the session is active when the Stream path helper is available; record execution separately from Daemon interim transcript sources.
   - For `FrameBatchChunkedRNNT` finalization, build `AudioFeatureIterator(..., pad_to_frame_len=False)` to avoid synthetic padded tail frames that can perturb utterance-end decoding.
-  - On session stop: flush remaining frames and finalize via the offline seal path (final transcript quality anchor).
+  - On session stop: flush remaining frames and finalize via the offline Seal path (final transcript quality anchor).
   - Warm-up pass executed at daemon startup to eliminate first-use latency.
 
 - **API server**
@@ -257,7 +268,7 @@ The canonical machine-checkable contract and fixtures live under [`docs/protocol
 | `stream_chunks_processed` | integer or null | non-negative count or `null` | Number of Stream path chunks processed for the current or last Session. |
 | `finalization_mode` | string or null | `"offline_seal"` or `null` | Final result path used to seal a session. |
 | `final_audio_source` | string or null | `"canonical_session_audio"` or `null` | Audio source used for final transcription. |
-| `tail_trim_mode` | string or null | `"rms"`, `"vad"`, or `null` | Tail trimming strategy used for the last seal path. |
+| `tail_trim_mode` | string or null | `"rms"`, `"vad"`, or `null` | Tail trimming strategy used for the last Seal path. |
 | `vad_enabled` | boolean or null | `true`, `false`, or `null` | Whether VAD is requested by configuration. |
 | `vad_active` | boolean or null | `true`, `false`, or `null` | Whether VAD was loaded and used by the runtime. |
 | `vad_fallback_reason` | string or null | implementation-defined reason or `null` | Set when `vad_enabled` is true and VAD is not active. |
@@ -277,6 +288,8 @@ The canonical machine-checkable contract and fixtures live under [`docs/protocol
 | `chunk_secs` | number or null | seconds, server setting range `0.1` to `10.0`, or `null` | Streaming chunk duration. Clients must accept any JSON number precision; current defaults commonly serialize with one decimal place. |
 
 Overlay event counters reset when the daemon process restarts.
+
+Interpret `stream_path_*`, `interim_transcript_*`, and `overlay_events_*` as separate runtime truth groups. For example, `stream_path_executed=false` with `interim_transcript_updates_emitted>0` means live Overlay text came from the Daemon interim transcript path while the NeMo Stream path did not process chunks. `overlay_events_emitted>0` only proves transport activity, and renderer animation can continue without new inference output.
 
 Future messages (like `partial_result`) must be backward compatible; clients should ignore unknown `type`s.
 Clients must also tolerate unknown error codes and unknown additional fields.

--- a/docs/stt-troubleshooting.md
+++ b/docs/stt-troubleshooting.md
@@ -1,4 +1,4 @@
-# STT helper status (updated 2026-03-05)
+# STT helper status (updated 2026-05-20)
 
 This document now has two parts:
 
@@ -61,6 +61,76 @@ the source of truth for effective device, Stream path helper state, Stream path
 execution evidence, Seal path finalization source, tail trim mode, VAD fallback,
 interim transcript source activity, and overlay-event enablement; the Helper should
 read those fields from `/status` instead of re-deriving them.
+
+Use `stt status` for Helper process health: Daemon PID, Client PID, endpoint,
+tmux session, and matching processes. Use the Daemon `/status` payload, the
+Client startup status log line, and Daemon session runtime truth logs for
+runtime truth. The Helper may parse `/status` to decide whether an existing
+Daemon matches the requested Profile, but shell logic should not infer Stream
+path, Seal path, interim transcript, or Overlay transport state from process
+names, flags, or logs alone.
+
+### Runtime truth field guide
+
+- Stream path: `streaming_enabled`, `stream_helper_active`,
+  `stream_helper_scope`, `stream_fallback_reason`, `stream_path_executed`, and
+  `stream_chunks_processed`.
+- Seal path: `finalization_mode`, `final_audio_source`, `tail_trim_mode`,
+  `vad_enabled`, `vad_active`, `vad_fallback_reason`, and finalization timing
+  fields such as `audio_stop_ms`, `finalize_ms`, `infer_ms`, and `send_ms`.
+- Daemon interim transcript sources: `interim_transcript_enabled`,
+  `interim_transcript_last_source`,
+  `interim_transcript_live_chunks_processed`,
+  `interim_transcript_stop_replay_chunks_processed`,
+  `interim_transcript_updates_emitted`,
+  `interim_transcript_live_updates_emitted`,
+  `interim_transcript_stop_replay_updates_emitted`,
+  `interim_transcript_live_failed`,
+  `interim_transcript_stop_replay_failed`, and
+  `interim_transcript_source_fallback_reason`.
+- Overlay event transport: `overlay_events_enabled`,
+  `overlay_events_emitted`, and `overlay_events_dropped`.
+- Client-side LLM answer deltas: generated and streamed by the Client in LLM
+  query mode. They can update the Overlay while the local LLM answers, but they
+  are not Daemon interim transcript fields and do not affect Stream path or Seal
+  path truth.
+- Renderer animation: local Overlay presentation only. Character fades,
+  listening/finalizing motion, width changes, and opacity transitions are not
+  inference, transport, or LLM progress evidence.
+
+### Live Overlay text with `stream_path_executed=false`
+
+This is not automatically a contradiction. The Stream path truth fields report
+whether the NeMo Stream path helper processed chunks. The Daemon interim
+transcript sources are a separate display-only path for Overlay text: the
+`live` source consumes arriving audio chunks during a Session, and the
+`stop_replay` source can replay ready chunks while stopping. A Session can
+therefore show live Overlay interim text while `/status` still reports
+`stream_path_executed=false`.
+
+When this happens, inspect the groups separately:
+
+1. Check `streaming_enabled`, `stream_helper_active`,
+   `stream_fallback_reason`, `stream_path_executed`, and
+   `stream_chunks_processed` to see whether the NeMo Stream path was requested,
+   available, and exercised.
+2. Check `interim_transcript_enabled`,
+   `interim_transcript_last_source`,
+   `interim_transcript_live_chunks_processed`,
+   `interim_transcript_live_updates_emitted`,
+   `interim_transcript_stop_replay_chunks_processed`,
+   `interim_transcript_stop_replay_updates_emitted`, and
+   `interim_transcript_source_fallback_reason` to see which Daemon interim
+   source produced visible text.
+3. Check `overlay_events_enabled`, `overlay_events_emitted`, and
+   `overlay_events_dropped` to confirm whether Overlay events were transported
+   or dropped.
+4. Check `finalization_mode`, `final_audio_source`, `tail_trim_mode`, and the
+   finalization timing fields to verify Seal path finalization for the result
+   that will be injected.
+5. If the Session used LLM query mode, distinguish Client-side LLM answer
+   deltas from Daemon interim transcript updates. LLM deltas are not evidence
+   that the Stream path executed.
 
 ## Historical notes (pre-2026 migration hardening)
 


### PR DESCRIPTION
## Summary

- Document the runtime boundary between NeMo Stream path execution, Seal path finalization, Daemon interim transcript sources, Overlay event transport, Client-side LLM answer deltas, and renderer animation.
- Add operator troubleshooting for `stream_path_executed=false` while live Overlay interim text appears.
- Point README runtime inspection wording at Daemon `/status` and Client startup status logs for runtime truth.

Closes #109

## Verification (#109)

- targeted: documentation review against #109 acceptance criteria -> PASSED
- regression: N/A - documentation-only clarification
- full suite: N/A - no runtime code changed
- lint: `git diff --check` -> PASSED
- types: N/A - no typed code changed
- dead-code: N/A
- build: N/A - no build outputs changed
- pre-commit: `prek run --files README.md docs/SPEC.md docs/stt-troubleshooting.md` -> PASSED; `prek run --all-files` -> PASSED
- static/security: N/A
- migrations: N/A
- CLI/script smoke: `bash -n scripts/stt-helper.sh` -> PASSED; `source scripts/stt-helper.sh && stt help start && stt help llm` -> PASSED
- UI render: N/A
- destructive/negative: N/A
- review: `coderabbit_review_watch.py local --fallback-codex-review-args "" -- --base main` -> exit 10 fallback completed clean, CodeRabbit local rate-limited, Codex fallback found no actionable issues; artifact `.git/coderabbit-review/20260520T143805Z/status.json`
- tests added/expanded: none - documentation-only
- preexisting failures left: none observed
- pre-push: `prek run --stage pre-push --all-files` -> PASSED

## Notes

No helper shell logic, Overlay rendering, Injection, or protocol behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Quick Start section with clarification on `stt status` output and runtime truth sources.
  * Expanded specifications with detailed control-flow documentation and runtime truth dimensions.
  * Added troubleshooting guide with operator guidance, field guide for runtime state, and validation checklists.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SystemicVoid/parakeet-stt/pull/115?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->