### PR TITLE
Define Runtime Truth status contract

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -213,6 +213,9 @@ The canonical machine-checkable contract and fixtures live under [`docs/protocol
     }
     ```
   - `status`
+    This is the Daemon `/status` Runtime Truth contract. The canonical schema
+    is `docs/protocol/schema/messages.schema.json`; the example below is a
+    representative complete payload, not a second schema.
     ```json
     {
       "type": "status",
@@ -260,8 +263,15 @@ The canonical machine-checkable contract and fixtures live under [`docs/protocol
 
 ### Status Runtime Fields
 
+The JSON schema's `StatusMessage.x-runtime-truth-field-groups` metadata names
+the current Runtime Truth groups. This table explains the operational meaning
+of those fields; it must not diverge into a separate schema.
+
 | Field | JSON type | Values / units | Semantics |
 | --- | --- | --- | --- |
+| `device` | string or null | configured device name or `null` | Device requested for Daemon inference. |
+| `effective_device` | string or null | effective device name or `null` | Device actually used by the Daemon runtime. |
+| `gpu_mem_mb` | integer or null | MiB or `null` | CUDA reserved memory for the Daemon process when available. |
 | `stream_helper_scope` | string or null | `"live_session_only"` or `null` | Scope where the streaming helper is active. |
 | `stream_fallback_reason` | string or null | implementation-defined reason or `null` | Set when streaming is enabled but the helper is unavailable or degraded. |
 | `stream_path_executed` | boolean or null | `true`, `false`, or `null` | Whether the current or last Session actually exercised chunked Stream path work. |
@@ -286,6 +296,11 @@ The canonical machine-checkable contract and fixtures live under [`docs/protocol
 | `overlay_events_emitted` | integer or null | non-negative count or `null` | Delivered overlay events for the daemon event-sink lifetime. |
 | `overlay_events_dropped` | integer or null | non-negative count or `null` | Overlay events dropped because of queue pressure, backpressure, or disconnects for the daemon event-sink lifetime. |
 | `chunk_secs` | number or null | seconds, server setting range `0.1` to `10.0`, or `null` | Streaming chunk duration. Clients must accept any JSON number precision; current defaults commonly serialize with one decimal place. |
+| `active_session_age_ms` | integer or null | milliseconds or `null` | Age of the active Session when `/status` is sampled. |
+| `audio_stop_ms` | integer or null | milliseconds or `null` | Last completed Session audio-stop stage duration. |
+| `finalize_ms` | integer or null | milliseconds or `null` | Last completed Session Seal path finalization duration. |
+| `infer_ms` | integer or null | milliseconds or `null` | Last completed Session inference duration. |
+| `send_ms` | integer or null | milliseconds or `null` | Last completed Session final-result send duration. |
 
 Overlay event counters reset when the daemon process restarts.
 
@@ -295,11 +310,10 @@ Future messages (like `partial_result`) must be backward compatible; clients sho
 Clients must also tolerate unknown error codes and unknown additional fields.
 Fields beyond `state` and `sessions_active` in `status` should be treated as optional.
 `audio_stop_ms`, `finalize_ms`, `infer_ms`, and `send_ms` represent the last completed session's stage
-durations. `last_*` fields are retained for compatibility and will be deprecated after client uptake.
+durations. `last_*` fields mirror the same runtime timings for compatibility and will be deprecated after client uptake.
 Client logs expose user-visible Injection completion timings separately with
 `enqueue_to_injection_complete_ms`, `hotkey_up_elapsed_ms_at_completion`, and
 `stop_message_elapsed_ms_at_completion`.
-`gpu_mem_mb` reports CUDA reserved memory for the daemon process when running on a CUDA device.
 
 ---
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -310,7 +310,9 @@ Future messages (like `partial_result`) must be backward compatible; clients sho
 Clients must also tolerate unknown error codes and unknown additional fields.
 Fields beyond `state` and `sessions_active` in `status` should be treated as optional.
 `audio_stop_ms`, `finalize_ms`, `infer_ms`, and `send_ms` represent the last completed session's stage
-durations. `last_*` fields mirror the same runtime timings for compatibility and will be deprecated after client uptake.
+durations. `last_infer_ms` and `last_send_ms` mirror `infer_ms` and `send_ms`
+for compatibility. `last_audio_ms` is the last Session's total audio duration,
+not the audio-stop stage duration reported by `audio_stop_ms`.
 Client logs expose user-visible Injection completion timings separately with
 `enqueue_to_injection_complete_ms`, `hotkey_up_elapsed_ms_at_completion`, and
 `stop_message_elapsed_ms_at_completion`.

--- a/docs/protocol/README.md
+++ b/docs/protocol/README.md
@@ -7,14 +7,21 @@ The schema is the source of truth for known daemon/client message fields. The Py
 daemon and Rust client keep their hand-written codec APIs, but CI round-trips every
 fixture through both implementations so schema drift is visible.
 
+`StatusMessage` is also the protocol-level Runtime Truth contract for the
+Daemon `/status` payload. Its `x-runtime-truth-field-groups` metadata names the
+current contract groups used by Daemon tests and operator docs; do not create a
+second status schema in code, Helper diagnostics, or docs.
+
 ## Adding A Field
 
 1. Add the field to `docs/protocol/schema/messages.schema.json`.
 2. Update both codecs:
    - Python: `parakeet-stt-daemon/src/parakeet_stt_daemon/messages.py`
    - Rust: `parakeet-ptt/src/protocol.rs`
-3. Add or update a fixture in `docs/protocol/fixtures/` that carries the field.
-4. Run the conformance checks:
+3. If the field belongs to `StatusMessage`, add it to the Runtime Truth field
+   groups in the schema and Python message model.
+4. Add or update a fixture in `docs/protocol/fixtures/` that carries the field.
+5. Run the conformance checks:
    - `cd parakeet-stt-daemon && uv run pytest -q tests/test_protocol_conformance.py`
    - `cd parakeet-ptt && cargo test protocol_conformance`
 

--- a/docs/protocol/schema/messages.schema.json
+++ b/docs/protocol/schema/messages.schema.json
@@ -273,6 +273,66 @@
     },
     "StatusMessage": {
       "type": "object",
+      "title": "Runtime Truth Status",
+      "description": "Daemon /status payload and protocol-level Runtime Truth contract.",
+      "x-runtime-truth-field-groups": {
+        "core": [
+          "type",
+          "state",
+          "sessions_active"
+        ],
+        "device": [
+          "gpu_mem_mb",
+          "device",
+          "effective_device"
+        ],
+        "stream_path": [
+          "streaming_enabled",
+          "stream_helper_active",
+          "stream_helper_scope",
+          "stream_fallback_reason",
+          "stream_path_executed",
+          "stream_chunks_processed",
+          "chunk_secs"
+        ],
+        "seal_path": [
+          "finalization_mode",
+          "final_audio_source"
+        ],
+        "tail_trim_vad": [
+          "tail_trim_mode",
+          "vad_enabled",
+          "vad_active",
+          "vad_fallback_reason"
+        ],
+        "interim_transcript": [
+          "interim_transcript_enabled",
+          "interim_transcript_last_source",
+          "interim_transcript_live_chunks_processed",
+          "interim_transcript_stop_replay_chunks_processed",
+          "interim_transcript_updates_emitted",
+          "interim_transcript_live_updates_emitted",
+          "interim_transcript_stop_replay_updates_emitted",
+          "interim_transcript_live_failed",
+          "interim_transcript_stop_replay_failed",
+          "interim_transcript_source_fallback_reason"
+        ],
+        "overlay_transport": [
+          "overlay_events_enabled",
+          "overlay_events_emitted",
+          "overlay_events_dropped"
+        ],
+        "timing": [
+          "active_session_age_ms",
+          "audio_stop_ms",
+          "finalize_ms",
+          "infer_ms",
+          "send_ms",
+          "last_audio_ms",
+          "last_infer_ms",
+          "last_send_ms"
+        ]
+      },
       "additionalProperties": true,
       "required": [
         "type",

--- a/docs/stt-troubleshooting.md
+++ b/docs/stt-troubleshooting.md
@@ -55,12 +55,13 @@ Canonical-source policy:
 - `stt llm` manages a local `llama-server` in tmux session `parakeet-llm`, waits for `http://<host>:<port>/health`, then delegates to the normal `stt start` path.
 - Machine-local LLM overrides should stay in `PARAKEET_LLM_*` or `PARAKEET_LLM_SERVER_*` env vars from your shell or the ignored repo-local files; do not commit workstation-specific endpoints or launcher paths.
 
-Runtime truth for `/status` and daemon logs is produced by
-`parakeet_stt_daemon.runtime_truth_snapshot.RuntimeTruthSnapshot`. That module is
-the source of truth for effective device, Stream path helper state, Stream path
-execution evidence, Seal path finalization source, tail trim mode, VAD fallback,
-interim transcript source activity, and overlay-event enablement; the Helper should
-read those fields from `/status` instead of re-deriving them.
+Runtime truth for `/status` and Daemon logs is produced by the
+`parakeet_stt_daemon.runtime_truth_snapshot` module and serialized through the
+protocol `StatusMessage` Runtime Truth contract. That contract is the source of
+truth for effective device, Stream path helper state, Stream path execution
+evidence, Seal path finalization source, tail trim mode, VAD fallback, interim
+transcript source activity, overlay-event transport, timing, and counter fields;
+the Helper should read those fields from `/status` instead of re-deriving them.
 
 Use `stt status` for Helper process health: Daemon PID, Client PID, endpoint,
 tmux session, and matching processes. Use the Daemon `/status` payload, the
@@ -72,9 +73,11 @@ names, flags, or logs alone.
 
 ### Runtime truth field guide
 
+- Device and status core: `state`, `sessions_active`, `device`,
+  `effective_device`, and `gpu_mem_mb`.
 - Stream path: `streaming_enabled`, `stream_helper_active`,
   `stream_helper_scope`, `stream_fallback_reason`, `stream_path_executed`, and
-  `stream_chunks_processed`.
+  `stream_chunks_processed`, and `chunk_secs`.
 - Seal path: `finalization_mode`, `final_audio_source`, `tail_trim_mode`,
   `vad_enabled`, `vad_active`, `vad_fallback_reason`, and finalization timing
   fields such as `audio_stop_ms`, `finalize_ms`, `infer_ms`, and `send_ms`.
@@ -90,6 +93,9 @@ names, flags, or logs alone.
   `interim_transcript_source_fallback_reason`.
 - Overlay event transport: `overlay_events_enabled`,
   `overlay_events_emitted`, and `overlay_events_dropped`.
+- Timing and counters: `active_session_age_ms`, `audio_stop_ms`,
+  `finalize_ms`, `infer_ms`, `send_ms`, `last_audio_ms`, `last_infer_ms`, and
+  `last_send_ms`.
 - Client-side LLM answer deltas: generated and streamed by the Client in LLM
   query mode. They can update the Overlay while the local LLM answers, but they
   are not Daemon interim transcript fields and do not affect Stream path or Seal

--- a/parakeet-stt-daemon/src/parakeet_stt_daemon/messages.py
+++ b/parakeet-stt-daemon/src/parakeet_stt_daemon/messages.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 from enum import StrEnum
+from types import MappingProxyType
 from typing import Literal
 from uuid import UUID
 
@@ -48,6 +49,60 @@ class SessionEndReason(StrEnum):
     FINAL = "final"
     ABORT = "abort"
     ERROR = "error"
+
+
+STATUS_RUNTIME_TRUTH_FIELD_GROUPS: MappingProxyType[str, tuple[str, ...]] = MappingProxyType(
+    {
+        "core": ("type", "state", "sessions_active"),
+        "device": ("gpu_mem_mb", "device", "effective_device"),
+        "stream_path": (
+            "streaming_enabled",
+            "stream_helper_active",
+            "stream_helper_scope",
+            "stream_fallback_reason",
+            "stream_path_executed",
+            "stream_chunks_processed",
+            "chunk_secs",
+        ),
+        "seal_path": ("finalization_mode", "final_audio_source"),
+        "tail_trim_vad": (
+            "tail_trim_mode",
+            "vad_enabled",
+            "vad_active",
+            "vad_fallback_reason",
+        ),
+        "interim_transcript": (
+            "interim_transcript_enabled",
+            "interim_transcript_last_source",
+            "interim_transcript_live_chunks_processed",
+            "interim_transcript_stop_replay_chunks_processed",
+            "interim_transcript_updates_emitted",
+            "interim_transcript_live_updates_emitted",
+            "interim_transcript_stop_replay_updates_emitted",
+            "interim_transcript_live_failed",
+            "interim_transcript_stop_replay_failed",
+            "interim_transcript_source_fallback_reason",
+        ),
+        "overlay_transport": (
+            "overlay_events_enabled",
+            "overlay_events_emitted",
+            "overlay_events_dropped",
+        ),
+        "timing": (
+            "active_session_age_ms",
+            "audio_stop_ms",
+            "finalize_ms",
+            "infer_ms",
+            "send_ms",
+            "last_audio_ms",
+            "last_infer_ms",
+            "last_send_ms",
+        ),
+    }
+)
+STATUS_RUNTIME_TRUTH_FIELDS = frozenset(
+    field for fields in STATUS_RUNTIME_TRUTH_FIELD_GROUPS.values() for field in fields
+)
 
 
 class StartSession(BaseModel):
@@ -253,6 +308,8 @@ __all__ = [
     "ServerMessageType",
     "InterimStateValue",
     "SessionEndReason",
+    "STATUS_RUNTIME_TRUTH_FIELDS",
+    "STATUS_RUNTIME_TRUTH_FIELD_GROUPS",
     "StartSession",
     "StopSession",
     "AbortSession",

--- a/parakeet-stt-daemon/tests/test_protocol_conformance.py
+++ b/parakeet-stt-daemon/tests/test_protocol_conformance.py
@@ -9,6 +9,8 @@ from jsonschema import Draft202012Validator, FormatChecker
 from pydantic import BaseModel
 
 from parakeet_stt_daemon.messages import (
+    STATUS_RUNTIME_TRUTH_FIELD_GROUPS,
+    STATUS_RUNTIME_TRUTH_FIELDS,
     AbortSession,
     AudioLevelMessage,
     ErrorMessage,
@@ -135,6 +137,50 @@ def test_schema_properties_match_pydantic_model_fields(schema: dict[str, Any]) -
     for message_type, model in MODEL_BY_TYPE.items():
         schema_def = defs[SCHEMA_DEF_BY_TYPE[message_type]]
         assert set(schema_def["properties"]) == set(model.model_fields), message_type
+
+
+def test_status_schema_declares_runtime_truth_contract_groups(schema: dict[str, Any]) -> None:
+    status_def = schema["$defs"]["StatusMessage"]
+    schema_groups = status_def["x-runtime-truth-field-groups"]
+    expected_groups = {
+        group: list(fields) for group, fields in STATUS_RUNTIME_TRUTH_FIELD_GROUPS.items()
+    }
+
+    assert schema_groups == expected_groups
+    assert set().union(*(set(fields) for fields in schema_groups.values())) == set(
+        status_def["properties"]
+    )
+    assert set(status_def["properties"]) == STATUS_RUNTIME_TRUTH_FIELDS
+
+
+def test_status_fixtures_cover_complete_runtime_truth_contract() -> None:
+    for path in _fixture_paths():
+        fixture = _load_json(path)
+        if fixture["type"] != "status":
+            continue
+
+        assert set(fixture) == STATUS_RUNTIME_TRUTH_FIELDS, path.name
+
+
+def test_default_status_fixture_represents_current_runtime_truth_groups() -> None:
+    fixture = _load_json(FIXTURE_DIR / "status_default.json")
+
+    assert fixture["type"] == "status"
+    assert fixture["effective_device"] == "cuda"
+    assert fixture["streaming_enabled"] is True
+    assert fixture["stream_helper_active"] is True
+    assert fixture["stream_path_executed"] is True
+    assert fixture["stream_chunks_processed"] > 0
+    assert fixture["chunk_secs"] is not None
+    assert fixture["finalization_mode"] == "offline_seal"
+    assert fixture["final_audio_source"] == "canonical_session_audio"
+    assert fixture["interim_transcript_enabled"] is True
+    assert fixture["interim_transcript_updates_emitted"] > 0
+    assert fixture["overlay_events_enabled"] is True
+    assert fixture["overlay_events_emitted"] > 0
+    assert fixture["audio_stop_ms"] is not None
+    assert fixture["finalize_ms"] is not None
+    assert fixture["last_audio_ms"] is not None
 
 
 def test_known_message_models_tolerate_unknown_fields() -> None:


### PR DESCRIPTION
## Summary

- Defines `StatusMessage` as the explicit protocol-level Runtime Truth contract for Daemon `/status`.
- Adds named Runtime Truth field groups to the Python protocol model and mirrors them in JSON Schema metadata.
- Strengthens Daemon protocol conformance tests so status fixtures must cover the complete contract.
- Clarifies protocol/operator docs so `/status` remains the source of truth instead of a second schema.

Closes #118.

## Verification (#118)

- targeted: `cd parakeet-stt-daemon && uv run pytest tests/test_protocol_conformance.py tests/test_messages.py -q` -> PASSED (20 passed)
- regression: N/A - contract hardening/docs/test enhancement, not a bug fix
- full suite: `cd parakeet-stt-daemon && uv run pytest -q` -> PASSED (200 passed)
- protocol: `cd parakeet-ptt && cargo test protocol_conformance` -> PASSED (4 passed)
- lint: `uv run --project parakeet-stt-daemon ruff check --config parakeet-stt-daemon/pyproject.toml parakeet-stt-daemon/src/parakeet_stt_daemon/messages.py parakeet-stt-daemon/tests/test_protocol_conformance.py`; `uv run --project parakeet-stt-daemon ruff format --check --config parakeet-stt-daemon/pyproject.toml parakeet-stt-daemon/src/parakeet_stt_daemon/messages.py parakeet-stt-daemon/tests/test_protocol_conformance.py`; `prek run --all-files` -> PASSED
- types: `ty check --project parakeet-stt-daemon --error-on-warning` -> PASSED
- dead-code: N/A - no dead-code gate discovered for this surface
- build: `uv build parakeet-stt-daemon --out-dir .git/issue-118-build --clear` -> PASSED
- pre-commit: `prek run --all-files` -> PASSED; `prek run --stage pre-push --all-files` -> PASSED
- static/security: N/A - no separate static/security hook discovered for this surface
- migrations: N/A
- CLI/script smoke: N/A - no Helper/script behavior changed
- UI render: N/A
- destructive/negative: N/A
- docs follow-up fix: `git diff --check` -> PASSED; `prek run --files docs/SPEC.md` -> PASSED
- tests added/expanded: `parakeet-stt-daemon/tests/test_protocol_conformance.py`
- preexisting failures left: first `cd parakeet-ptt && cargo test -q` hit a transient `Text file busy (os error 26)` in `app::tests::injector_subprocess_runner_does_not_wait_for_background_grandchild_stderr_close`; retry passed and the pre-push Rust test hook passed.

## Review

- CodeRabbit local base review first reported one valid docs mismatch (`chunk_secs` missing from troubleshooting Stream path guide); fixed and reran.
- Final clean local CodeRabbit status before the follow-up docs commit: `.git/coderabbit-review/20260521T172736Z/status.json`.
- Final same-head local CodeRabbit attempts were rate-limited; helper fallback completed with Codex after using an empty fallback-scope override: `.git/coderabbit-review/20260521T174518Z/gate-summary.json`.
- Final PR-side CodeRabbit watcher gate: `.git/coderabbit-review/20260521T174755Z/gate-summary.json`, clean; remote CodeRabbit verdict `completed_clean`, no actionable findings.

## Deferrals

None.
