### PR TITLE
Preserve Client Overlay text-producer separation

### DIFF
--- a/parakeet-ptt/src/app.rs
+++ b/parakeet-ptt/src/app.rs
@@ -509,8 +509,7 @@ pub async fn run(config: ClientConfig, ports: ClientPorts) -> Result<()> {
                                         if llm_busy {
                                             warn!("ignoring hotkey down while LLM response is in progress");
                                             llm_busy_overlay_seq = llm_busy_overlay_seq.saturating_add(1);
-                                            overlay_router.route_interim_state(
-                                                None,
+                                            overlay_router.route_llm_answer_state(
                                                 llm_busy_overlay_session,
                                                 llm_busy_overlay_seq,
                                                 "LLM busy; wait for current answer".to_string(),
@@ -618,8 +617,7 @@ pub async fn run(config: ClientConfig, ports: ClientPorts) -> Result<()> {
                                                 llm_in_flight_session = Some(session_id);
                                                 let seq = llm_seq.entry(session_id).or_insert(0);
                                                 *seq = seq.saturating_add(1);
-                                                overlay_router.route_interim_state(
-                                                    None,
+                                                overlay_router.route_llm_answer_state(
                                                     session_id,
                                                     *seq,
                                                     "Generating answer...".to_string(),
@@ -695,7 +693,11 @@ pub async fn run(config: ClientConfig, ports: ClientPorts) -> Result<()> {
                                         entry.push_str(&delta);
                                         let seq = llm_seq.entry(session_id).or_insert(0);
                                         *seq = seq.saturating_add(1);
-                                        overlay_router.route_interim_text(None, session_id, *seq, entry.clone());
+                                        overlay_router.route_llm_answer_delta(
+                                            session_id,
+                                            *seq,
+                                            entry.clone(),
+                                        );
                                     }
                                     LlmProgress::Finished {
                                         session_id,
@@ -1185,7 +1187,7 @@ mod tests {
         FailInjector, InjectorContext, ParentFocusCapture, PasteChordSender, PasteKeySender,
         TextInjector,
     };
-    use crate::overlay_router::{OverlayEvent, OverlayRouter};
+    use crate::overlay_router::{OverlayEvent, OverlayRouter, OverlayTextProducer};
     use crate::protocol::{ClientMessage, ServerMessage};
     use crate::state::PttState;
 
@@ -1631,6 +1633,116 @@ mod tests {
         assert_eq!(
             runtime.recorded_injections(),
             vec!["test answer".to_string()]
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn app_llm_answer_deltas_route_with_independent_overlay_producer() {
+        let (config, ports, mut runtime) = ClientRuntimeHarness::new_with_llm_deltas(
+            test_app_config(),
+            ["answer", " delta"],
+            "answer delta",
+        )
+        .into_parts();
+
+        let app_task = tokio::spawn(run(config, ports));
+        runtime.send_hotkey_down(HotkeyIntent::LlmQuery);
+        let start = runtime.next_sent_message(Duration::from_millis(250)).await;
+        let active_session_id = match start {
+            ClientMessage::StartSession { session_id, .. } => session_id,
+            other => panic!("expected start_session, got {other:?}"),
+        };
+        runtime.send_hotkey_up();
+        let stop = runtime.next_sent_message(Duration::from_millis(250)).await;
+        match stop {
+            ClientMessage::StopSession { session_id, .. } => {
+                assert_eq!(session_id, active_session_id);
+            }
+            other => panic!("expected stop_session, got {other:?}"),
+        }
+
+        runtime.send_daemon_message(ServerMessage::InterimText {
+            session_id: active_session_id,
+            seq: 10,
+            text: "daemon interim transcript".to_string(),
+        });
+        runtime.send_daemon_message(ServerMessage::FinalResult {
+            session_id: active_session_id,
+            text: "private prompt".to_string(),
+            latency_ms: 55,
+            audio_ms: 1500,
+            lang: Some("en".to_string()),
+            confidence: Some(0.95),
+        });
+        timeout(Duration::from_secs(1), async {
+            loop {
+                let overlay_event_count = runtime
+                    .recorded_overlay_events()
+                    .into_iter()
+                    .filter(|event| {
+                        matches!(
+                            event,
+                            OverlayEvent::InterimState { .. } | OverlayEvent::InterimText { .. }
+                        )
+                    })
+                    .count();
+                if overlay_event_count >= 4 && !runtime.recorded_injections().is_empty() {
+                    break;
+                }
+                yield_now().await;
+            }
+        })
+        .await
+        .expect("LLM deltas should route and final answer should inject");
+        app_task.abort();
+
+        assert_eq!(
+            runtime.recorded_llm_requests(),
+            vec![(active_session_id, "private prompt".to_string())]
+        );
+        assert_eq!(
+            runtime.recorded_injections(),
+            vec!["answer delta".to_string()]
+        );
+
+        let overlay_text_events: Vec<_> = runtime
+            .recorded_overlay_events()
+            .into_iter()
+            .filter(|event| {
+                matches!(
+                    event,
+                    OverlayEvent::InterimState { .. } | OverlayEvent::InterimText { .. }
+                )
+            })
+            .collect();
+        assert_eq!(
+            overlay_text_events,
+            vec![
+                OverlayEvent::InterimText {
+                    producer: OverlayTextProducer::DaemonSttInterim,
+                    session_id: active_session_id,
+                    seq: 10,
+                    text: "daemon interim transcript".to_string(),
+                },
+                OverlayEvent::InterimState {
+                    producer: OverlayTextProducer::LlmAnswerDelta,
+                    session_id: active_session_id,
+                    seq: 1,
+                    state: "Generating answer...".to_string(),
+                },
+                OverlayEvent::InterimText {
+                    producer: OverlayTextProducer::LlmAnswerDelta,
+                    session_id: active_session_id,
+                    seq: 2,
+                    text: "answer".to_string(),
+                },
+                OverlayEvent::InterimText {
+                    producer: OverlayTextProducer::LlmAnswerDelta,
+                    session_id: active_session_id,
+                    seq: 3,
+                    text: "answer delta".to_string(),
+                },
+            ]
         );
     }
 

--- a/parakeet-ptt/src/client_runtime_fixtures.rs
+++ b/parakeet-ptt/src/client_runtime_fixtures.rs
@@ -29,12 +29,24 @@ pub(crate) struct ClientRuntimeHarness {
 
 impl ClientRuntimeHarness {
     pub(crate) fn new(config: ClientConfig) -> Self {
+        Self::new_with_llm_deltas(config, std::iter::empty::<String>(), "test answer")
+    }
+
+    pub(crate) fn new_with_llm_deltas<I, S>(
+        config: ClientConfig,
+        deltas: I,
+        answer: impl Into<String>,
+    ) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
         let (hotkey_tx, hotkey_rx) = mpsc::unbounded_channel();
         let (sent_tx, sent_rx) = mpsc::unbounded_channel();
         let (daemon_tx, daemon_rx) = mpsc::unbounded_channel();
         let (injection_runner, injections) = RecordingInjectionRunner::shared();
         let (overlay_sink, overlay_events) = RecordingOverlaySink::shared();
-        let (llm_answerer, llm_requests) = TestLlmAnswerer::shared();
+        let (llm_answerer, llm_requests) = TestLlmAnswerer::shared_with_deltas(deltas, answer);
         let ports = ClientPorts::new(
             AudioFeedback::new(false, None, 0),
             Arc::new(TestDaemonConnector::new(TestDaemonConnection {
@@ -247,14 +259,25 @@ impl DaemonConnection for TestDaemonConnection {
 
 struct TestLlmAnswerer {
     requests: RecordedLlmRequests,
+    progress_deltas: Vec<String>,
+    answer: String,
 }
 
 impl TestLlmAnswerer {
-    fn shared() -> (Arc<Self>, RecordedLlmRequests) {
+    fn shared_with_deltas<I, S>(
+        deltas: I,
+        answer: impl Into<String>,
+    ) -> (Arc<Self>, RecordedLlmRequests)
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
         let requests = Arc::new(Mutex::new(Vec::new()));
         (
             Arc::new(Self {
                 requests: Arc::clone(&requests),
+                progress_deltas: deltas.into_iter().map(Into::into).collect(),
+                answer: answer.into(),
             }),
             requests,
         )
@@ -280,14 +303,20 @@ impl LlmAnswerer for TestLlmAnswerer {
         &'a self,
         session_id: Uuid,
         transcript: String,
-        _progress_tx: mpsc::UnboundedSender<LlmProgress>,
+        progress_tx: mpsc::UnboundedSender<LlmProgress>,
     ) -> TestBoxFuture<'a, anyhow::Result<String>> {
         Box::pin(async move {
             self.requests
                 .lock()
                 .expect("recorded LLM request lock should be available")
                 .push((session_id, transcript));
-            Ok("test answer".to_string())
+            for delta in &self.progress_deltas {
+                let _ = progress_tx.send(LlmProgress::Delta {
+                    session_id,
+                    delta: delta.clone(),
+                });
+            }
+            Ok(self.answer.clone())
         })
     }
 }

--- a/parakeet-ptt/src/client_session.rs
+++ b/parakeet-ptt/src/client_session.rs
@@ -124,7 +124,7 @@ pub(crate) async fn handle_server_message<S: OverlaySink>(
             seq,
             state: interim_state,
         } => {
-            overlay_router.route_interim_state(
+            overlay_router.route_daemon_interim_state(
                 session_id_from_state(state),
                 session_id,
                 seq,
@@ -136,7 +136,12 @@ pub(crate) async fn handle_server_message<S: OverlaySink>(
             seq,
             text,
         } => {
-            overlay_router.route_interim_text(session_id_from_state(state), session_id, seq, text);
+            overlay_router.route_daemon_interim_text(
+                session_id_from_state(state),
+                session_id,
+                seq,
+                text,
+            );
         }
         ServerMessage::AudioLevel {
             session_id,
@@ -246,7 +251,8 @@ mod tests {
         OverlayProcessManager, OverlayProcessMetrics, OverlayProcessSink,
     };
     use crate::overlay_router::{
-        NoopOverlaySink, OverlayEvent, OverlayRouter, OverlaySink, RuntimeOverlaySink,
+        NoopOverlaySink, OverlayEvent, OverlayRouter, OverlaySink, OverlayTextProducer,
+        RuntimeOverlaySink,
     };
     use crate::protocol::ServerMessage;
     use crate::state::PttState;
@@ -594,11 +600,13 @@ mod tests {
             overlay_events,
             vec![
                 OverlayEvent::InterimState {
+                    producer: OverlayTextProducer::DaemonSttInterim,
                     session_id,
                     seq: 1,
                     state: "listening".to_string(),
                 },
                 OverlayEvent::InterimText {
+                    producer: OverlayTextProducer::DaemonSttInterim,
                     session_id,
                     seq: 2,
                     text: "hello".to_string(),
@@ -958,6 +966,7 @@ mod tests {
             first_seen,
             parakeet_ptt::overlay_ipc::OverlayIpcMessage::InterimText {
                 session_id,
+                producer: parakeet_ptt::overlay_ipc::OverlayTextProducer::DaemonSttInterim,
                 seq: 1,
                 text: "old-state".to_string(),
             }
@@ -986,6 +995,7 @@ mod tests {
             second_seen,
             parakeet_ptt::overlay_ipc::OverlayIpcMessage::InterimText {
                 session_id,
+                producer: parakeet_ptt::overlay_ipc::OverlayTextProducer::DaemonSttInterim,
                 seq: 2,
                 text: "current-state".to_string(),
             }
@@ -1037,7 +1047,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn stale_interim_sequences_are_dropped_on_overlay_path_only() {
+    async fn daemon_interim_text_requires_active_session_and_fresh_sequence() {
         let seen_overlay_events = Arc::new(Mutex::new(Vec::<OverlayEvent>::new()));
         let mut overlay_router = OverlayRouter::new(
             RecordingOverlaySink {
@@ -1054,7 +1064,20 @@ mod tests {
         let session_id = state
             .begin_listening()
             .expect("state should begin listening");
+        let stale_session_id = Uuid::new_v4();
         state.stop_listening();
+        handle_server_message_for_tests(
+            ServerMessage::InterimText {
+                session_id: stale_session_id,
+                seq: 1,
+                text: "stale session".to_string(),
+            },
+            &mut state,
+            &mut overlay_router,
+            &worker,
+        )
+        .await
+        .expect("mismatched interim text should be dropped without failure");
         handle_server_message_for_tests(
             ServerMessage::InterimText {
                 session_id,
@@ -1079,6 +1102,19 @@ mod tests {
         )
         .await
         .expect("stale interim text should be dropped without failure");
+        state.reset();
+        handle_server_message_for_tests(
+            ServerMessage::InterimText {
+                session_id,
+                seq: 11,
+                text: "late daemon after reset".to_string(),
+            },
+            &mut state,
+            &mut overlay_router,
+            &worker,
+        )
+        .await
+        .expect("late daemon interim text without active session should be dropped");
 
         assert_eq!(worker.metrics().queued_total.load(Ordering::Relaxed), 0);
         let overlay_events = seen_overlay_events
@@ -1089,6 +1125,7 @@ mod tests {
         assert_eq!(
             overlay_events[0],
             OverlayEvent::InterimText {
+                producer: OverlayTextProducer::DaemonSttInterim,
                 session_id,
                 seq: 10,
                 text: "newest".to_string(),

--- a/parakeet-ptt/src/overlay_ipc.rs
+++ b/parakeet-ptt/src/overlay_ipc.rs
@@ -1,6 +1,23 @@
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+#[derive(Debug, Clone, Copy, Default, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OverlayTextProducer {
+    #[default]
+    DaemonSttInterim,
+    LlmAnswerDelta,
+}
+
+impl OverlayTextProducer {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::DaemonSttInterim => "daemon_stt_interim",
+            Self::LlmAnswerDelta => "llm_answer_delta",
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum OverlayIpcMessage {
@@ -9,11 +26,15 @@ pub enum OverlayIpcMessage {
     },
     InterimState {
         session_id: Uuid,
+        #[serde(default)]
+        producer: OverlayTextProducer,
         seq: u64,
         state: String,
     },
     InterimText {
         session_id: Uuid,
+        #[serde(default)]
+        producer: OverlayTextProducer,
         seq: u64,
         text: String,
     },
@@ -38,23 +59,45 @@ pub enum OverlayIpcMessage {
 mod tests {
     use uuid::Uuid;
 
-    use super::OverlayIpcMessage;
+    use super::{OverlayIpcMessage, OverlayTextProducer};
 
     #[test]
     fn overlay_ipc_message_round_trips_as_tagged_json() {
         let session_id = Uuid::new_v4();
         let message = OverlayIpcMessage::InterimText {
             session_id,
+            producer: OverlayTextProducer::DaemonSttInterim,
             seq: 7,
             text: "hello".to_string(),
         };
 
         let encoded = serde_json::to_string(&message).expect("message should serialize");
         assert!(encoded.contains("\"type\":\"interim_text\""));
+        assert!(encoded.contains("\"producer\":\"daemon_stt_interim\""));
 
         let decoded: OverlayIpcMessage =
             serde_json::from_str(&encoded).expect("message should deserialize");
         assert_eq!(decoded, message);
+    }
+
+    #[test]
+    fn interim_messages_without_producer_decode_as_daemon_stt() {
+        let session_id = Uuid::new_v4();
+        let encoded = format!(
+            r#"{{"type":"interim_text","session_id":"{session_id}","seq":7,"text":"hello"}}"#
+        );
+
+        let decoded: OverlayIpcMessage =
+            serde_json::from_str(&encoded).expect("message should deserialize");
+        assert_eq!(
+            decoded,
+            OverlayIpcMessage::InterimText {
+                session_id,
+                producer: OverlayTextProducer::DaemonSttInterim,
+                seq: 7,
+                text: "hello".to_string(),
+            }
+        );
     }
 
     #[test]

--- a/parakeet-ptt/src/overlay_process.rs
+++ b/parakeet-ptt/src/overlay_process.rs
@@ -668,7 +668,7 @@ mod tests {
     use super::{
         OverlayLauncher, OverlayProcessManager, OverlayProcessMetrics, OverlayProcessSink,
     };
-    use parakeet_ptt::overlay_ipc::OverlayIpcMessage;
+    use parakeet_ptt::overlay_ipc::{OverlayIpcMessage, OverlayTextProducer};
 
     fn queued_launcher(
         queue: Arc<Mutex<VecDeque<std::result::Result<OverlayProcessSink, anyhow::Error>>>>,
@@ -728,6 +728,7 @@ mod tests {
 
         let message = OverlayIpcMessage::InterimText {
             session_id: Uuid::new_v4(),
+            producer: OverlayTextProducer::DaemonSttInterim,
             seq: 10,
             text: "current".to_string(),
         };
@@ -784,6 +785,7 @@ mod tests {
         let session_id = Uuid::new_v4();
         let old_state = OverlayIpcMessage::InterimText {
             session_id,
+            producer: OverlayTextProducer::DaemonSttInterim,
             seq: 1,
             text: "old-state".to_string(),
         };
@@ -798,6 +800,7 @@ mod tests {
 
         let current_state = OverlayIpcMessage::InterimText {
             session_id,
+            producer: OverlayTextProducer::DaemonSttInterim,
             seq: 2,
             text: "current-state".to_string(),
         };
@@ -842,6 +845,7 @@ mod tests {
         let session_id = Uuid::new_v4();
         let state_message = OverlayIpcMessage::InterimText {
             session_id,
+            producer: OverlayTextProducer::DaemonSttInterim,
             seq: 2,
             text: "current-state".to_string(),
         };
@@ -901,6 +905,7 @@ mod tests {
         let session_id = Uuid::new_v4();
         let state_message = OverlayIpcMessage::InterimText {
             session_id,
+            producer: OverlayTextProducer::DaemonSttInterim,
             seq: 2,
             text: "current-state".to_string(),
         };
@@ -975,6 +980,7 @@ mod tests {
         let session_id = Uuid::new_v4();
         let state_message = OverlayIpcMessage::InterimText {
             session_id,
+            producer: OverlayTextProducer::DaemonSttInterim,
             seq: 2,
             text: "current-state".to_string(),
         };
@@ -1040,6 +1046,7 @@ mod tests {
         let session_id = Uuid::new_v4();
         let state_message = OverlayIpcMessage::InterimText {
             session_id,
+            producer: OverlayTextProducer::DaemonSttInterim,
             seq: 2,
             text: "current-state".to_string(),
         };
@@ -1108,6 +1115,7 @@ mod tests {
         let session_id = Uuid::new_v4();
         let latest_state = OverlayIpcMessage::InterimText {
             session_id,
+            producer: OverlayTextProducer::DaemonSttInterim,
             seq: 7,
             text: "latest-state".to_string(),
         };
@@ -1173,6 +1181,7 @@ mod tests {
 
         let state = OverlayIpcMessage::InterimText {
             session_id: Uuid::new_v4(),
+            producer: OverlayTextProducer::DaemonSttInterim,
             seq: 1,
             text: "watchdog-fallback".to_string(),
         };
@@ -1233,6 +1242,7 @@ mod tests {
         let session_id = Uuid::new_v4();
         manager.send(OverlayIpcMessage::InterimText {
             session_id,
+            producer: OverlayTextProducer::DaemonSttInterim,
             seq: 1,
             text: "first fallback".to_string(),
         });
@@ -1242,6 +1252,7 @@ mod tests {
 
         manager.send(OverlayIpcMessage::InterimText {
             session_id,
+            producer: OverlayTextProducer::DaemonSttInterim,
             seq: 2,
             text: "second fallback".to_string(),
         });
@@ -1254,6 +1265,7 @@ mod tests {
             replayed,
             OverlayIpcMessage::InterimText {
                 session_id,
+                producer: OverlayTextProducer::DaemonSttInterim,
                 seq: 2,
                 text: "second fallback".to_string()
             }
@@ -1291,6 +1303,7 @@ mod tests {
 
         manager.send(OverlayIpcMessage::InterimText {
             session_id: Uuid::new_v4(),
+            producer: OverlayTextProducer::DaemonSttInterim,
             seq: 1,
             text: "state survives missing binary".to_string(),
         });
@@ -1338,6 +1351,7 @@ mod tests {
 
         manager.send(OverlayIpcMessage::InterimText {
             session_id: Uuid::new_v4(),
+            producer: OverlayTextProducer::DaemonSttInterim,
             seq: 1,
             text: "check adaptive width forwarding".to_string(),
         });
@@ -1384,6 +1398,7 @@ mod tests {
         let session_a = Uuid::new_v4();
         manager.send(OverlayIpcMessage::InterimState {
             session_id: session_a,
+            producer: OverlayTextProducer::DaemonSttInterim,
             seq: 1,
             state: "listening".to_string(),
         });
@@ -1392,6 +1407,7 @@ mod tests {
         });
         manager.send(OverlayIpcMessage::InterimText {
             session_id: session_a,
+            producer: OverlayTextProducer::DaemonSttInterim,
             seq: 2,
             text: "still session a".to_string(),
         });
@@ -1418,6 +1434,7 @@ mod tests {
             first_interim,
             OverlayIpcMessage::InterimState {
                 session_id,
+                producer: OverlayTextProducer::DaemonSttInterim,
                 seq: 1,
                 ..
             } if session_id == session_a
@@ -1441,6 +1458,7 @@ mod tests {
             first_text,
             OverlayIpcMessage::InterimText {
                 session_id,
+                producer: OverlayTextProducer::DaemonSttInterim,
                 seq: 2,
                 ..
             } if session_id == session_a
@@ -1458,6 +1476,7 @@ mod tests {
         let session_b = Uuid::new_v4();
         manager.send(OverlayIpcMessage::InterimState {
             session_id: session_b,
+            producer: OverlayTextProducer::DaemonSttInterim,
             seq: 1,
             state: "listening".to_string(),
         });
@@ -1470,6 +1489,7 @@ mod tests {
             retargeted_interim,
             OverlayIpcMessage::InterimState {
                 session_id,
+                producer: OverlayTextProducer::DaemonSttInterim,
                 seq: 1,
                 ..
             } if session_id == session_b

--- a/parakeet-ptt/src/overlay_router.rs
+++ b/parakeet-ptt/src/overlay_router.rs
@@ -3,6 +3,7 @@
 //! This Module owns the policy for filtering stale or mismatched Session
 //! events before they reach the Overlay Implementation.
 
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
@@ -13,6 +14,7 @@ use crate::config::OverlayMode;
 use crate::overlay_process::OverlayProcessManager;
 use crate::surface_focus::WaylandFocusCache;
 use parakeet_ptt::overlay_ipc::OverlayIpcMessage;
+pub(crate) use parakeet_ptt::overlay_ipc::OverlayTextProducer;
 
 #[derive(Debug, Default)]
 struct OverlayRoutingMetrics {
@@ -55,11 +57,13 @@ pub enum OverlayEvent {
         output_name: String,
     },
     InterimState {
+        producer: OverlayTextProducer,
         session_id: Uuid,
         seq: u64,
         state: String,
     },
     InterimText {
+        producer: OverlayTextProducer,
         session_id: Uuid,
         seq: u64,
         text: String,
@@ -118,20 +122,24 @@ fn overlay_event_to_ipc(event: OverlayEvent) -> OverlayIpcMessage {
     match event {
         OverlayEvent::OutputHint { output_name } => OverlayIpcMessage::OutputHint { output_name },
         OverlayEvent::InterimState {
+            producer,
             session_id,
             seq,
             state,
         } => OverlayIpcMessage::InterimState {
             session_id,
+            producer,
             seq,
             state,
         },
         OverlayEvent::InterimText {
+            producer,
             session_id,
             seq,
             text,
         } => OverlayIpcMessage::InterimText {
             session_id,
+            producer,
             seq,
             text,
         },
@@ -185,7 +193,7 @@ pub(crate) struct OverlayRouter<S: OverlaySink> {
     sink: S,
     metrics: Arc<OverlayRoutingMetrics>,
     active_session_id: Option<Uuid>,
-    last_seq: Option<u64>,
+    last_seq_by_producer: HashMap<OverlayTextProducer, u64>,
     focus_cache: Option<WaylandFocusCache>,
     last_output_name: Option<String>,
 }
@@ -196,7 +204,7 @@ impl<S: OverlaySink> OverlayRouter<S> {
             sink,
             metrics: Arc::new(OverlayRoutingMetrics::default()),
             active_session_id: None,
-            last_seq: None,
+            last_seq_by_producer: HashMap::new(),
             focus_cache,
             last_output_name: None,
         }
@@ -210,51 +218,79 @@ impl<S: OverlaySink> OverlayRouter<S> {
     pub(crate) fn note_session_started(&mut self, session_id: Uuid) {
         if self.active_session_id != Some(session_id) {
             self.active_session_id = Some(session_id);
-            self.last_seq = None;
+            self.last_seq_by_producer.clear();
             self.last_output_name = None;
         }
     }
 
-    pub(crate) fn route_interim_state(
+    pub(crate) fn route_daemon_interim_state(
         &mut self,
         expected_session_id: Option<Uuid>,
         session_id: Uuid,
         seq: u64,
         state: String,
     ) {
-        if !self.allow_session(expected_session_id, session_id) || !self.accept_seq(session_id, seq)
-        {
+        let Some(expected_session_id) = expected_session_id else {
+            self.metrics.note_session_mismatch_drop();
+            debug!(
+                incoming_session = %session_id,
+                "dropping daemon interim state without an active session"
+            );
             return;
-        }
+        };
 
-        self.maybe_emit_output_hint();
-        self.sink.on_overlay_event(OverlayEvent::InterimState {
+        self.route_interim_state(
+            Some(expected_session_id),
             session_id,
             seq,
             state,
-        });
-        self.metrics.note_interim_state();
+            OverlayTextProducer::DaemonSttInterim,
+        );
     }
 
-    pub(crate) fn route_interim_text(
+    pub(crate) fn route_daemon_interim_text(
         &mut self,
         expected_session_id: Option<Uuid>,
         session_id: Uuid,
         seq: u64,
         text: String,
     ) {
-        if !self.allow_session(expected_session_id, session_id) || !self.accept_seq(session_id, seq)
-        {
+        let Some(expected_session_id) = expected_session_id else {
+            self.metrics.note_session_mismatch_drop();
+            debug!(
+                incoming_session = %session_id,
+                "dropping daemon interim text without an active session"
+            );
             return;
-        }
+        };
 
-        self.maybe_emit_output_hint();
-        self.sink.on_overlay_event(OverlayEvent::InterimText {
+        self.route_interim_text(
+            Some(expected_session_id),
             session_id,
             seq,
             text,
-        });
-        self.metrics.note_interim_text();
+            OverlayTextProducer::DaemonSttInterim,
+        );
+    }
+
+    pub(crate) fn route_llm_answer_state(&mut self, session_id: Uuid, seq: u64, state: String) {
+        self.route_interim_state(
+            None,
+            session_id,
+            seq,
+            state,
+            OverlayTextProducer::LlmAnswerDelta,
+        );
+    }
+
+    pub(crate) fn route_llm_answer_delta(&mut self, session_id: Uuid, seq: u64, text: String) {
+        self.route_interim_text(
+            None,
+            session_id,
+            seq,
+            text,
+            OverlayTextProducer::LlmAnswerDelta,
+        );
     }
 
     pub(crate) fn route_audio_level(
@@ -289,9 +325,70 @@ impl<S: OverlaySink> OverlayRouter<S> {
 
         if self.active_session_id == Some(session_id) {
             self.active_session_id = None;
-            self.last_seq = None;
+            self.last_seq_by_producer.clear();
             self.last_output_name = None;
         }
+    }
+
+    fn route_interim_state(
+        &mut self,
+        expected_session_id: Option<Uuid>,
+        session_id: Uuid,
+        seq: u64,
+        state: String,
+        producer: OverlayTextProducer,
+    ) {
+        if !self.allow_session(expected_session_id, session_id)
+            || !self.accept_seq(session_id, seq, &producer)
+        {
+            return;
+        }
+
+        debug!(
+            session = %session_id,
+            seq,
+            overlay_text_producer = producer.as_str(),
+            "routing overlay interim state"
+        );
+        self.maybe_emit_output_hint();
+        self.sink.on_overlay_event(OverlayEvent::InterimState {
+            producer,
+            session_id,
+            seq,
+            state,
+        });
+        self.metrics.note_interim_state();
+    }
+
+    fn route_interim_text(
+        &mut self,
+        expected_session_id: Option<Uuid>,
+        session_id: Uuid,
+        seq: u64,
+        text: String,
+        producer: OverlayTextProducer,
+    ) {
+        if !self.allow_session(expected_session_id, session_id)
+            || !self.accept_seq(session_id, seq, &producer)
+        {
+            return;
+        }
+
+        debug!(
+            session = %session_id,
+            seq,
+            overlay_text_producer = producer.as_str(),
+            text_chars = text.chars().count(),
+            "routing overlay interim text"
+        );
+        self.maybe_emit_output_hint();
+        self.sink.on_overlay_event(OverlayEvent::InterimText {
+            producer,
+            session_id,
+            seq,
+            text,
+        });
+        self.metrics.note_interim_text();
     }
 
     pub(crate) fn route_injection_complete(&mut self, session_id: Uuid, success: bool) {
@@ -342,26 +439,32 @@ impl<S: OverlaySink> OverlayRouter<S> {
         }
     }
 
-    fn accept_seq(&mut self, incoming_session_id: Uuid, seq: u64) -> bool {
+    fn accept_seq(
+        &mut self,
+        incoming_session_id: Uuid,
+        seq: u64,
+        producer: &OverlayTextProducer,
+    ) -> bool {
         if self.active_session_id != Some(incoming_session_id) {
             self.active_session_id = Some(incoming_session_id);
-            self.last_seq = None;
+            self.last_seq_by_producer.clear();
         }
 
-        if let Some(last_seq) = self.last_seq {
-            if seq <= last_seq {
+        if let Some(last_seq) = self.last_seq_by_producer.get(producer) {
+            if seq <= *last_seq {
                 self.metrics.note_stale_seq_drop();
                 debug!(
                     session = %incoming_session_id,
                     seq,
                     last_seq,
+                    overlay_text_producer = producer.as_str(),
                     "dropping stale overlay event sequence"
                 );
                 return false;
             }
         }
 
-        self.last_seq = Some(seq);
+        self.last_seq_by_producer.insert(*producer, seq);
         true
     }
 }
@@ -373,7 +476,7 @@ mod tests {
 
     use uuid::Uuid;
 
-    use super::{OverlayEvent, OverlayRouter, OverlaySink};
+    use super::{OverlayEvent, OverlayRouter, OverlaySink, OverlayTextProducer};
 
     struct RecordingOverlaySink {
         seen: Arc<Mutex<Vec<OverlayEvent>>>,
@@ -405,9 +508,10 @@ mod tests {
         let session_id = Uuid::new_v4();
         let (sink, seen) = RecordingOverlaySink::new();
         let mut router = OverlayRouter::new(sink, None);
+        router.note_session_started(session_id);
 
-        router.route_interim_text(None, session_id, 10, "newest".to_string());
-        router.route_interim_text(None, session_id, 9, "stale".to_string());
+        router.route_daemon_interim_text(Some(session_id), session_id, 10, "newest".to_string());
+        router.route_daemon_interim_text(Some(session_id), session_id, 9, "stale".to_string());
 
         assert_eq!(
             router
@@ -421,11 +525,34 @@ mod tests {
                 .expect("overlay recording lock should be available")
                 .clone(),
             vec![OverlayEvent::InterimText {
+                producer: OverlayTextProducer::DaemonSttInterim,
                 session_id,
                 seq: 10,
                 text: "newest".to_string(),
             }]
         );
+    }
+
+    #[test]
+    fn daemon_interim_requires_active_client_session() {
+        let session_id = Uuid::new_v4();
+        let (sink, seen) = RecordingOverlaySink::new();
+        let mut router = OverlayRouter::new(sink, None);
+
+        router.route_daemon_interim_state(None, session_id, 1, "listening".to_string());
+        router.route_daemon_interim_text(None, session_id, 2, "late daemon".to_string());
+
+        assert_eq!(
+            router
+                .metrics()
+                .dropped_session_mismatch_total
+                .load(Ordering::Relaxed),
+            2
+        );
+        assert!(seen
+            .lock()
+            .expect("overlay recording lock should be available")
+            .is_empty());
     }
 
     #[test]
@@ -436,13 +563,13 @@ mod tests {
         let mut router = OverlayRouter::new(sink, None);
         router.note_session_started(active_session_id);
 
-        router.route_interim_text(
+        router.route_daemon_interim_text(
             Some(active_session_id),
             stale_session_id,
             1,
             "stale session".to_string(),
         );
-        router.route_interim_text(
+        router.route_daemon_interim_text(
             Some(active_session_id),
             active_session_id,
             1,
@@ -461,10 +588,68 @@ mod tests {
                 .expect("overlay recording lock should be available")
                 .clone(),
             vec![OverlayEvent::InterimText {
+                producer: OverlayTextProducer::DaemonSttInterim,
                 session_id: active_session_id,
                 seq: 1,
                 text: "active session".to_string(),
             }]
+        );
+    }
+
+    #[test]
+    fn daemon_and_llm_overlay_text_sequences_are_independent() {
+        let session_id = Uuid::new_v4();
+        let (sink, seen) = RecordingOverlaySink::new();
+        let mut router = OverlayRouter::new(sink, None);
+        router.note_session_started(session_id);
+
+        router.route_daemon_interim_text(
+            Some(session_id),
+            session_id,
+            10,
+            "daemon interim".to_string(),
+        );
+        router.route_llm_answer_delta(session_id, 1, "answer".to_string());
+        router.route_llm_answer_delta(session_id, 2, "answer delta".to_string());
+        router.route_daemon_interim_text(
+            Some(session_id),
+            session_id,
+            9,
+            "stale daemon".to_string(),
+        );
+        router.route_llm_answer_delta(session_id, 2, "stale llm".to_string());
+
+        assert_eq!(
+            router
+                .metrics()
+                .dropped_stale_seq_total
+                .load(Ordering::Relaxed),
+            2
+        );
+        assert_eq!(
+            seen.lock()
+                .expect("overlay recording lock should be available")
+                .clone(),
+            vec![
+                OverlayEvent::InterimText {
+                    producer: OverlayTextProducer::DaemonSttInterim,
+                    session_id,
+                    seq: 10,
+                    text: "daemon interim".to_string(),
+                },
+                OverlayEvent::InterimText {
+                    producer: OverlayTextProducer::LlmAnswerDelta,
+                    session_id,
+                    seq: 1,
+                    text: "answer".to_string(),
+                },
+                OverlayEvent::InterimText {
+                    producer: OverlayTextProducer::LlmAnswerDelta,
+                    session_id,
+                    seq: 2,
+                    text: "answer delta".to_string(),
+                },
+            ]
         );
     }
 

--- a/parakeet-ptt/src/overlay_state.rs
+++ b/parakeet-ptt/src/overlay_state.rs
@@ -1,8 +1,9 @@
+use std::collections::HashMap;
 use std::time::Duration;
 
 use uuid::Uuid;
 
-use crate::overlay_ipc::OverlayIpcMessage;
+use crate::overlay_ipc::{OverlayIpcMessage, OverlayTextProducer};
 
 pub const DEFAULT_AUTO_HIDE_AFTER_MS: u64 = 600;
 
@@ -102,7 +103,7 @@ pub enum ApplyOutcome {
 pub struct OverlayStateMachine {
     visibility: OverlayVisibility,
     active_session_id: Option<Uuid>,
-    last_seq: Option<u64>,
+    last_seq_by_producer: HashMap<OverlayTextProducer, u64>,
     finalize_deadline_ms: Option<u64>,
     auto_hide_after_ms: u64,
     warning_active: bool,
@@ -113,7 +114,7 @@ impl OverlayStateMachine {
         Self {
             visibility: OverlayVisibility::Hidden,
             active_session_id: None,
-            last_seq: None,
+            last_seq_by_producer: HashMap::new(),
             finalize_deadline_ms: None,
             auto_hide_after_ms: auto_hide_after.as_millis() as u64,
             warning_active: false,
@@ -133,10 +134,11 @@ impl OverlayStateMachine {
             OverlayIpcMessage::OutputHint { .. } => ApplyOutcome::Applied,
             OverlayIpcMessage::InterimState {
                 session_id,
+                producer,
                 seq,
                 state,
             } => {
-                if let Some(outcome) = self.apply_seq(session_id, seq) {
+                if let Some(outcome) = self.apply_seq(session_id, producer, seq) {
                     return outcome;
                 }
                 if state == "listening" {
@@ -152,10 +154,11 @@ impl OverlayStateMachine {
             }
             OverlayIpcMessage::InterimText {
                 session_id,
+                producer,
                 seq,
                 text,
             } => {
-                if let Some(outcome) = self.apply_seq(session_id, seq) {
+                if let Some(outcome) = self.apply_seq(session_id, producer, seq) {
                     return outcome;
                 }
                 self.visibility = OverlayVisibility::Interim { session_id, text };
@@ -178,7 +181,7 @@ impl OverlayStateMachine {
                 };
 
                 self.active_session_id = Some(session_id);
-                self.last_seq = None;
+                self.last_seq_by_producer.clear();
                 self.warning_active = false;
                 self.visibility = OverlayVisibility::Finalizing {
                     session_id,
@@ -205,7 +208,7 @@ impl OverlayStateMachine {
                 } if *finalizing_session == session_id => {
                     self.visibility = OverlayVisibility::Hidden;
                     self.active_session_id = None;
-                    self.last_seq = None;
+                    self.last_seq_by_producer.clear();
                     self.finalize_deadline_ms = None;
                     self.warning_active = false;
                     ApplyOutcome::Applied
@@ -220,7 +223,7 @@ impl OverlayStateMachine {
             if now_ms >= deadline_ms {
                 self.visibility = OverlayVisibility::Hidden;
                 self.active_session_id = None;
-                self.last_seq = None;
+                self.last_seq_by_producer.clear();
                 self.finalize_deadline_ms = None;
                 self.warning_active = false;
                 return true;
@@ -230,20 +233,25 @@ impl OverlayStateMachine {
         false
     }
 
-    fn apply_seq(&mut self, session_id: Uuid, seq: u64) -> Option<ApplyOutcome> {
+    fn apply_seq(
+        &mut self,
+        session_id: Uuid,
+        producer: OverlayTextProducer,
+        seq: u64,
+    ) -> Option<ApplyOutcome> {
         if self.active_session_id != Some(session_id) {
             self.active_session_id = Some(session_id);
-            self.last_seq = None;
+            self.last_seq_by_producer.clear();
             self.warning_active = false;
         }
 
-        if let Some(last_seq) = self.last_seq {
-            if seq <= last_seq {
+        if let Some(last_seq) = self.last_seq_by_producer.get(&producer) {
+            if seq <= *last_seq {
                 return Some(ApplyOutcome::DroppedStaleSeq);
             }
         }
 
-        self.last_seq = Some(seq);
+        self.last_seq_by_producer.insert(producer, seq);
         None
     }
 }
@@ -260,7 +268,7 @@ mod tests {
 
     use uuid::Uuid;
 
-    use crate::overlay_ipc::OverlayIpcMessage;
+    use crate::overlay_ipc::{OverlayIpcMessage, OverlayTextProducer};
 
     use super::{
         ApplyOutcome, OverlayRenderIntent, OverlayRenderPhase, OverlayStateMachine,
@@ -276,6 +284,7 @@ mod tests {
             machine.apply_event(
                 OverlayIpcMessage::InterimState {
                     session_id,
+                    producer: OverlayTextProducer::DaemonSttInterim,
                     seq: 1,
                     state: "listening".to_string(),
                 },
@@ -292,6 +301,7 @@ mod tests {
             machine.apply_event(
                 OverlayIpcMessage::InterimText {
                     session_id,
+                    producer: OverlayTextProducer::DaemonSttInterim,
                     seq: 2,
                     text: "hello".to_string(),
                 },
@@ -349,6 +359,7 @@ mod tests {
             machine.apply_event(
                 OverlayIpcMessage::InterimText {
                     session_id,
+                    producer: OverlayTextProducer::DaemonSttInterim,
                     seq: 10,
                     text: "newest".to_string(),
                 },
@@ -361,6 +372,7 @@ mod tests {
             machine.apply_event(
                 OverlayIpcMessage::InterimText {
                     session_id,
+                    producer: OverlayTextProducer::DaemonSttInterim,
                     seq: 9,
                     text: "stale".to_string(),
                 },
@@ -379,6 +391,85 @@ mod tests {
     }
 
     #[test]
+    fn state_machine_sequences_are_independent_by_text_producer() {
+        let mut machine = OverlayStateMachine::default();
+        let session_id = Uuid::new_v4();
+
+        assert_eq!(
+            machine.apply_event(
+                OverlayIpcMessage::InterimText {
+                    session_id,
+                    producer: OverlayTextProducer::DaemonSttInterim,
+                    seq: 10,
+                    text: "daemon interim".to_string(),
+                },
+                0
+            ),
+            ApplyOutcome::Applied
+        );
+
+        assert_eq!(
+            machine.apply_event(
+                OverlayIpcMessage::InterimState {
+                    session_id,
+                    producer: OverlayTextProducer::LlmAnswerDelta,
+                    seq: 1,
+                    state: "Generating answer...".to_string(),
+                },
+                1
+            ),
+            ApplyOutcome::Applied
+        );
+
+        assert_eq!(
+            machine.apply_event(
+                OverlayIpcMessage::InterimText {
+                    session_id,
+                    producer: OverlayTextProducer::LlmAnswerDelta,
+                    seq: 2,
+                    text: "answer".to_string(),
+                },
+                2
+            ),
+            ApplyOutcome::Applied
+        );
+
+        assert_eq!(
+            machine.apply_event(
+                OverlayIpcMessage::InterimText {
+                    session_id,
+                    producer: OverlayTextProducer::DaemonSttInterim,
+                    seq: 9,
+                    text: "stale daemon".to_string(),
+                },
+                3
+            ),
+            ApplyOutcome::DroppedStaleSeq
+        );
+
+        assert_eq!(
+            machine.apply_event(
+                OverlayIpcMessage::InterimText {
+                    session_id,
+                    producer: OverlayTextProducer::LlmAnswerDelta,
+                    seq: 2,
+                    text: "stale llm".to_string(),
+                },
+                4
+            ),
+            ApplyOutcome::DroppedStaleSeq
+        );
+
+        assert_eq!(
+            machine.visibility(),
+            &OverlayVisibility::Interim {
+                session_id,
+                text: "answer".to_string(),
+            }
+        );
+    }
+
+    #[test]
     fn session_ended_for_other_session_is_dropped() {
         let mut machine = OverlayStateMachine::default();
         let active_session = Uuid::new_v4();
@@ -388,6 +479,7 @@ mod tests {
             machine.apply_event(
                 OverlayIpcMessage::InterimState {
                     session_id: active_session,
+                    producer: OverlayTextProducer::DaemonSttInterim,
                     seq: 1,
                     state: "listening".to_string(),
                 },
@@ -425,6 +517,7 @@ mod tests {
             machine.apply_event(
                 OverlayIpcMessage::InterimText {
                     session_id: old_session,
+                    producer: OverlayTextProducer::DaemonSttInterim,
                     seq: 30,
                     text: "old".to_string(),
                 },
@@ -437,6 +530,7 @@ mod tests {
             machine.apply_event(
                 OverlayIpcMessage::InterimText {
                     session_id: new_session,
+                    producer: OverlayTextProducer::DaemonSttInterim,
                     seq: 1,
                     text: "new".to_string(),
                 },
@@ -536,6 +630,7 @@ mod tests {
             machine.apply_event(
                 OverlayIpcMessage::InterimText {
                     session_id,
+                    producer: OverlayTextProducer::DaemonSttInterim,
                     seq: 1,
                     text: "hello".to_string(),
                 },


### PR DESCRIPTION
## Summary
- separate Client Overlay text routing by producer for Daemon STT interim text and LLM answer deltas
- drop stale, mismatched, and no-active-session Daemon interim events before they can overwrite Client Overlay state
- keep LLM answer delta accumulation independent from Daemon interim transcript runtime truth
- carry the producer through the internal Overlay IPC boundary so the child renderer process keeps the same per-producer stale-sequence behavior as in-process test sinks
- keep the Daemon WebSocket protocol unchanged

Closes #111

## Acceptance Evidence
- Daemon `interim_text` routes only for the relevant active Session; stale, mismatched, and no-active-session events are dropped in `client_session`/router tests.
- LLM answer deltas accumulate and route to Overlay with the `llm_answer_delta` producer independently of Daemon STT interim text.
- Overlay router, IPC, and renderer-state diagnostics distinguish `daemon_stt_interim` from `llm_answer_delta`.
- Overlay renderer append animation remains a display concern; existing append/fade tests still prove appended chars animate without implying backend character-level streaming.
- No Daemon protocol changes; only internal Client Overlay routing/IPC carries producer metadata.
- Initial PR-gate Codex fallback finding about losing producer metadata at the overlay process boundary was fixed by carrying producer metadata through `OverlayIpcMessage` and making `OverlayStateMachine` track stale sequence cursors per producer.
- Rerun CodeRabbit finding about late Daemon interim updates without an active session was fixed by making Daemon interim state/text require an active Client session.

## Verification (#111)
- targeted: `cd parakeet-ptt && cargo test overlay_router -q` → PASSED
- targeted: `cd parakeet-ptt && cargo test client_session -q` → PASSED
- targeted: `cd parakeet-ptt && cargo test app_llm_answer_deltas_route_with_independent_overlay_producer -q` → PASSED
- regression: `cd parakeet-ptt && cargo test state_machine_sequences_are_independent_by_text_producer -q` → PASSED
- targeted: `cd parakeet-ptt && cargo test overlay_state -q` → PASSED
- targeted: `cd parakeet-ptt && cargo test overlay_process -q` → PASSED
- targeted: `cd parakeet-ptt && cargo test overlay_ipc -q` → PASSED
- renderer: `cd parakeet-ptt && cargo test appended_range -q` → PASSED
- renderer: `cd parakeet-ptt && cargo test char_fadein -q` → PASSED
- renderer: `cd parakeet-ptt && cargo test staggered_fade -q` → PASSED
- regression: producer-isolated routing, renderer-process producer preservation, no-active-session daemon interim drops, and stale/mismatched Session drops covered by expanded Rust tests → PASSED
- full suite: `cd parakeet-ptt && cargo test -q` → PASSED
- lint: `cd parakeet-ptt && cargo fmt --all --check` → PASSED
- lint/types: `cd parakeet-ptt && cargo clippy --all-targets --all-features -- -D warnings` → PASSED
- protocol/static: `cd parakeet-ptt && cargo test protocol_conformance -q` → PASSED
- whitespace: `git diff --check` → PASSED
- pre-commit: `prek run --all-files` → PASSED
- pre-push: `prek run --stage pre-push --all-files` → PASSED
- dead-code: N/A; repo has no Rust dead-code gate for this issue
- build: Rust test/clippy compile for touched crate targets → PASSED
- migrations: N/A
- CLI/script smoke: N/A
- UI render: N/A; renderer behavior covered by existing append/fade tests
- destructive/negative: N/A
- local review: `coderabbit_review_watch.py local --fallback-codex-review-args "" -- --base main` → clean (`.git/coderabbit-review/20260520T152153Z/status.json`)
- PR review: final `coderabbit_review_watch.py gate --pr 117 --fallback-codex-review-args ""` → clean (`.git/coderabbit-review/20260520T155101Z/gate-summary.json`). Earlier gate findings were fixed in `1c9cf9b` and `d44add8`.
- tests added/expanded: `parakeet-ptt/src/overlay_router.rs`, `parakeet-ptt/src/client_session.rs`, `parakeet-ptt/src/app.rs`, `parakeet-ptt/src/client_runtime_fixtures.rs`, `parakeet-ptt/src/overlay_ipc.rs`, `parakeet-ptt/src/overlay_state.rs`, `parakeet-ptt/src/overlay_process.rs`
- preexisting failures left: none
