### PR TITLE
Add Runtime Truth drift checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,7 @@ repos:
         entry: uv run --project parakeet-stt-daemon pytest -q
         language: system
         pass_filenames: false
-        files: ^parakeet-stt-daemon/(pyproject\.toml|tests/.*\.py|src/.*\.py)$
+        files: ^(parakeet-stt-daemon/(pyproject\.toml|tests/.*\.py|src/.*\.py)|docs/(protocol/(schema|fixtures)/.*\.json|SPEC\.md|stt-troubleshooting\.md)|scripts/stt-helper\.sh)$
         stages: [pre-push]
 
       - id: rust-clippy
@@ -56,7 +56,7 @@ repos:
         entry: cargo clippy --manifest-path parakeet-ptt/Cargo.toml --all-targets --all-features -- -D warnings
         language: system
         pass_filenames: false
-        files: ^parakeet-ptt/(Cargo\.toml|Cargo\.lock|src/.*\.rs)$
+        files: ^parakeet-ptt/(Cargo\.toml|Cargo\.lock|src/.*\.rs|tests/.*\.rs)$
         stages: [pre-push]
 
       - id: rust-test
@@ -64,5 +64,5 @@ repos:
         entry: cargo test --manifest-path parakeet-ptt/Cargo.toml -q
         language: system
         pass_filenames: false
-        files: ^parakeet-ptt/(Cargo\.toml|Cargo\.lock|src/.*\.rs)$
+        files: ^(parakeet-ptt/(Cargo\.toml|Cargo\.lock|src/.*\.rs|tests/.*\.rs)|docs/protocol/(schema|fixtures)/.*\.json)$
         stages: [pre-push]

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -266,6 +266,8 @@ The canonical machine-checkable contract and fixtures live under [`docs/protocol
 The JSON schema's `StatusMessage.x-runtime-truth-field-groups` metadata names
 the current Runtime Truth groups. This table explains the operational meaning
 of those fields; it must not diverge into a separate schema.
+The schema-defined groups are `core`, `device`, `stream_path`, `seal_path`,
+`tail_trim_vad`, `interim_transcript`, `overlay_transport`, and `timing`.
 
 | Field | JSON type | Values / units | Semantics |
 | --- | --- | --- | --- |

--- a/docs/stt-troubleshooting.md
+++ b/docs/stt-troubleshooting.md
@@ -74,6 +74,10 @@ names, flags, or logs alone.
 
 ### Runtime truth field guide
 
+The schema-defined Runtime Truth groups are `core`, `device`, `stream_path`,
+`seal_path`, `tail_trim_vad`, `interim_transcript`, `overlay_transport`, and
+`timing`.
+
 - Device and status core: `state`, `sessions_active`, `device`,
   `effective_device`, and `gpu_mem_mb`.
 - Stream path: `streaming_enabled`, `stream_helper_active`,

--- a/parakeet-ptt/src/app.rs
+++ b/parakeet-ptt/src/app.rs
@@ -1033,57 +1033,16 @@ fn session_intent_from_hotkey(intent: HotkeyIntent) -> SessionIntent {
 }
 
 fn format_daemon_status(status: &DaemonStatus) -> String {
-    format!(
-        "Daemon status: state={:?}, sessions_active={:?}, device={:?}, effective_device={:?}, \
-streaming={:?}, helper_active={:?}, helper_scope={:?}, stream_path_executed={:?}, \
-stream_chunks_processed={:?}, stream_fallback={:?}, finalization_mode={:?}, \
-final_audio_source={:?}, tail_trim={:?}, vad_enabled={:?}, vad_active={:?}, \
-vad_fallback={:?}, interim_enabled={:?}, interim_source={:?}, interim_live_chunks={:?}, \
-interim_stop_replay_chunks={:?}, interim_updates={:?}, interim_live_updates={:?}, \
-interim_stop_replay_updates={:?}, interim_live_failed={:?}, interim_stop_replay_failed={:?}, \
-interim_fallback={:?}, overlay_enabled={:?}, overlay_emitted={:?}, overlay_dropped={:?}, \
-chunk_secs={:?}, active_age_ms={:?}, audio_stop_ms={:?}, finalize_ms={:?}, infer_ms={:?}, \
-send_ms={:?}, last_audio_ms={:?}, last_infer_ms={:?}, last_send_ms={:?}, gpu_mem_mb={:?}",
-        Some(status.state.as_str()),
-        Some(status.sessions_active),
-        status.device,
-        status.effective_device,
-        status.streaming_enabled,
-        status.stream_helper_active,
-        status.stream_helper_scope,
-        status.stream_path_executed,
-        status.stream_chunks_processed,
-        status.stream_fallback_reason,
-        status.finalization_mode,
-        status.final_audio_source,
-        status.tail_trim_mode,
-        status.vad_enabled,
-        status.vad_active,
-        status.vad_fallback_reason,
-        status.interim_transcript_enabled,
-        status.interim_transcript_last_source,
-        status.interim_transcript_live_chunks_processed,
-        status.interim_transcript_stop_replay_chunks_processed,
-        status.interim_transcript_updates_emitted,
-        status.interim_transcript_live_updates_emitted,
-        status.interim_transcript_stop_replay_updates_emitted,
-        status.interim_transcript_live_failed,
-        status.interim_transcript_stop_replay_failed,
-        status.interim_transcript_source_fallback_reason,
-        status.overlay_events_enabled,
-        status.overlay_events_emitted,
-        status.overlay_events_dropped,
-        status.chunk_secs,
-        status.active_session_age_ms,
-        status.audio_stop_ms,
-        status.finalize_ms,
-        status.infer_ms,
-        status.send_ms,
-        status.last_audio_ms,
-        status.last_infer_ms,
-        status.last_send_ms,
-        status.gpu_mem_mb
-    )
+    let payload = serde_json::to_value(ServerMessage::Status(status.clone()))
+        .expect("daemon status should serialize");
+    let fields = payload
+        .as_object()
+        .expect("daemon status should serialize to an object")
+        .iter()
+        .map(|(key, value)| format!("{key}={value}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("Daemon status: {fields}")
 }
 
 async fn fetch_status_once(config: &ClientConfig) {
@@ -1119,7 +1078,7 @@ async fn fetch_status_once(config: &ClientConfig) {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::collections::{BTreeSet, HashMap};
     use std::ffi::OsString;
     use std::fs;
     use std::io::Write;
@@ -1189,12 +1148,13 @@ mod tests {
         assert_eq!(status.gpu_mem_mb, None);
 
         let summary = format_daemon_status(&status);
-        assert!(summary.contains("state=Some(\"idle\")"));
-        assert!(summary.contains("sessions_active=Some(0)"));
-        assert!(summary.contains("stream_path_executed=None"));
-        assert!(summary.contains("finalization_mode=None"));
-        assert!(summary.contains("interim_enabled=None"));
-        assert!(summary.contains("gpu_mem_mb=None"));
+        assert!(summary.contains("type=\"status\""));
+        assert!(summary.contains("state=\"idle\""));
+        assert!(summary.contains("sessions_active=0"));
+        assert!(summary.contains("stream_path_executed=null"));
+        assert!(summary.contains("finalization_mode=null"));
+        assert!(summary.contains("interim_transcript_enabled=null"));
+        assert!(summary.contains("gpu_mem_mb=null"));
     }
 
     #[test]
@@ -1284,17 +1244,70 @@ mod tests {
         assert_eq!(status.last_send_ms, Some(0));
 
         let summary = format_daemon_status(&status);
-        assert!(summary.contains("helper_scope=Some(\"live_session_only\")"));
-        assert!(summary.contains("stream_path_executed=Some(false)"));
-        assert!(summary.contains("stream_fallback=Some(\"init_failed:RuntimeError\")"));
-        assert!(summary.contains("finalization_mode=Some(\"offline_seal\")"));
-        assert!(summary.contains("final_audio_source=Some(\"canonical_session_audio\")"));
-        assert!(summary.contains("tail_trim=Some(\"rms\")"));
-        assert!(summary.contains("interim_enabled=Some(true)"));
-        assert!(summary.contains("interim_source=Some(\"live\")"));
-        assert!(summary.contains("interim_updates=Some(1)"));
-        assert!(summary.contains("overlay_emitted=Some(3)"));
-        assert!(summary.contains("gpu_mem_mb=Some(1024)"));
+        assert!(summary.contains("stream_helper_scope=\"live_session_only\""));
+        assert!(summary.contains("stream_path_executed=false"));
+        assert!(summary.contains("stream_fallback_reason=\"init_failed:RuntimeError\""));
+        assert!(summary.contains("finalization_mode=\"offline_seal\""));
+        assert!(summary.contains("final_audio_source=\"canonical_session_audio\""));
+        assert!(summary.contains("tail_trim_mode=\"rms\""));
+        assert!(summary.contains("interim_transcript_enabled=true"));
+        assert!(summary.contains("interim_transcript_last_source=\"live\""));
+        assert!(summary.contains("interim_transcript_updates_emitted=1"));
+        assert!(summary.contains("overlay_events_emitted=3"));
+        assert!(summary.contains("gpu_mem_mb=1024"));
+    }
+
+    #[test]
+    fn daemon_status_format_mentions_current_runtime_truth_fields() {
+        let schema_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../docs/protocol/schema/messages.schema.json");
+        let schema: serde_json::Value = serde_json::from_str(
+            &fs::read_to_string(schema_path).expect("status schema should be readable"),
+        )
+        .expect("status schema should parse");
+        let fields = schema
+            .pointer("/$defs/StatusMessage/x-runtime-truth-field-groups")
+            .and_then(serde_json::Value::as_object)
+            .expect("schema should declare Runtime Truth groups")
+            .values()
+            .flat_map(|group_fields| {
+                group_fields
+                    .as_array()
+                    .expect("Runtime Truth group should be an array")
+                    .iter()
+                    .map(|field| {
+                        field
+                            .as_str()
+                            .expect("Runtime Truth field should be a string")
+                            .to_string()
+                    })
+            })
+            .collect::<BTreeSet<_>>();
+
+        let fixture_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../docs/protocol/fixtures/status_stream_fallback.json");
+        let fixture = fs::read_to_string(fixture_path).expect("status fixture should be readable");
+        let status = match serde_json::from_str::<ServerMessage>(&fixture)
+            .expect("status fixture should parse")
+        {
+            ServerMessage::Status(status) => status,
+            other => panic!("expected status message, got {other:?}"),
+        };
+        let summary = format_daemon_status(&status);
+        let formatted_fields = summary
+            .strip_prefix("Daemon status: ")
+            .expect("formatted status should use expected prefix")
+            .split(", ")
+            .map(|field| {
+                field
+                    .split_once('=')
+                    .expect("formatted field should be key=value")
+                    .0
+                    .to_string()
+            })
+            .collect::<BTreeSet<_>>();
+
+        assert_eq!(formatted_fields, fields);
     }
 
     #[test]

--- a/parakeet-ptt/tests/protocol_conformance.rs
+++ b/parakeet-ptt/tests/protocol_conformance.rs
@@ -134,6 +134,29 @@ fn schema_message_definitions(schema: &Value) -> Vec<(&'static str, &Value)> {
     .collect()
 }
 
+fn status_runtime_truth_fields(schema: &Value) -> BTreeSet<String> {
+    let groups = schema
+        .pointer("/$defs/StatusMessage/x-runtime-truth-field-groups")
+        .and_then(Value::as_object)
+        .expect("schema should declare StatusMessage runtime truth groups");
+
+    groups
+        .values()
+        .flat_map(|fields| {
+            fields
+                .as_array()
+                .expect("runtime truth groups should be arrays")
+                .iter()
+                .map(|field| {
+                    field
+                        .as_str()
+                        .expect("runtime truth fields should be strings")
+                        .to_string()
+                })
+        })
+        .collect()
+}
+
 fn synthetic_message_from_schema(definition: &Value) -> Value {
     let properties = definition
         .get("properties")
@@ -157,6 +180,25 @@ fn round_trip_through_rust_codec(fixture: Value) -> Result<Value, Box<dyn Error>
         let decoded: protocol::ServerMessage = serde_json::from_value(fixture)?;
         Ok(serde_json::to_value(decoded)?)
     }
+}
+
+#[test]
+fn protocol_conformance_status_runtime_truth_fields_round_trip() -> Result<(), Box<dyn Error>> {
+    let schema = load_json(&schema_path())?;
+    let status_definition = schema
+        .pointer("/$defs/StatusMessage")
+        .expect("schema should include StatusMessage");
+    let synthetic = synthetic_message_from_schema(status_definition);
+    let encoded = round_trip_through_rust_codec(synthetic)?;
+    let actual = encoded
+        .as_object()
+        .expect("encoded status should be an object")
+        .keys()
+        .cloned()
+        .collect::<BTreeSet<_>>();
+
+    assert_eq!(actual, status_runtime_truth_fields(&schema));
+    Ok(())
 }
 
 #[test]

--- a/parakeet-stt-daemon/tests/test_protocol_conformance.py
+++ b/parakeet-stt-daemon/tests/test_protocol_conformance.py
@@ -29,6 +29,10 @@ from parakeet_stt_daemon.messages import (
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCHEMA_PATH = REPO_ROOT / "docs/protocol/schema/messages.schema.json"
 FIXTURE_DIR = REPO_ROOT / "docs/protocol/fixtures"
+RUNTIME_TRUTH_DOC_PATHS = (
+    REPO_ROOT / "docs/SPEC.md",
+    REPO_ROOT / "docs/stt-troubleshooting.md",
+)
 
 CLIENT_MODELS: dict[str, type[BaseModel]] = {
     "start_session": StartSession,
@@ -75,6 +79,12 @@ def _load_json(path: Path) -> dict[str, Any]:
 
 def _fixture_paths() -> list[Path]:
     return sorted(FIXTURE_DIR.glob("*.json"))
+
+
+def _status_runtime_truth_groups(schema: dict[str, Any]) -> dict[str, list[str]]:
+    groups = schema["$defs"]["StatusMessage"]["x-runtime-truth-field-groups"]
+    assert isinstance(groups, dict)
+    return groups
 
 
 @pytest.fixture(scope="module")
@@ -141,7 +151,7 @@ def test_schema_properties_match_pydantic_model_fields(schema: dict[str, Any]) -
 
 def test_status_schema_declares_runtime_truth_contract_groups(schema: dict[str, Any]) -> None:
     status_def = schema["$defs"]["StatusMessage"]
-    schema_groups = status_def["x-runtime-truth-field-groups"]
+    schema_groups = _status_runtime_truth_groups(schema)
     expected_groups = {
         group: list(fields) for group, fields in STATUS_RUNTIME_TRUTH_FIELD_GROUPS.items()
     }
@@ -160,6 +170,20 @@ def test_status_fixtures_cover_complete_runtime_truth_contract() -> None:
             continue
 
         assert set(fixture) == STATUS_RUNTIME_TRUTH_FIELDS, path.name
+
+
+def test_runtime_truth_docs_reference_current_schema_groups(schema: dict[str, Any]) -> None:
+    groups = _status_runtime_truth_groups(schema)
+
+    for path in RUNTIME_TRUTH_DOC_PATHS:
+        text = path.read_text(encoding="utf-8")
+        missing_groups = [group for group in groups if f"`{group}`" not in text]
+
+        assert not missing_groups, (
+            f"{path.relative_to(REPO_ROOT)} must mention Runtime Truth groups from "
+            "StatusMessage.x-runtime-truth-field-groups: "
+            f"{missing_groups}"
+        )
 
 
 def test_default_status_fixture_represents_current_runtime_truth_groups() -> None:

--- a/parakeet-stt-daemon/tests/test_stt_helper_runtime_profiles.py
+++ b/parakeet-stt-daemon/tests/test_stt_helper_runtime_profiles.py
@@ -25,6 +25,7 @@ from parakeet_stt_daemon.messages import (
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 HELPER_PATH = REPO_ROOT / "scripts" / "stt-helper.sh"
+FIXTURE_DIR = REPO_ROOT / "docs" / "protocol" / "fixtures"
 
 
 @contextmanager
@@ -534,6 +535,14 @@ def test_daemon_status_runtime_truth_accepts_minimal_protocol_status(
     assert truth["sessions_active"] == "0"
     for field in STATUS_RUNTIME_TRUTH_FIELDS - {"type", "state", "sessions_active"}:
         assert truth[field] == ""
+
+
+def test_daemon_status_runtime_truth_accepts_protocol_status_fixtures() -> None:
+    for payload_path in sorted(FIXTURE_DIR.glob("status_*.json")):
+        truth = _run_status_runtime_truth(payload_path)
+
+        assert set(truth) == STATUS_RUNTIME_TRUTH_FIELDS, payload_path.name
+        assert list(truth) == _runtime_truth_contract_fields(), payload_path.name
 
 
 def test_daemon_status_runtime_truth_normalizes_numeric_string(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Add schema-driven drift checks across the Runtime Truth schema/groups, Python model metadata, status fixtures, Rust protocol round trips, Client status formatting, Helper projection, and operator docs.
- Format Client startup status output from serialized Runtime Truth keys so new Rust status fields are not manually mapped twice.
- Expand pre-push hook file patterns so schema, fixture, docs, Helper, and Rust test changes run the drift checks.

## Verification
- `cd parakeet-stt-daemon && uv run pytest tests/test_protocol_conformance.py tests/test_stt_helper_runtime_profiles.py -q` -> 40 passed
- `cd parakeet-ptt && cargo test protocol_conformance` -> 5 protocol conformance tests passed
- `cd parakeet-ptt && cargo test daemon_status` -> 4 Client status tests passed
- `cd parakeet-stt-daemon && uv run pytest -q` -> 203 passed
- `cd parakeet-ptt && cargo test -q` -> 87 lib, 150 bin, and 12 protocol conformance tests passed
- `uv run --project parakeet-stt-daemon ruff format --check --config parakeet-stt-daemon/pyproject.toml parakeet-stt-daemon/tests/test_protocol_conformance.py parakeet-stt-daemon/tests/test_stt_helper_runtime_profiles.py`
- `uv run --project parakeet-stt-daemon ruff check --config parakeet-stt-daemon/pyproject.toml parakeet-stt-daemon/tests/test_protocol_conformance.py parakeet-stt-daemon/tests/test_stt_helper_runtime_profiles.py`
- `ty check --project parakeet-stt-daemon --error-on-warning`
- `cargo fmt --manifest-path parakeet-ptt/Cargo.toml --check`
- `cd parakeet-ptt && cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`
- `prek run --all-files`
- `prek run --stage pre-push --all-files`
- push hook retry: first push hit a transient Rust timeout-path test failure outside this change; exact test retry passed and the second push hook passed.

## Deferrals
- None.

Closes #121
