### PR TITLE
Reuse Runtime Truth status in Client

### DIFF
--- a/parakeet-ptt/src/app.rs
+++ b/parakeet-ptt/src/app.rs
@@ -11,7 +11,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
-use serde::Deserialize;
 use tokio::sync::mpsc;
 use tokio::time::{
     sleep, timeout, Duration as TokioDuration, Instant as TokioInstant, MissedTickBehavior,
@@ -39,7 +38,7 @@ use crate::injector_runtime::{
 };
 use crate::llm::{sanitize_model_answer, LlmAnswerer, LlmProgress};
 use crate::overlay_router::{OverlayRouter, OverlaySink};
-use crate::protocol::{start_message, stop_message, ClientMessage, ServerMessage};
+use crate::protocol::{start_message, stop_message, ClientMessage, DaemonStatus, ServerMessage};
 use crate::state::PttState;
 use crate::surface_focus::{WaylandFocusCache, WaylandFocusObservation};
 
@@ -1033,50 +1032,7 @@ fn session_intent_from_hotkey(intent: HotkeyIntent) -> SessionIntent {
     }
 }
 
-#[derive(Debug, Deserialize)]
-struct StatusInfo {
-    state: Option<String>,
-    sessions_active: Option<u32>,
-    gpu_mem_mb: Option<u64>,
-    device: Option<String>,
-    effective_device: Option<String>,
-    streaming_enabled: Option<bool>,
-    stream_helper_active: Option<bool>,
-    stream_helper_scope: Option<String>,
-    stream_fallback_reason: Option<String>,
-    stream_path_executed: Option<bool>,
-    stream_chunks_processed: Option<u64>,
-    finalization_mode: Option<String>,
-    final_audio_source: Option<String>,
-    tail_trim_mode: Option<String>,
-    vad_enabled: Option<bool>,
-    vad_active: Option<bool>,
-    vad_fallback_reason: Option<String>,
-    interim_transcript_enabled: Option<bool>,
-    interim_transcript_last_source: Option<String>,
-    interim_transcript_live_chunks_processed: Option<u64>,
-    interim_transcript_stop_replay_chunks_processed: Option<u64>,
-    interim_transcript_updates_emitted: Option<u64>,
-    interim_transcript_live_updates_emitted: Option<u64>,
-    interim_transcript_stop_replay_updates_emitted: Option<u64>,
-    interim_transcript_live_failed: Option<bool>,
-    interim_transcript_stop_replay_failed: Option<bool>,
-    interim_transcript_source_fallback_reason: Option<String>,
-    overlay_events_enabled: Option<bool>,
-    overlay_events_emitted: Option<u64>,
-    overlay_events_dropped: Option<u64>,
-    chunk_secs: Option<f64>,
-    active_session_age_ms: Option<u64>,
-    audio_stop_ms: Option<u64>,
-    finalize_ms: Option<u64>,
-    infer_ms: Option<u64>,
-    send_ms: Option<u64>,
-    last_audio_ms: Option<u64>,
-    last_infer_ms: Option<u64>,
-    last_send_ms: Option<u64>,
-}
-
-fn format_daemon_status(status: &StatusInfo) -> String {
+fn format_daemon_status(status: &DaemonStatus) -> String {
     format!(
         "Daemon status: state={:?}, sessions_active={:?}, device={:?}, effective_device={:?}, \
 streaming={:?}, helper_active={:?}, helper_scope={:?}, stream_path_executed={:?}, \
@@ -1088,8 +1044,8 @@ interim_stop_replay_updates={:?}, interim_live_failed={:?}, interim_stop_replay_
 interim_fallback={:?}, overlay_enabled={:?}, overlay_emitted={:?}, overlay_dropped={:?}, \
 chunk_secs={:?}, active_age_ms={:?}, audio_stop_ms={:?}, finalize_ms={:?}, infer_ms={:?}, \
 send_ms={:?}, last_audio_ms={:?}, last_infer_ms={:?}, last_send_ms={:?}, gpu_mem_mb={:?}",
-        status.state,
-        status.sessions_active,
+        Some(status.state.as_str()),
+        Some(status.sessions_active),
         status.device,
         status.effective_device,
         status.streaming_enabled,
@@ -1141,9 +1097,15 @@ async fn fetch_status_once(config: &ClientConfig) {
         .send()
         .await
     {
-        Ok(response) => match response.json::<StatusInfo>().await {
-            Ok(status) => {
+        Ok(response) => match response.json::<ServerMessage>().await {
+            Ok(ServerMessage::Status(status)) => {
                 info!("{}", format_daemon_status(&status));
+            }
+            Ok(other) => {
+                warn!(
+                    "Failed to decode daemon status from {}: expected status message, got {:?}",
+                    url, other
+                );
             }
             Err(err) => {
                 warn!("Failed to decode daemon status from {}: {}", url, err);
@@ -1188,7 +1150,7 @@ mod tests {
         TextInjector,
     };
     use crate::overlay_router::{OverlayEvent, OverlayRouter, OverlayTextProducer};
-    use crate::protocol::{ClientMessage, ServerMessage};
+    use crate::protocol::{ClientMessage, DaemonStatus, ServerMessage};
     use crate::state::PttState;
 
     use crate::injector::INJECTOR_JOB_TIMEOUT_MS;
@@ -1203,17 +1165,22 @@ mod tests {
     use super::{
         clear_transient_session_state, format_daemon_status, handle_injection_report,
         maybe_defer_llm_session_end, run, CapturedParentFocus, HotkeyIntentDiagnostics,
-        SessionIntent, StatusInfo, TransientSessionState,
+        SessionIntent, TransientSessionState,
     };
 
     #[test]
-    fn status_info_accepts_minimal_legacy_payload() {
-        let status: StatusInfo =
-            serde_json::from_str(r#"{"type":"status","state":"idle","sessions_active":0}"#)
-                .expect("minimal status payload should parse");
+    fn daemon_status_accepts_minimal_protocol_payload() {
+        let status = match serde_json::from_str::<ServerMessage>(
+            r#"{"type":"status","state":"idle","sessions_active":0}"#,
+        )
+        .expect("minimal status payload should parse")
+        {
+            ServerMessage::Status(status) => status,
+            other => panic!("expected status message, got {other:?}"),
+        };
 
-        assert_eq!(status.state.as_deref(), Some("idle"));
-        assert_eq!(status.sessions_active, Some(0));
+        assert_eq!(status.state, "idle");
+        assert_eq!(status.sessions_active, 0);
         assert_eq!(status.stream_path_executed, None);
         assert_eq!(status.finalization_mode, None);
         assert_eq!(status.interim_transcript_enabled, None);
@@ -1222,6 +1189,8 @@ mod tests {
         assert_eq!(status.gpu_mem_mb, None);
 
         let summary = format_daemon_status(&status);
+        assert!(summary.contains("state=Some(\"idle\")"));
+        assert!(summary.contains("sessions_active=Some(0)"));
         assert!(summary.contains("stream_path_executed=None"));
         assert!(summary.contains("finalization_mode=None"));
         assert!(summary.contains("interim_enabled=None"));
@@ -1229,15 +1198,35 @@ mod tests {
     }
 
     #[test]
-    fn status_info_preserves_and_formats_interim_truth_fixture() {
+    fn daemon_status_standalone_type_accepts_status_payload() {
+        let status: DaemonStatus =
+            serde_json::from_str(r#"{"type":"status","state":"idle","sessions_active":0}"#)
+                .expect("minimal status payload should parse");
+
+        assert_eq!(status.state, "idle");
+        assert_eq!(status.sessions_active, 0);
+        assert_eq!(status.stream_path_executed, None);
+        assert_eq!(status.finalization_mode, None);
+        assert_eq!(status.interim_transcript_enabled, None);
+        assert_eq!(status.interim_transcript_last_source, None);
+        assert_eq!(status.overlay_events_enabled, None);
+        assert_eq!(status.gpu_mem_mb, None);
+    }
+
+    #[test]
+    fn daemon_status_preserves_and_formats_interim_truth_fixture() {
         let fixture_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("../docs/protocol/fixtures/status_stream_fallback.json");
         let fixture = fs::read_to_string(fixture_path).expect("status fixture should be readable");
-        let status: StatusInfo =
-            serde_json::from_str(&fixture).expect("status fixture should parse");
+        let status = match serde_json::from_str::<ServerMessage>(&fixture)
+            .expect("status fixture should parse")
+        {
+            ServerMessage::Status(status) => status,
+            other => panic!("expected status message, got {other:?}"),
+        };
 
-        assert_eq!(status.state.as_deref(), Some("idle"));
-        assert_eq!(status.sessions_active, Some(0));
+        assert_eq!(status.state, "idle");
+        assert_eq!(status.sessions_active, 0);
         assert_eq!(status.gpu_mem_mb, Some(1024));
         assert_eq!(status.device.as_deref(), Some("cuda"));
         assert_eq!(status.effective_device.as_deref(), Some("cuda"));

--- a/parakeet-ptt/src/client_session.rs
+++ b/parakeet-ptt/src/client_session.rs
@@ -167,7 +167,7 @@ pub(crate) async fn handle_server_message<S: OverlaySink>(
             );
             overlay_router.route_session_warning(session_id);
         }
-        ServerMessage::Status { .. } => {}
+        ServerMessage::Status(_) => {}
     }
     Ok(())
 }

--- a/parakeet-ptt/src/protocol.rs
+++ b/parakeet-ptt/src/protocol.rs
@@ -24,6 +24,49 @@ pub enum ClientMessage {
     },
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DaemonStatus {
+    pub state: String,
+    pub sessions_active: u32,
+    pub gpu_mem_mb: Option<u64>,
+    pub device: Option<String>,
+    pub effective_device: Option<String>,
+    pub streaming_enabled: Option<bool>,
+    pub stream_helper_active: Option<bool>,
+    pub stream_helper_scope: Option<String>,
+    pub stream_fallback_reason: Option<String>,
+    pub stream_path_executed: Option<bool>,
+    pub stream_chunks_processed: Option<u64>,
+    pub finalization_mode: Option<String>,
+    pub final_audio_source: Option<String>,
+    pub tail_trim_mode: Option<String>,
+    pub vad_enabled: Option<bool>,
+    pub vad_active: Option<bool>,
+    pub vad_fallback_reason: Option<String>,
+    pub interim_transcript_enabled: Option<bool>,
+    pub interim_transcript_last_source: Option<String>,
+    pub interim_transcript_live_chunks_processed: Option<u64>,
+    pub interim_transcript_stop_replay_chunks_processed: Option<u64>,
+    pub interim_transcript_updates_emitted: Option<u64>,
+    pub interim_transcript_live_updates_emitted: Option<u64>,
+    pub interim_transcript_stop_replay_updates_emitted: Option<u64>,
+    pub interim_transcript_live_failed: Option<bool>,
+    pub interim_transcript_stop_replay_failed: Option<bool>,
+    pub interim_transcript_source_fallback_reason: Option<String>,
+    pub overlay_events_enabled: Option<bool>,
+    pub overlay_events_emitted: Option<u64>,
+    pub overlay_events_dropped: Option<u64>,
+    pub chunk_secs: Option<f64>,
+    pub active_session_age_ms: Option<u64>,
+    pub audio_stop_ms: Option<u64>,
+    pub finalize_ms: Option<u64>,
+    pub infer_ms: Option<u64>,
+    pub send_ms: Option<u64>,
+    pub last_audio_ms: Option<u64>,
+    pub last_infer_ms: Option<u64>,
+    pub last_send_ms: Option<u64>,
+}
+
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 #[allow(clippy::large_enum_variant)] // Keep serde's wire shape direct; Status is the only large payload.
@@ -47,47 +90,7 @@ pub enum ServerMessage {
         code: String,
         message: String,
     },
-    Status {
-        state: String,
-        sessions_active: u32,
-        gpu_mem_mb: Option<u64>,
-        device: Option<String>,
-        effective_device: Option<String>,
-        streaming_enabled: Option<bool>,
-        stream_helper_active: Option<bool>,
-        stream_helper_scope: Option<String>,
-        stream_fallback_reason: Option<String>,
-        stream_path_executed: Option<bool>,
-        stream_chunks_processed: Option<u64>,
-        finalization_mode: Option<String>,
-        final_audio_source: Option<String>,
-        tail_trim_mode: Option<String>,
-        vad_enabled: Option<bool>,
-        vad_active: Option<bool>,
-        vad_fallback_reason: Option<String>,
-        interim_transcript_enabled: Option<bool>,
-        interim_transcript_last_source: Option<String>,
-        interim_transcript_live_chunks_processed: Option<u64>,
-        interim_transcript_stop_replay_chunks_processed: Option<u64>,
-        interim_transcript_updates_emitted: Option<u64>,
-        interim_transcript_live_updates_emitted: Option<u64>,
-        interim_transcript_stop_replay_updates_emitted: Option<u64>,
-        interim_transcript_live_failed: Option<bool>,
-        interim_transcript_stop_replay_failed: Option<bool>,
-        interim_transcript_source_fallback_reason: Option<String>,
-        overlay_events_enabled: Option<bool>,
-        overlay_events_emitted: Option<u64>,
-        overlay_events_dropped: Option<u64>,
-        chunk_secs: Option<f64>,
-        active_session_age_ms: Option<u64>,
-        audio_stop_ms: Option<u64>,
-        finalize_ms: Option<u64>,
-        infer_ms: Option<u64>,
-        send_ms: Option<u64>,
-        last_audio_ms: Option<u64>,
-        last_infer_ms: Option<u64>,
-        last_send_ms: Option<u64>,
-    },
+    Status(DaemonStatus),
     InterimState {
         session_id: Uuid,
         seq: u64,
@@ -191,9 +194,10 @@ pub fn abort_message(session_id: Uuid, reason: &str) -> ClientMessage {
 
 #[cfg(test)]
 mod tests {
+    use serde_json::json;
     use uuid::Uuid;
 
-    use super::{decode_server_message, DecodedServerMessage, ServerMessage};
+    use super::{decode_server_message, DaemonStatus, DecodedServerMessage, ServerMessage};
 
     #[test]
     fn status_deserializes_when_optional_fields_are_missing() {
@@ -202,89 +206,73 @@ mod tests {
             serde_json::from_str(raw).expect("status payload should deserialize");
 
         match msg {
-            ServerMessage::Status {
-                state,
-                sessions_active,
-                gpu_mem_mb,
-                device,
-                effective_device,
-                streaming_enabled,
-                stream_helper_active,
-                stream_helper_scope,
-                stream_fallback_reason,
-                stream_path_executed,
-                stream_chunks_processed,
-                finalization_mode,
-                final_audio_source,
-                tail_trim_mode,
-                vad_enabled,
-                vad_active,
-                vad_fallback_reason,
-                interim_transcript_enabled,
-                interim_transcript_last_source,
-                interim_transcript_live_chunks_processed,
-                interim_transcript_stop_replay_chunks_processed,
-                interim_transcript_updates_emitted,
-                interim_transcript_live_updates_emitted,
-                interim_transcript_stop_replay_updates_emitted,
-                interim_transcript_live_failed,
-                interim_transcript_stop_replay_failed,
-                interim_transcript_source_fallback_reason,
-                overlay_events_enabled,
-                overlay_events_emitted,
-                overlay_events_dropped,
-                chunk_secs,
-                active_session_age_ms,
-                audio_stop_ms,
-                finalize_ms,
-                infer_ms,
-                send_ms,
-                last_audio_ms,
-                last_infer_ms,
-                last_send_ms,
-            } => {
-                assert_eq!(state, "idle");
-                assert_eq!(sessions_active, 0);
-                assert_eq!(gpu_mem_mb, None);
-                assert_eq!(device, None);
-                assert_eq!(effective_device, None);
-                assert_eq!(streaming_enabled, None);
-                assert_eq!(stream_helper_active, None);
-                assert_eq!(stream_helper_scope, None);
-                assert_eq!(stream_fallback_reason, None);
-                assert_eq!(stream_path_executed, None);
-                assert_eq!(stream_chunks_processed, None);
-                assert_eq!(finalization_mode, None);
-                assert_eq!(final_audio_source, None);
-                assert_eq!(tail_trim_mode, None);
-                assert_eq!(vad_enabled, None);
-                assert_eq!(vad_active, None);
-                assert_eq!(vad_fallback_reason, None);
-                assert_eq!(interim_transcript_enabled, None);
-                assert_eq!(interim_transcript_last_source, None);
-                assert_eq!(interim_transcript_live_chunks_processed, None);
-                assert_eq!(interim_transcript_stop_replay_chunks_processed, None);
-                assert_eq!(interim_transcript_updates_emitted, None);
-                assert_eq!(interim_transcript_live_updates_emitted, None);
-                assert_eq!(interim_transcript_stop_replay_updates_emitted, None);
-                assert_eq!(interim_transcript_live_failed, None);
-                assert_eq!(interim_transcript_stop_replay_failed, None);
-                assert_eq!(interim_transcript_source_fallback_reason, None);
-                assert_eq!(overlay_events_enabled, None);
-                assert_eq!(overlay_events_emitted, None);
-                assert_eq!(overlay_events_dropped, None);
-                assert_eq!(chunk_secs, None);
-                assert_eq!(active_session_age_ms, None);
-                assert_eq!(audio_stop_ms, None);
-                assert_eq!(finalize_ms, None);
-                assert_eq!(infer_ms, None);
-                assert_eq!(send_ms, None);
-                assert_eq!(last_audio_ms, None);
-                assert_eq!(last_infer_ms, None);
-                assert_eq!(last_send_ms, None);
+            ServerMessage::Status(status) => {
+                assert_eq!(status.state, "idle");
+                assert_eq!(status.sessions_active, 0);
+                assert_eq!(status.gpu_mem_mb, None);
+                assert_eq!(status.device, None);
+                assert_eq!(status.effective_device, None);
+                assert_eq!(status.streaming_enabled, None);
+                assert_eq!(status.stream_helper_active, None);
+                assert_eq!(status.stream_helper_scope, None);
+                assert_eq!(status.stream_fallback_reason, None);
+                assert_eq!(status.stream_path_executed, None);
+                assert_eq!(status.stream_chunks_processed, None);
+                assert_eq!(status.finalization_mode, None);
+                assert_eq!(status.final_audio_source, None);
+                assert_eq!(status.tail_trim_mode, None);
+                assert_eq!(status.vad_enabled, None);
+                assert_eq!(status.vad_active, None);
+                assert_eq!(status.vad_fallback_reason, None);
+                assert_eq!(status.interim_transcript_enabled, None);
+                assert_eq!(status.interim_transcript_last_source, None);
+                assert_eq!(status.interim_transcript_live_chunks_processed, None);
+                assert_eq!(status.interim_transcript_stop_replay_chunks_processed, None);
+                assert_eq!(status.interim_transcript_updates_emitted, None);
+                assert_eq!(status.interim_transcript_live_updates_emitted, None);
+                assert_eq!(status.interim_transcript_stop_replay_updates_emitted, None);
+                assert_eq!(status.interim_transcript_live_failed, None);
+                assert_eq!(status.interim_transcript_stop_replay_failed, None);
+                assert_eq!(status.interim_transcript_source_fallback_reason, None);
+                assert_eq!(status.overlay_events_enabled, None);
+                assert_eq!(status.overlay_events_emitted, None);
+                assert_eq!(status.overlay_events_dropped, None);
+                assert_eq!(status.chunk_secs, None);
+                assert_eq!(status.active_session_age_ms, None);
+                assert_eq!(status.audio_stop_ms, None);
+                assert_eq!(status.finalize_ms, None);
+                assert_eq!(status.infer_ms, None);
+                assert_eq!(status.send_ms, None);
+                assert_eq!(status.last_audio_ms, None);
+                assert_eq!(status.last_infer_ms, None);
+                assert_eq!(status.last_send_ms, None);
             }
             other => panic!("expected status message, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn status_payload_uses_shared_runtime_truth_type() {
+        let raw = r#"{"type":"status","state":"listening","sessions_active":1,"stream_path_executed":true,"chunk_secs":2.4}"#;
+        let status_from_http: DaemonStatus =
+            serde_json::from_str(raw).expect("status payload should decode by shared type");
+        let status_from_protocol = match serde_json::from_str::<ServerMessage>(raw)
+            .expect("status payload should decode as a server message")
+        {
+            ServerMessage::Status(status) => status,
+            other => panic!("expected status message, got {other:?}"),
+        };
+
+        assert_eq!(status_from_http, status_from_protocol);
+        assert_eq!(status_from_http.state, "listening");
+        assert_eq!(status_from_http.sessions_active, 1);
+        assert_eq!(status_from_http.stream_path_executed, Some(true));
+        assert_eq!(status_from_http.chunk_secs, Some(2.4));
+
+        let encoded = serde_json::to_value(ServerMessage::Status(status_from_http))
+            .expect("serialize status");
+        assert_eq!(encoded["type"], json!("status"));
+        assert_eq!(encoded["stream_path_executed"], json!(true));
     }
 
     #[test]
@@ -405,7 +393,7 @@ mod tests {
                 code: "SESSION_ABORTED".to_string(),
                 message: "aborted".to_string(),
             },
-            ServerMessage::Status {
+            ServerMessage::Status(DaemonStatus {
                 state: "idle".to_string(),
                 sessions_active: 0,
                 gpu_mem_mb: None,
@@ -445,7 +433,7 @@ mod tests {
                 last_audio_ms: None,
                 last_infer_ms: None,
                 last_send_ms: None,
-            },
+            }),
             ServerMessage::InterimState {
                 session_id,
                 seq: 1,


### PR DESCRIPTION
## Summary
- Add exported `DaemonStatus` protocol payload and use it for `ServerMessage::Status`.
- Decode Client startup `/status` through `ServerMessage` instead of the private `StatusInfo` duplicate.
- Update protocol and Client tests for minimal status payloads and Runtime Truth fixtures.

## Verification
- `cd parakeet-ptt && cargo test protocol::tests`
- `cd parakeet-ptt && cargo test daemon_status`
- `cd parakeet-ptt && cargo test protocol_conformance`
- `cd parakeet-ptt && cargo test -q`
- `cd parakeet-ptt && cargo fmt --all --check`
- `cd parakeet-ptt && cargo clippy --all-targets --all-features -- -D warnings`
- `cd parakeet-ptt && cargo build --bins`
- `cd parakeet-stt-daemon && uv run pytest tests/test_protocol_conformance.py -q`
- `prek run --all-files`
- `prek run --stage pre-push --all-files`

## Deferrals
- None.

Closes #119

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal status message handling to consolidate status information into a unified structure for improved consistency across components.
  * Enhanced protocol message dispatching for better alignment and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SystemicVoid/parakeet-stt/pull/137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->