### PR TITLE
Fix NeMo TDT Stream path chunk handling

### DIFF
--- a/parakeet-stt-daemon/src/parakeet_stt_daemon/model.py
+++ b/parakeet-stt-daemon/src/parakeet_stt_daemon/model.py
@@ -449,6 +449,24 @@ class ParakeetStreamingTranscriber:
         preprocessor = getattr(helper, "raw_preprocessor", None)
         if preprocessor is None:
             raise RuntimeError("streaming_preprocessor_unavailable")
+        helper_class_name = self._helper_class_name or type(helper).__name__
+        if helper_class_name == "BatchedFrameASRTDT":
+            tokens_per_chunk, delay = self._tdt_streaming_params()
+            delay_pad_samples = int(
+                math.ceil(delay * _model_stride_secs(self.model) * model_sample_rate)
+            )
+            stream_samples = samples
+            if delay_pad_samples > 0:
+                stream_samples = np.pad(stream_samples, (0, delay_pad_samples))
+            frame_reader = AudioFeatureIterator(
+                stream_samples.astype(np.float32, copy=False),
+                self.chunk_secs,
+                preprocessor,
+                self.model.device,
+                pad_to_frame_len=True,
+            )
+            helper.set_frame_reader(frame_reader, 0)
+            return helper.transcribe(tokens_per_chunk, delay)
         frame_reader = AudioFeatureIterator(
             samples,
             self.chunk_secs,
@@ -456,11 +474,6 @@ class ParakeetStreamingTranscriber:
             self.model.device,
             pad_to_frame_len=False,
         )
-        helper_class_name = self._helper_class_name or type(helper).__name__
-        if helper_class_name == "BatchedFrameASRTDT":
-            tokens_per_chunk, delay = self._tdt_streaming_params()
-            helper.set_frame_reader(frame_reader, 0)
-            return helper.transcribe(tokens_per_chunk, delay)
         helper.set_frame_reader(frame_reader)
         return helper.transcribe()
 

--- a/parakeet-stt-daemon/tests/test_streaming_chunk_padding.py
+++ b/parakeet-stt-daemon/tests/test_streaming_chunk_padding.py
@@ -35,6 +35,18 @@ class _FakeTDTLoss:
     pass
 
 
+class _FailingStreamParent(_FakeParent):
+    def __init__(self) -> None:
+        super().__init__()
+        self.marked_fallback_reason: str | None = None
+
+    def process_stream_chunk(self, _samples: np.ndarray, _sample_rate: int) -> object:
+        raise RuntimeError("stream helper failed")
+
+    def mark_stream_fallback(self, reason: str) -> None:
+        self.marked_fallback_reason = reason
+
+
 def test_finalize_returns_empty_when_no_audio() -> None:
     from parakeet_stt_daemon.model import ParakeetStreamingSession
 
@@ -180,6 +192,131 @@ def test_tdt_streaming_helper_rebuilds_decoder_with_cuda_graphs_disabled(monkeyp
     assert transcriber._helper_class_name == "BatchedFrameASRTDT"
     assert model.change_decoding_flags == [(False, False)]
     assert rebuilt_decoder.disable_calls == 1
+
+
+def test_tdt_stream_chunk_pads_terminal_frame_and_records_execution(monkeypatch) -> None:
+    from parakeet_stt_daemon.model import ParakeetStreamingTranscriber
+
+    streaming_utils = ModuleType("nemo.collections.asr.parts.utils.streaming_utils")
+    captured: dict[str, Any] = {}
+
+    class _FakeAudioFeatureIterator:
+        def __init__(
+            self,
+            samples: np.ndarray,
+            frame_len: float,
+            preprocessor: object,
+            device: str,
+            *,
+            pad_to_frame_len: bool = True,
+        ) -> None:
+            self.samples = np.asarray(samples)
+            self.frame_len = frame_len
+            self.preprocessor = preprocessor
+            self.device = device
+            self.pad_to_frame_len = pad_to_frame_len
+            captured["frame_reader"] = self
+
+    class _FakeFrameBatchChunkedRNNT:
+        def __init__(self, **_kwargs: Any) -> None:
+            raise AssertionError("TDT model should use BatchedFrameASRTDT")
+
+    class _FakeBatchedFrameASRTDT:
+        def __init__(self, **_kwargs: Any) -> None:
+            self.raw_preprocessor = SimpleNamespace(_cfg={"window_stride": 0.01})
+            self.reader: _FakeAudioFeatureIterator | None = None
+            self.reset_calls = 0
+
+        def reset(self) -> None:
+            self.reset_calls += 1
+
+        def set_frame_reader(self, frame_reader: _FakeAudioFeatureIterator, idx: int) -> None:
+            self.reader = frame_reader
+            captured["set_frame_reader_idx"] = idx
+
+        def transcribe(self, tokens_per_chunk: int, delay: int) -> list[str]:
+            captured["tokens_per_chunk"] = tokens_per_chunk
+            captured["delay"] = delay
+            if self.reader is None:
+                raise AssertionError("missing frame reader")
+            if not self.reader.pad_to_frame_len:
+                raise ValueError("short terminal frame broadcast failure")
+            if self.reader.samples.shape[0] <= 1_600:
+                raise ValueError("missing TDT delay pad")
+            return ["partial text"]
+
+    streaming_utils_any = cast(Any, streaming_utils)
+    streaming_utils_any.AudioFeatureIterator = _FakeAudioFeatureIterator
+    streaming_utils_any.FrameBatchChunkedRNNT = _FakeFrameBatchChunkedRNNT
+    streaming_utils_any.BatchedFrameASRTDT = _FakeBatchedFrameASRTDT
+    for module_name in (
+        "nemo",
+        "nemo.collections",
+        "nemo.collections.asr",
+        "nemo.collections.asr.parts",
+        "nemo.collections.asr.parts.utils",
+    ):
+        monkeypatch.setitem(sys.modules, module_name, ModuleType(module_name))
+    monkeypatch.setitem(
+        sys.modules,
+        "nemo.collections.asr.parts.utils.streaming_utils",
+        streaming_utils,
+    )
+    monkeypatch.setitem(sys.modules, "omegaconf", None)
+
+    model = SimpleNamespace(
+        _cfg=SimpleNamespace(
+            sample_rate=16_001,
+            preprocessor=SimpleNamespace(window_stride=0.01),
+            decoding={"greedy": {"max_symbols_per_step": 5}},
+        ),
+        device="cpu",
+        encoder=SimpleNamespace(subsampling_factor=8),
+        loss=SimpleNamespace(_loss=_FakeTDTLoss()),
+        decoding=SimpleNamespace(decoding=SimpleNamespace()),
+    )
+
+    transcriber = ParakeetStreamingTranscriber(
+        cast(Any, model),
+        chunk_secs=0.2,
+        right_context_secs=0.1,
+        batch_size=32,
+    )
+    session = transcriber.start_session(16_001)
+
+    processed = session.feed(np.ones((1_600,), dtype=np.float32))
+
+    frame_reader = captured["frame_reader"]
+    assert processed is True
+    assert session.stream_path_executed is True
+    assert session.stream_chunks_processed == 1
+    assert session.stream_fallback_reason is None
+    assert captured["set_frame_reader_idx"] == 0
+    assert captured["tokens_per_chunk"] == 3
+    assert captured["delay"] == 4
+    assert frame_reader.pad_to_frame_len is True
+    assert frame_reader.samples.dtype == np.float32
+    assert frame_reader.samples.shape == (6_721,)
+
+
+def test_streaming_session_falls_back_to_seal_path_after_helper_failure() -> None:
+    from parakeet_stt_daemon.model import ParakeetStreamingSession
+
+    parent = _FailingStreamParent()
+    session = ParakeetStreamingSession(cast(Any, parent), sample_rate=16_000)
+
+    processed = session.feed(np.array([0.1, 0.2], dtype=np.float32))
+    result = session.finalize()
+
+    assert processed is False
+    assert session.stream_path_executed is False
+    assert session.stream_chunks_processed == 0
+    assert session.stream_fallback_reason == "stream_chunk_failed:RuntimeError"
+    assert parent.marked_fallback_reason == "stream_chunk_failed:RuntimeError"
+    assert result == "offline text"
+    assert parent.offline_calls == 1
+    assert parent.last_samples is not None
+    np.testing.assert_allclose(parent.last_samples, np.array([0.1, 0.2], dtype=np.float32))
 
 
 def test_finalize_concatenates_stream_chunks_before_offline_seal() -> None:


### PR DESCRIPTION
## Summary
- Route `BatchedFrameASRTDT` chunks through NeMo-compatible delay padding and `AudioFeatureIterator(..., pad_to_frame_len=True)`.
- Leave the RNNT helper frame-reader behavior unchanged.
- Add regressions for TDT terminal-frame padding/delay behavior and helper failure fallback to Seal finalization.

## Acceptance Evidence
- BatchedFrameASRTDT chunk processing now pads by the TDT delay and enables frame-length padding before `helper.transcribe(tokens_per_chunk, delay)`.
- Regression test simulates the TDT frame-reader path and fails if the terminal frame is short or the delay pad is missing.
- Successful TDT session records `stream_path_executed=true` and a positive stream chunk count.
- Helper failure still records `stream_fallback_reason=stream_chunk_failed:RuntimeError` and finalizes through the Seal path.
- Manual runtime probe used an isolated branch daemon on `127.0.0.1:8876` with CUDA stream+seal settings and overlay events disabled. The helper-managed local `stt llm` stack was not stopped or restarted. Runtime truth showed `live_session_helper_class=BatchedFrameASRTDT`, `stream_fallback_reason=null`, `stream_path_executed=true`, `stream_chunks_processed=2`, `finalization_mode=offline_seal`, `final_audio_source=canonical_session_audio`.

## Verification
- `cd parakeet-stt-daemon && uv run pytest tests/test_streaming_chunk_padding.py -q` -> 9 passed
- `cd parakeet-stt-daemon && uv run pytest tests/test_streaming_truth.py tests/test_session_orchestrator.py tests/test_session_cleanup.py -q` -> 51 passed
- `cd parakeet-stt-daemon && uv run pytest -q` -> 197 passed
- `cd parakeet-stt-daemon && uv run ruff check src/parakeet_stt_daemon/model.py tests/test_streaming_chunk_padding.py`
- `cd parakeet-stt-daemon && uv run ruff format --check src/parakeet_stt_daemon/model.py tests/test_streaming_chunk_padding.py`
- `cd parakeet-stt-daemon && uv run ty check`
- `uv build parakeet-stt-daemon --out-dir .git/issue-110-build --clear`
- `prek run --all-files`
- `prek run --stage pre-push --all-files`
- CodeRabbit local review: `.git/coderabbit-review/20260520T150110Z/status.json`, zero findings

Closes #110


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streaming transcription now pads the terminal audio frame for a specific streaming path, ensuring stable tokenization and recording execution parameters; streaming helpers also trigger automatic fallback to offline mode when they fail.

* **Tests**
  * Added regression tests covering terminal-frame padding, recorded execution metadata, error handling, and recovery that ensure finalize() still returns offline transcription after helper failure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SystemicVoid/parakeet-stt/pull/116?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->