### PR TITLE
Derive Helper Runtime Truth fields from protocol schema

### DIFF
--- a/docs/stt-troubleshooting.md
+++ b/docs/stt-troubleshooting.md
@@ -64,8 +64,9 @@ transcript source activity, overlay-event transport, timing, and counter fields;
 the Helper should read those fields from `/status` instead of re-deriving them.
 
 Use `stt status` for Helper process health: Daemon PID, Client PID, endpoint,
-tmux session, and matching processes. Use the Daemon `/status` payload, the
-Client startup status log line, and Daemon session runtime truth logs for
+tmux session, matching processes, and the normalized Daemon Runtime Truth block
+when `/status` is available. Use the Daemon `/status` payload, the Client
+startup status log line, and Daemon session runtime truth logs for deeper
 runtime truth. The Helper may parse `/status` to decide whether an existing
 Daemon matches the requested Profile, but shell logic should not infer Stream
 path, Seal path, interim transcript, or Overlay transport state from process

--- a/parakeet-stt-daemon/tests/test_stt_helper_runtime_profiles.py
+++ b/parakeet-stt-daemon/tests/test_stt_helper_runtime_profiles.py
@@ -6,6 +6,8 @@ import json
 import os
 import shlex
 import subprocess
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
@@ -16,9 +18,32 @@ from parakeet_stt_daemon.config import (
     daemon_status_url,
     daemon_websocket_endpoint,
 )
+from parakeet_stt_daemon.messages import (
+    STATUS_RUNTIME_TRUTH_FIELD_GROUPS,
+    STATUS_RUNTIME_TRUTH_FIELDS,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 HELPER_PATH = REPO_ROOT / "scripts" / "stt-helper.sh"
+
+
+@contextmanager
+def _preserve_paths(*paths: Path) -> Iterator[None]:
+    snapshots = {path: path.read_bytes() if path.exists() else None for path in paths}
+    try:
+        yield
+    finally:
+        for path, snapshot in snapshots.items():
+            if snapshot is None:
+                path.unlink(missing_ok=True)
+            else:
+                path.write_bytes(snapshot)
+
+
+def _write_fake_command(bin_dir: Path, name: str, script: str) -> None:
+    command_path = bin_dir / name
+    command_path.write_text(script, encoding="utf-8")
+    command_path.chmod(0o755)
 
 
 def _run_runtime_config(*args: str, extra_env: dict[str, str] | None = None) -> dict[str, str]:
@@ -173,11 +198,16 @@ def _run_status_runtime_truth(payload_path: Path) -> dict[str, str]:
     return truth
 
 
+def _runtime_truth_contract_fields() -> list[str]:
+    return [field for fields in STATUS_RUNTIME_TRUTH_FIELD_GROUPS.values() for field in fields]
+
+
 def _status_payload(**overrides: object) -> dict[str, object]:
     payload: dict[str, object] = {
         "type": "status",
         "state": "idle",
         "sessions_active": 0,
+        "gpu_mem_mb": 1024,
         "device": "cuda",
         "effective_device": "cpu",
         "streaming_enabled": True,
@@ -193,7 +223,27 @@ def _status_payload(**overrides: object) -> dict[str, object]:
         "vad_enabled": True,
         "vad_active": False,
         "vad_fallback_reason": "load_failed:missing_dependency:onnxruntime",
+        "interim_transcript_enabled": True,
+        "interim_transcript_last_source": "live",
+        "interim_transcript_live_chunks_processed": 2,
+        "interim_transcript_stop_replay_chunks_processed": 1,
+        "interim_transcript_updates_emitted": 3,
+        "interim_transcript_live_updates_emitted": 2,
+        "interim_transcript_stop_replay_updates_emitted": 1,
+        "interim_transcript_live_failed": False,
+        "interim_transcript_stop_replay_failed": False,
+        "interim_transcript_source_fallback_reason": None,
         "overlay_events_enabled": True,
+        "overlay_events_emitted": 9,
+        "overlay_events_dropped": 1,
+        "active_session_age_ms": 321,
+        "audio_stop_ms": 0,
+        "finalize_ms": 4,
+        "infer_ms": 5,
+        "send_ms": 6,
+        "last_audio_ms": 2400,
+        "last_infer_ms": 7,
+        "last_send_ms": 8,
     }
     payload.update(overrides)
     return payload
@@ -421,7 +471,13 @@ def test_daemon_status_runtime_truth_reads_status_fields_unchanged(tmp_path: Pat
 
     truth = _run_status_runtime_truth(payload_path)
 
+    assert set(truth) == STATUS_RUNTIME_TRUTH_FIELDS
+    assert list(truth) == _runtime_truth_contract_fields()
     assert truth == {
+        "type": "status",
+        "state": "idle",
+        "sessions_active": "0",
+        "gpu_mem_mb": "1024",
         "device": "cuda",
         "effective_device": "cpu",
         "streaming_enabled": "true",
@@ -437,7 +493,27 @@ def test_daemon_status_runtime_truth_reads_status_fields_unchanged(tmp_path: Pat
         "vad_enabled": "true",
         "vad_active": "false",
         "vad_fallback_reason": "load_failed:missing_dependency:onnxruntime",
+        "interim_transcript_enabled": "true",
+        "interim_transcript_last_source": "live",
+        "interim_transcript_live_chunks_processed": "2",
+        "interim_transcript_stop_replay_chunks_processed": "1",
+        "interim_transcript_updates_emitted": "3",
+        "interim_transcript_live_updates_emitted": "2",
+        "interim_transcript_stop_replay_updates_emitted": "1",
+        "interim_transcript_live_failed": "false",
+        "interim_transcript_stop_replay_failed": "false",
+        "interim_transcript_source_fallback_reason": "",
         "overlay_events_enabled": "true",
+        "overlay_events_emitted": "9",
+        "overlay_events_dropped": "1",
+        "active_session_age_ms": "321",
+        "audio_stop_ms": "0",
+        "finalize_ms": "4",
+        "infer_ms": "5",
+        "send_ms": "6",
+        "last_audio_ms": "2400",
+        "last_infer_ms": "7",
+        "last_send_ms": "8",
     }
 
 
@@ -452,24 +528,12 @@ def test_daemon_status_runtime_truth_accepts_minimal_protocol_status(
 
     truth = _run_status_runtime_truth(payload_path)
 
-    assert truth == {
-        "device": "",
-        "effective_device": "",
-        "streaming_enabled": "",
-        "stream_helper_active": "",
-        "stream_helper_scope": "",
-        "stream_fallback_reason": "",
-        "stream_path_executed": "",
-        "stream_chunks_processed": "",
-        "chunk_secs": "",
-        "finalization_mode": "",
-        "final_audio_source": "",
-        "tail_trim_mode": "",
-        "vad_enabled": "",
-        "vad_active": "",
-        "vad_fallback_reason": "",
-        "overlay_events_enabled": "",
-    }
+    assert set(truth) == STATUS_RUNTIME_TRUTH_FIELDS
+    assert truth["type"] == "status"
+    assert truth["state"] == "idle"
+    assert truth["sessions_active"] == "0"
+    for field in STATUS_RUNTIME_TRUTH_FIELDS - {"type", "state", "sessions_active"}:
+        assert truth[field] == ""
 
 
 def test_daemon_status_runtime_truth_normalizes_numeric_string(tmp_path: Path) -> None:
@@ -534,3 +598,102 @@ def test_status_runtime_truth_rejects_non_finite_numeric_tokens(tmp_path: Path) 
 
         with pytest.raises(subprocess.CalledProcessError):
             _run_status_runtime_truth(payload_path)
+
+
+def test_status_uses_persisted_daemon_authority_for_liveness(
+    tmp_path: Path,
+) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    listener_port = "9876"
+    listener_pid = "424242"
+    expected_status_url = f"http://127.0.0.1:{listener_port}/status"
+    curl_url_file = tmp_path / "curl-url.txt"
+
+    _write_fake_command(
+        fake_bin,
+        "lsof",
+        """#!/usr/bin/env bash
+if [ "${1:-}" = "-tiTCP:${STT_TEST_LISTENER_PORT}" ]; then
+    printf '%s\\n' "$STT_TEST_LISTENER_PID"
+    exit 0
+fi
+exit 1
+""",
+    )
+    _write_fake_command(
+        fake_bin,
+        "ps",
+        """#!/usr/bin/env bash
+if [ "${1:-}" = "-p" ] && [ "${2:-}" = "$STT_TEST_LISTENER_PID" ]; then
+    exit 0
+fi
+exit 1
+""",
+    )
+    _write_fake_command(
+        fake_bin,
+        "curl",
+        """#!/usr/bin/env bash
+url="${@: -1}"
+printf '%s\\n' "$url" > "$STT_TEST_CURL_URL_FILE"
+if [ "$url" = "$STT_TEST_EXPECTED_STATUS_URL" ]; then
+    printf '%s' "$STT_TEST_STATUS_PAYLOAD"
+    exit 0
+fi
+exit 22
+""",
+    )
+    for command_name in ("nc", "pgrep", "tmux"):
+        _write_fake_command(
+            fake_bin,
+            command_name,
+            "#!/usr/bin/env bash\nexit 1\n",
+        )
+
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("PARAKEET_") and not key.startswith("_STT_")
+    }
+    env.update(
+        {
+            "PARAKEET_ROOT": str(REPO_ROOT),
+            "PARAKEET_PORT": "8765",
+            "PATH": f"{fake_bin}:{env['PATH']}",
+            "_STT_SKIP_LOCAL_OVERRIDES": "1",
+            "STT_TEST_CURL_URL_FILE": str(curl_url_file),
+            "STT_TEST_EXPECTED_STATUS_URL": expected_status_url,
+            "STT_TEST_LISTENER_PID": listener_pid,
+            "STT_TEST_LISTENER_PORT": listener_port,
+            "STT_TEST_STATUS_PAYLOAD": json.dumps(
+                {"type": "status", "state": "idle", "sessions_active": 0}
+            ),
+        }
+    )
+
+    port_file = Path("/tmp/parakeet-daemon.port")
+    pid_file = Path("/tmp/parakeet-daemon.pid")
+    with _preserve_paths(port_file, pid_file):
+        port_file.write_text(f"127.0.0.1:{listener_port}\n", encoding="utf-8")
+        pid_file.unlink(missing_ok=True)
+
+        completed = subprocess.run(
+            [
+                "bash",
+                "-lc",
+                f"source {shlex.quote(str(HELPER_PATH))} && stt status",
+            ],
+            check=True,
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+        )
+
+        assert f"Daemon running (pid {listener_pid})" in completed.stdout
+        assert f"Endpoint: ws://127.0.0.1:{listener_port}/ws" in completed.stdout
+        assert "Daemon runtime truth:" in completed.stdout
+        assert "sessions_active=0" in completed.stdout
+        assert curl_url_file.read_text(encoding="utf-8").strip() == expected_status_url
+        assert pid_file.read_text(encoding="utf-8").strip() == listener_pid

--- a/scripts/stt-helper.sh
+++ b/scripts/stt-helper.sh
@@ -103,6 +103,21 @@ stt() {
         printf "ws://%s%s" "$1" "$DAEMON_WS_PATH"
     }
 
+    _daemon_status_url_from_authority() {
+        printf "http://%s%s" "$1" "$DAEMON_STATUS_PATH"
+    }
+
+    _port_from_authority() {
+        local authority="$1"
+        local port="${authority##*:}"
+        case "$port" in
+            ""|*[!0-9]*)
+                return 1
+                ;;
+        esac
+        printf "%s" "$port"
+    }
+
     _llm_api_base_url() {
         _endpoint_url "http" "$default_llm_server_host" "$default_llm_server_port" "$LLM_API_PATH"
     }
@@ -747,109 +762,163 @@ PY
         local body
         body="$(_http_get "$status_url")" || return 1
 
-        STATUS_JSON="$body" python3 - <<'PY'
+        STATUS_SCHEMA_PATH="$REPO_ROOT/docs/protocol/schema/messages.schema.json" STATUS_JSON="$body" python3 - <<'PY'
 import json
 import math
 import os
 import sys
 
+
+def fail(reason: str = "invalid daemon /status Runtime Truth payload") -> None:
+    print(reason, file=sys.stderr)
+    sys.exit(1)
+
+
 body = os.environ.get("STATUS_JSON", "")
 try:
     payload = json.loads(body)
-except Exception:
-    sys.exit(1)
+except json.JSONDecodeError as err:
+    fail(f"failed to parse daemon /status JSON: {err}")
 
 if not isinstance(payload, dict):
-    sys.exit(1)
+    fail("daemon /status JSON must be an object")
 
-if payload.get("type") != "status":
-    sys.exit(1)
+schema_path = os.environ.get("STATUS_SCHEMA_PATH", "")
+try:
+    with open(schema_path, encoding="utf-8") as schema_file:
+        schema = json.load(schema_file)
+except OSError as err:
+    fail(f"failed to read status schema '{schema_path}': {err}")
+except json.JSONDecodeError as err:
+    fail(f"failed to parse status schema '{schema_path}': {err}")
 
-if payload.get("state") not in {"idle", "listening", "processing"}:
-    sys.exit(1)
+try:
+    status_def = schema["$defs"]["StatusMessage"]
+    groups = status_def["x-runtime-truth-field-groups"]
+    properties = status_def["properties"]
+except (KeyError, TypeError):
+    fail("status schema missing StatusMessage Runtime Truth contract")
 
-sessions_active = payload.get("sessions_active")
-if isinstance(sessions_active, bool) or not isinstance(sessions_active, int) or sessions_active < 0:
-    sys.exit(1)
+if not isinstance(groups, dict) or not isinstance(properties, dict):
+    fail("status schema Runtime Truth contract has invalid shape")
 
-fields = (
-    "device",
-    "effective_device",
-    "streaming_enabled",
-    "stream_helper_active",
-    "stream_helper_scope",
-    "stream_fallback_reason",
-    "stream_path_executed",
-    "stream_chunks_processed",
-    "chunk_secs",
-    "finalization_mode",
-    "final_audio_source",
-    "tail_trim_mode",
-    "vad_enabled",
-    "vad_active",
-    "vad_fallback_reason",
-    "overlay_events_enabled",
-)
-bool_fields = {
-    "streaming_enabled",
-    "stream_helper_active",
-    "stream_path_executed",
-    "vad_enabled",
-    "vad_active",
-    "overlay_events_enabled",
-}
-numeric_fields = {
-    "chunk_secs",
-}
-non_negative_int_fields = {
-    "stream_chunks_processed",
-}
+required = set(status_def.get("required", ()))
+fields: list[str] = []
+for group_fields in groups.values():
+    if not isinstance(group_fields, list):
+        fail("status schema Runtime Truth group must be a list")
+    for field in group_fields:
+        if not isinstance(field, str) or field not in properties:
+            fail(f"status schema Runtime Truth field is not declared: {field!r}")
+        if field not in fields:
+            fields.append(field)
+
+def normalize_bool(value: object) -> str:
+    if not isinstance(value, bool):
+        fail()
+    return "true" if value else "false"
+
+
+def normalize_non_negative_integer(value: object) -> str:
+    if isinstance(value, bool):
+        fail()
+    if isinstance(value, int):
+        if value < 0:
+            fail()
+        return str(value)
+    if isinstance(value, str) and value.isdigit():
+        return str(int(value))
+    fail()
+
+
+def normalize_number(value: object) -> str:
+    if isinstance(value, bool):
+        fail()
+    if isinstance(value, (int, float)):
+        parsed = float(value)
+    elif isinstance(value, str):
+        try:
+            parsed = float(value)
+        except ValueError:
+            fail()
+    else:
+        fail()
+    if not math.isfinite(parsed):
+        fail()
+    return f"{parsed:g}"
+
+
+def normalize_string(value: object) -> str:
+    if not isinstance(value, str):
+        fail()
+    return value
+
+
+def normalize_ref(ref: str, value: object) -> str:
+    if ref == "#/$defs/nullable_string":
+        return normalize_string(value)
+    if ref == "#/$defs/nullable_boolean":
+        return normalize_bool(value)
+    if ref in {"#/$defs/non_negative_integer", "#/$defs/nullable_non_negative_integer"}:
+        return normalize_non_negative_integer(value)
+    if ref == "#/$defs/nullable_number":
+        return normalize_number(value)
+    fail()
+
+
+def normalize_value(property_schema: dict[str, object], value: object) -> str:
+    if "const" in property_schema:
+        expected = property_schema["const"]
+        if value != expected:
+            fail()
+        return str(expected)
+    enum = property_schema.get("enum")
+    if isinstance(enum, list):
+        if value not in enum:
+            fail()
+        return normalize_string(value)
+    ref = property_schema.get("$ref")
+    if isinstance(ref, str):
+        return normalize_ref(ref, value)
+    type_spec = property_schema.get("type")
+    type_names = type_spec if isinstance(type_spec, list) else [type_spec]
+    if "number" in type_names:
+        normalized = normalize_number(value)
+        parsed = float(normalized)
+        minimum = property_schema.get("minimum")
+        maximum = property_schema.get("maximum")
+        if isinstance(minimum, (int, float)) and parsed < float(minimum):
+            fail()
+        if isinstance(maximum, (int, float)) and parsed > float(maximum):
+            fail()
+        return normalized
+    fail()
+
+
+missing = object()
 
 for key in fields:
-    value = payload.get(key)
-    if value is None:
+    value = payload.get(key, missing)
+    if value is missing or value is None:
+        if key in required:
+            fail()
         print(f"{key}=")
         continue
 
-    if key in bool_fields:
-        if not isinstance(value, bool):
-            sys.exit(1)
-        print(f"{key}={'true' if value else 'false'}")
-    elif key in non_negative_int_fields:
-        if isinstance(value, bool):
-            sys.exit(1)
-        elif isinstance(value, int):
-            if value < 0:
-                sys.exit(1)
-            print(f"{key}={value}")
-        elif isinstance(value, str):
-            if not value.isdigit():
-                sys.exit(1)
-            print(f"{key}={int(value)}")
-        else:
-            sys.exit(1)
-    elif key in numeric_fields:
-        if isinstance(value, bool):
-            sys.exit(1)
-        elif isinstance(value, (int, float)):
-            if not math.isfinite(float(value)):
-                sys.exit(1)
-            print(f"{key}={value}")
-        elif isinstance(value, str):
-            try:
-                parsed = float(value)
-            except ValueError:
-                sys.exit(1)
-            if not math.isfinite(parsed):
-                sys.exit(1)
-            print(f"{key}={parsed:g}")
-        else:
-            sys.exit(1)
-    else:
-        if not isinstance(value, str):
-            sys.exit(1)
-        print(f"{key}={value}")
+    property_schema = properties.get(key)
+    if not isinstance(property_schema, dict):
+        fail()
+    print(f"{key}={normalize_value(property_schema, value)}")
 PY
+    }
+
+    _print_daemon_runtime_truth() {
+        local runtime_truth="$1"
+        echo "   - Daemon runtime truth:"
+        while IFS='=' read -r key value; do
+            [ -n "$key" ] || continue
+            printf "     %s=%s\n" "$key" "$value"
+        done <<< "$runtime_truth"
     }
 
     _stop_running_daemon() {
@@ -1747,11 +1816,21 @@ EOF
             ;;
         status)
             echo ">>> Status:"
-            if _socket_ready_once && _refresh_daemon_pid_file_from_listener >/dev/null 2>&1; then
-                :
+            local daemon_authority=""
+            local daemon_listener_port="$PORT"
+            local daemon_status_url
+            if [ -s "$PORT_FILE" ]; then
+                daemon_authority="$(cat "$PORT_FILE")"
+                daemon_status_url="$(_daemon_status_url_from_authority "$daemon_authority")"
+                daemon_listener_port="$(_port_from_authority "$daemon_authority" || printf "%s" "$PORT")"
+            else
+                daemon_status_url="$(_daemon_status_url)"
             fi
+            _refresh_pid_file_from_listener "$daemon_listener_port" "$DAEMON_PID_FILE" >/dev/null 2>&1 || true
+            local daemon_runtime_truth=""
             if _pid_alive "$DAEMON_PID_FILE"; then
                 echo "   - Daemon running (pid $(cat "$DAEMON_PID_FILE"))"
+                daemon_runtime_truth="$(_daemon_status_runtime_truth "$daemon_status_url")" || daemon_runtime_truth=""
             else
                 echo "   - Daemon not running"
             fi
@@ -1760,8 +1839,8 @@ EOF
             else
                 echo "   - Client not running"
             fi
-            if [ -f "$PORT_FILE" ]; then
-                echo "   - Endpoint: $(_daemon_ws_endpoint_from_authority "$(cat "$PORT_FILE")")"
+            if [ -n "$daemon_authority" ]; then
+                echo "   - Endpoint: $(_daemon_ws_endpoint_from_authority "$daemon_authority")"
             else
                 echo "   - Endpoint: $DEFAULT_ENDPOINT"
             fi
@@ -1771,6 +1850,11 @@ EOF
             fi
             if _tmux_has_session "$TMUX_SESSION"; then
                 echo "   - tmux session: $TMUX_SESSION"
+            fi
+            if [ -n "$daemon_runtime_truth" ]; then
+                _print_daemon_runtime_truth "$daemon_runtime_truth"
+            elif _pid_alive "$DAEMON_PID_FILE"; then
+                echo "   - Daemon runtime truth: unavailable from $daemon_status_url"
             fi
             ;;
         tmux)


### PR DESCRIPTION
## Summary
- Load `StatusMessage` `x-runtime-truth-field-groups` from the protocol schema instead of maintaining Helper-side Runtime Truth field lists.
- Normalize and print every Runtime Truth field in canonical group order from `stt status` when `/status` is available.
- Derive both the `/status` URL and daemon liveness refresh from the persisted daemon authority, with focused regression coverage for stale/missing pid files.
- Update Helper tests and troubleshooting docs for the normalized Runtime Truth block.

## Verification
- `bash -n scripts/stt-helper.sh`
- `shellcheck scripts/stt-helper.sh`
- `cd parakeet-stt-daemon && uv run pytest tests/test_protocol_conformance.py tests/test_stt_helper_runtime_profiles.py -q` -> 38 passed
- `source scripts/stt-helper.sh && stt __daemon-status-runtime-truth file://$PWD/docs/protocol/fixtures/status_stream_fallback.json`
- `source scripts/stt-helper.sh && stt help start`
- `source scripts/stt-helper.sh && stt help llm`
- `ruff check parakeet-stt-daemon/tests/test_stt_helper_runtime_profiles.py`
- `ruff format --check parakeet-stt-daemon/tests/test_stt_helper_runtime_profiles.py`
- `ty check --project parakeet-stt-daemon --error-on-warning`
- `cd parakeet-stt-daemon && uv run pytest -q` -> 201 passed
- `git diff --check`
- `prek run --all-files`
- `prek run --stage pre-push --all-files`

## Review
- CodeRabbit PR gate remote clean; local CodeRabbit hit a rate limit and the watcher completed Codex fallback: `.git/coderabbit-review/20260521T184527Z/gate-summary.json`.
- Final classified CodeRabbit watcher gate clean: `.git/coderabbit-review/20260521T185501Z/gate-summary.json`.
- Addressed all actionable review findings: parser failure reasons, narrow schema exception handling, runtime-truth projection scope, persisted-authority status URL, and persisted-authority liveness refresh.

## Deferrals
- None.

Closes #120


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Refined daemon status guidance in troubleshooting documentation.

* **Bug Fixes**
  * `stt status` command now correctly derives and uses authority-specific daemon status URLs.
  * Improved runtime truth display to show parsed values when available, or indicate unavailability from the daemon.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SystemicVoid/parakeet-stt/pull/138?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->