### PR TITLE
Refactor daemon Stream path runtime truth

### DIFF
--- a/parakeet-stt-daemon/src/parakeet_stt_daemon/runtime_truth_snapshot.py
+++ b/parakeet-stt-daemon/src/parakeet_stt_daemon/runtime_truth_snapshot.py
@@ -8,7 +8,7 @@ from typing import Any, Literal
 
 from .messages import StatusMessage
 from .overlay_interim import InterimTranscriptRuntimeFacts, InterimTranscriptSource
-from .session import SessionState
+from .session import SessionState, StreamPathRuntimeFacts
 from .tail_trim import TailTrimMode
 
 StreamHelperScope = Literal["live_session_only"]
@@ -296,6 +296,23 @@ def _stream_path_facts(orchestrator: Any) -> StreamPathFacts:
     settings = orchestrator.settings
     streaming_enabled = bool(getattr(settings, "streaming_enabled", False))
     chunk_secs = _chunk_secs_or_none(settings)
+    getter = getattr(orchestrator, "stream_path_runtime_facts_for_runtime", None)
+    if callable(getter):
+        try:
+            runtime_facts = getter()
+        except Exception:  # noqa: BLE001
+            runtime_facts = None
+        if isinstance(runtime_facts, StreamPathRuntimeFacts):
+            return StreamPathFacts(
+                streaming_enabled=runtime_facts.streaming_enabled,
+                helper_active=runtime_facts.helper_active,
+                helper_scope=runtime_facts.helper_scope,
+                helper_class_name=runtime_facts.helper_class_name,
+                fallback_reason=runtime_facts.fallback_reason,
+                chunk_secs=runtime_facts.chunk_secs,
+                path_executed=runtime_facts.path_executed,
+                chunks_processed=runtime_facts.chunks_processed,
+            )
     streaming_transcriber = getattr(orchestrator, "streaming_transcriber", None)
     if not streaming_enabled:
         return StreamPathFacts(
@@ -319,30 +336,7 @@ def _stream_path_facts(orchestrator: Any) -> StreamPathFacts:
             path_executed=False,
             chunks_processed=0,
         )
-    sessions = getattr(orchestrator, "sessions", None)
-    active_session = getattr(sessions, "active", None)
-    if active_session is not None:
-        chunks_processed = _non_negative_int(
-            getattr(orchestrator, "_current_stream_chunks_processed", 0)
-        )
-        path_executed = chunks_processed > 0
-        current_fallback_reason = getattr(orchestrator, "_current_stream_fallback_reason", None)
-    else:
-        path_executed = bool(getattr(orchestrator, "_last_stream_path_executed", False))
-        chunks_processed = _non_negative_int(
-            getattr(orchestrator, "_last_stream_chunks_processed", 0)
-        )
-        current_fallback_reason = None
     fallback_reason = getattr(streaming_transcriber, "fallback_reason", None)
-    last_fallback_reason = (
-        getattr(orchestrator, "_last_stream_fallback_reason", None)
-        if active_session is None
-        else None
-    )
-    if current_fallback_reason is not None:
-        fallback_reason = current_fallback_reason
-    elif last_fallback_reason is not None:
-        fallback_reason = last_fallback_reason
     return StreamPathFacts(
         streaming_enabled=True,
         helper_active=bool(getattr(streaming_transcriber, "helper_active", False)),
@@ -352,8 +346,8 @@ def _stream_path_facts(orchestrator: Any) -> StreamPathFacts:
         ),
         fallback_reason=fallback_reason,
         chunk_secs=chunk_secs,
-        path_executed=path_executed,
-        chunks_processed=chunks_processed,
+        path_executed=False,
+        chunks_processed=0,
     )
 
 
@@ -383,25 +377,6 @@ def _string_or_none(value: object) -> str | None:
     if value is None:
         return None
     return str(value)
-
-
-def _non_negative_int(value: object) -> int:
-    if isinstance(value, bool):
-        return 0
-    if isinstance(value, int):
-        parsed = value
-    elif isinstance(value, float):
-        if not math.isfinite(value):
-            return 0
-        parsed = int(value)
-    elif isinstance(value, str):
-        try:
-            parsed = int(value)
-        except ValueError:
-            return 0
-    else:
-        return 0
-    return max(0, parsed)
 
 
 def _chunk_secs_or_none(settings: object) -> float | None:

--- a/parakeet-stt-daemon/src/parakeet_stt_daemon/session.py
+++ b/parakeet-stt-daemon/src/parakeet_stt_daemon/session.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import asyncio
+import math
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import StrEnum
+from typing import Literal
 from uuid import UUID
 
 
@@ -42,6 +44,162 @@ class SessionBusyError(RuntimeError):
 
 class SessionNotFoundError(RuntimeError):
     pass
+
+
+StreamHelperScope = Literal["live_session_only"]
+
+
+@dataclass(frozen=True, slots=True)
+class StreamPathRuntimeFacts:
+    streaming_enabled: bool
+    helper_active: bool
+    helper_scope: StreamHelperScope
+    helper_class_name: str | None
+    fallback_reason: str | None
+    chunk_secs: float | None
+    path_executed: bool
+    chunks_processed: int
+
+
+class StreamPathRuntime:
+    """Own Stream path runtime truth for the active and last Daemon Session."""
+
+    def __init__(
+        self,
+        *,
+        streaming_enabled: bool,
+        chunk_secs: object,
+        streaming_transcriber: object | None,
+    ) -> None:
+        self.streaming_enabled = bool(streaming_enabled)
+        self.chunk_secs = _chunk_secs_or_none(chunk_secs)
+        self.streaming_transcriber = streaming_transcriber
+        self._current_chunks_processed = 0
+        self._current_fallback_reason: str | None = None
+        self._last_path_executed = False
+        self._last_chunks_processed = 0
+        self._last_fallback_reason: str | None = None
+
+    @classmethod
+    def from_settings(
+        cls,
+        settings: object,
+        streaming_transcriber: object | None,
+    ) -> StreamPathRuntime:
+        return cls(
+            streaming_enabled=bool(getattr(settings, "streaming_enabled", False)),
+            chunk_secs=getattr(settings, "chunk_secs", None),
+            streaming_transcriber=streaming_transcriber,
+        )
+
+    def sync_from_runtime(
+        self,
+        *,
+        settings: object,
+        streaming_transcriber: object | None,
+    ) -> None:
+        self.streaming_enabled = bool(getattr(settings, "streaming_enabled", False))
+        self.chunk_secs = _chunk_secs_or_none(getattr(settings, "chunk_secs", None))
+        self.streaming_transcriber = streaming_transcriber
+
+    def should_start_drain_loop(self) -> bool:
+        return self.streaming_enabled or self.streaming_transcriber is not None
+
+    def reset_current(self) -> None:
+        self._current_chunks_processed = 0
+        self._current_fallback_reason = None
+
+    def helper_available(self) -> bool:
+        transcriber = self.streaming_transcriber
+        return transcriber is not None and bool(getattr(transcriber, "helper_active", False))
+
+    def fallback_reason_from_runtime(self) -> str | None:
+        if not self.streaming_enabled:
+            return None
+        transcriber = self.streaming_transcriber
+        if transcriber is None:
+            return "streaming_transcriber_unavailable"
+        fallback_reason = getattr(transcriber, "fallback_reason", None)
+        if fallback_reason is not None:
+            return str(fallback_reason)
+        if not bool(getattr(transcriber, "helper_active", False)):
+            return "streaming_helper_inactive"
+        return None
+
+    def record_current_fallback(self, reason: object | None) -> None:
+        self._current_fallback_reason = str(reason) if reason is not None else None
+
+    def record_chunk_processed(self) -> None:
+        self._current_chunks_processed += 1
+
+    def record_session_result(self, *, active_stream: object | None) -> None:
+        chunks_processed = self._current_chunks_processed
+        fallback_reason = self._current_fallback_reason
+        if active_stream is not None and fallback_reason is None:
+            stream_reason = getattr(active_stream, "stream_fallback_reason", None)
+            fallback_reason = str(stream_reason) if stream_reason is not None else None
+        if self.streaming_enabled:
+            if fallback_reason is None:
+                fallback_reason = self.fallback_reason_from_runtime()
+            if chunks_processed <= 0 and fallback_reason is None:
+                fallback_reason = "stream_path_not_exercised:no_chunks"
+        else:
+            fallback_reason = None
+        self._last_chunks_processed = max(0, int(chunks_processed))
+        self._last_path_executed = chunks_processed > 0
+        self._last_fallback_reason = fallback_reason
+
+    def facts(self, *, active_session: bool) -> StreamPathRuntimeFacts:
+        if not self.streaming_enabled:
+            return StreamPathRuntimeFacts(
+                streaming_enabled=False,
+                helper_active=False,
+                helper_scope="live_session_only",
+                helper_class_name=None,
+                fallback_reason=None,
+                chunk_secs=None,
+                path_executed=False,
+                chunks_processed=0,
+            )
+
+        transcriber = self.streaming_transcriber
+        if transcriber is None:
+            return StreamPathRuntimeFacts(
+                streaming_enabled=True,
+                helper_active=False,
+                helper_scope="live_session_only",
+                helper_class_name=None,
+                fallback_reason="streaming_transcriber_unavailable",
+                chunk_secs=self.chunk_secs,
+                path_executed=False,
+                chunks_processed=0,
+            )
+
+        if active_session:
+            chunks_processed = self._current_chunks_processed
+            path_executed = chunks_processed > 0
+            fallback_reason = self._current_fallback_reason
+        else:
+            chunks_processed = self._last_chunks_processed
+            path_executed = self._last_path_executed
+            fallback_reason = self._last_fallback_reason
+
+        if fallback_reason is None:
+            transcriber_fallback = getattr(transcriber, "fallback_reason", None)
+            fallback_reason = (
+                str(transcriber_fallback) if transcriber_fallback is not None else None
+            )
+
+        return StreamPathRuntimeFacts(
+            streaming_enabled=True,
+            helper_active=bool(getattr(transcriber, "helper_active", False)),
+            helper_scope="live_session_only",
+            helper_class_name=_string_or_none(getattr(transcriber, "_helper_class_name", None)),
+            fallback_reason=fallback_reason,
+            chunk_secs=self.chunk_secs,
+            path_executed=path_executed,
+            chunks_processed=max(0, int(chunks_processed)),
+        )
 
 
 class SessionManager:
@@ -89,4 +247,28 @@ __all__ = [
     "SessionManager",
     "SessionNotFoundError",
     "SessionState",
+    "StreamPathRuntime",
+    "StreamPathRuntimeFacts",
 ]
+
+
+def _chunk_secs_or_none(value: object) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return None
+    if not isinstance(value, str | int | float):
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(parsed):
+        return None
+    return parsed
+
+
+def _string_or_none(value: object) -> str | None:
+    if value is None:
+        return None
+    return str(value)

--- a/parakeet-stt-daemon/src/parakeet_stt_daemon/session_orchestrator.py
+++ b/parakeet-stt-daemon/src/parakeet_stt_daemon/session_orchestrator.py
@@ -58,7 +58,15 @@ from .runtime_truth_snapshot import (
 from .runtime_truth_snapshot import (
     snapshot as runtime_truth_snapshot,
 )
-from .session import Session, SessionBusyError, SessionManager, SessionNotFoundError, SessionState
+from .session import (
+    Session,
+    SessionBusyError,
+    SessionManager,
+    SessionNotFoundError,
+    SessionState,
+    StreamPathRuntime,
+    StreamPathRuntimeFacts,
+)
 from .tail_trim import SealPathTailTrimmer
 
 SESSION_GUARD_POLL_SECS = 0.1
@@ -134,11 +142,10 @@ class SessionOrchestrator:
         self._active_stream: ParakeetStreamingSession | None = None
         self._stream_drain_task: asyncio.Task | None = None
         self._stream_drain_running = False
-        self._current_stream_chunks_processed = 0
-        self._current_stream_fallback_reason: str | None = None
-        self._last_stream_path_executed = False
-        self._last_stream_chunks_processed = 0
-        self._last_stream_fallback_reason: str | None = None
+        self.stream_path_runtime = StreamPathRuntime.from_settings(
+            settings,
+            self.streaming_transcriber,
+        )
         self._session_guard_task: asyncio.Task | None = None
         self._session_guard_running = False
         self._last_audio_ms: int | None = None
@@ -180,19 +187,18 @@ class SessionOrchestrator:
             return
         try:
             self._reset_interim_transcript_session(message.session_id)
-            self._reset_current_stream_runtime()
+            self._stream_path_runtime_for_runtime().reset_current()
             self.audio.start_session()
             streaming_transcriber = self.streaming_transcriber
-            if streaming_transcriber is not None or bool(
-                getattr(self.settings, "streaming_enabled", False)
-            ):
-                if self._streaming_helper_available() and streaming_transcriber is not None:
+            stream_runtime = self._stream_path_runtime_for_runtime()
+            if stream_runtime.should_start_drain_loop():
+                if stream_runtime.helper_available() and streaming_transcriber is not None:
                     self._active_stream = streaming_transcriber.start_session(
                         self.audio.sample_rate
                     )
                 else:
-                    self._current_stream_fallback_reason = (
-                        self._stream_fallback_reason_from_runtime()
+                    stream_runtime.record_current_fallback(
+                        stream_runtime.fallback_reason_from_runtime()
                     )
                 self._start_stream_drain_loop(event_sink, message.session_id)
             self._start_session_guard_loop(event_sink, message.session_id, owner_token=owner_token)
@@ -278,7 +284,7 @@ class SessionOrchestrator:
             await self._stop_stream_drain_loop()
             self._record_stream_runtime_result()
             # Final correctness must come from the capture layer's canonical buffer,
-            # not whatever the drain task managed to mirror into `_active_stream`.
+            # not whatever the Stream path managed to mirror into its active stream.
             self._active_stream = None
             audio_stop_ms = int((time.perf_counter() - audio_stop_started) * 1000)
             audio_duration_raw = len(audio_samples) / self.audio.sample_rate
@@ -493,7 +499,7 @@ class SessionOrchestrator:
                 await self.sessions.clear(active_session_id, owner_token=active_owner_token)
                 self._clear_overlay_session_runtime(active_session_id)
             self._active_stream = None
-            self._reset_current_stream_runtime()
+            self._stream_path_runtime_for_runtime().reset_current()
             if active_session_id is not None and event_sink is not None and session_end_reason:
                 await self._emit_session_ended(
                     event_sink, active_session_id, reason=session_end_reason
@@ -827,6 +833,11 @@ class SessionOrchestrator:
             overlay_events_enabled=overlay_events_enabled,
         )
 
+    def stream_path_runtime_facts_for_runtime(self) -> StreamPathRuntimeFacts:
+        return self._stream_path_runtime_for_runtime().facts(
+            active_session=self.sessions.active is not None
+        )
+
     def runtime_status_state(self) -> RuntimeTruthState:
         active = self.sessions.active
         return RuntimeTruthState(
@@ -911,53 +922,20 @@ class SessionOrchestrator:
         finally:
             _release_cuda_cache(effective_device)
 
-    def _reset_current_stream_runtime(self) -> None:
-        self._current_stream_chunks_processed = 0
-        self._current_stream_fallback_reason = None
-
-    def _streaming_helper_available(self) -> bool:
-        transcriber = getattr(self, "streaming_transcriber", None)
-        return transcriber is not None and bool(getattr(transcriber, "helper_active", False))
-
-    def _stream_fallback_reason_from_runtime(self) -> str | None:
-        if not bool(getattr(self.settings, "streaming_enabled", False)):
-            return None
-        transcriber = getattr(self, "streaming_transcriber", None)
-        if transcriber is None:
-            return "streaming_transcriber_unavailable"
-        fallback_reason = getattr(transcriber, "fallback_reason", None)
-        if fallback_reason is not None:
-            return fallback_reason
-        if not bool(getattr(transcriber, "helper_active", False)):
-            return "streaming_helper_inactive"
-        return None
-
     def _record_stream_runtime_result(self) -> None:
-        chunks_processed = int(getattr(self, "_current_stream_chunks_processed", 0))
-        fallback_reason = getattr(self, "_current_stream_fallback_reason", None)
-        active_stream = getattr(self, "_active_stream", None)
-        if active_stream is not None and fallback_reason is None:
-            fallback_reason = getattr(active_stream, "stream_fallback_reason", None)
-        if bool(getattr(self.settings, "streaming_enabled", False)):
-            if fallback_reason is None:
-                fallback_reason = self._stream_fallback_reason_from_runtime()
-            if chunks_processed <= 0 and fallback_reason is None:
-                fallback_reason = "stream_path_not_exercised:no_chunks"
-        else:
-            fallback_reason = None
-        self._last_stream_chunks_processed = chunks_processed
-        self._last_stream_path_executed = chunks_processed > 0
-        self._last_stream_fallback_reason = fallback_reason
+        self._stream_path_runtime_for_runtime().record_session_result(
+            active_stream=getattr(self, "_active_stream", None)
+        )
 
     async def _feed_stream_chunk(self, stream: ParakeetStreamingSession, chunk: np.ndarray) -> None:
         async with self._inference_lock_for_runtime():
             processed = await asyncio.to_thread(stream.feed, chunk)
         if processed:
-            self._current_stream_chunks_processed += 1
+            self._stream_path_runtime_for_runtime().record_chunk_processed()
             return
         reason = getattr(stream, "stream_fallback_reason", None)
         if reason is not None:
-            self._current_stream_fallback_reason = reason
+            self._stream_path_runtime_for_runtime().record_current_fallback(reason)
 
     def _start_stream_drain_loop(self, event_sink: EventSink, session_id: UUID) -> None:
         if self._stream_drain_task is not None:
@@ -998,6 +976,21 @@ class SessionOrchestrator:
                 "Stream drain loop stopped with {} during shutdown",
                 exc.__class__.__name__,
             )
+
+    def _stream_path_runtime_for_runtime(self) -> StreamPathRuntime:
+        runtime = getattr(self, "stream_path_runtime", None)
+        if not isinstance(runtime, StreamPathRuntime):
+            runtime = StreamPathRuntime.from_settings(
+                self.settings,
+                getattr(self, "streaming_transcriber", None),
+            )
+            self.stream_path_runtime = runtime
+        else:
+            runtime.sync_from_runtime(
+                settings=self.settings,
+                streaming_transcriber=getattr(self, "streaming_transcriber", None),
+            )
+        return runtime
 
 
 __all__ = [

--- a/parakeet-stt-daemon/tests/test_session_orchestrator.py
+++ b/parakeet-stt-daemon/tests/test_session_orchestrator.py
@@ -20,7 +20,7 @@ from parakeet_stt_daemon.events import (
     SessionWarningEvent,
 )
 from parakeet_stt_daemon.messages import SessionEndReason
-from parakeet_stt_daemon.session import SessionManager
+from parakeet_stt_daemon.session import SessionManager, StreamPathRuntime
 from parakeet_stt_daemon.session_orchestrator import (
     AbortSessionIntent,
     SessionOrchestrator,
@@ -123,11 +123,10 @@ def _build_orchestrator(
     orchestrator._active_stream = None
     orchestrator._stream_drain_task = None
     orchestrator._stream_drain_running = False
-    orchestrator._current_stream_chunks_processed = 0
-    orchestrator._current_stream_fallback_reason = None
-    orchestrator._last_stream_path_executed = False
-    orchestrator._last_stream_chunks_processed = 0
-    orchestrator._last_stream_fallback_reason = None
+    orchestrator.stream_path_runtime = StreamPathRuntime.from_settings(
+        settings,
+        orchestrator.streaming_transcriber,
+    )
     orchestrator._session_guard_task = None
     orchestrator._session_guard_running = False
     orchestrator._session_sample_limit = int(max_session_seconds * FakeAudio.sample_rate)
@@ -216,7 +215,10 @@ def test_start_keeps_stream_drain_loop_when_helper_inactive() -> None:
         await orchestrator.sessions.clear(session_id, owner_token=1)
 
         assert orchestrator._active_stream is None
-        assert orchestrator._current_stream_fallback_reason == "init_failed:ImportError"
+        assert (
+            orchestrator.stream_path_runtime.facts(active_session=True).fallback_reason
+            == "init_failed:ImportError"
+        )
         assert audio.take_audio_levels_calls > 0
         assert audio.take_stream_chunks_calls > 0
 

--- a/parakeet-stt-daemon/tests/test_streaming_truth.py
+++ b/parakeet-stt-daemon/tests/test_streaming_truth.py
@@ -12,7 +12,12 @@ import numpy as np
 from parakeet_stt_daemon.config import ServerSettings
 from parakeet_stt_daemon.messages import StatusMessage
 from parakeet_stt_daemon.runtime_truth_snapshot import RuntimeTruth, snapshot
-from parakeet_stt_daemon.session import Session, SessionManager
+from parakeet_stt_daemon.session import (
+    Session,
+    SessionManager,
+    StreamPathRuntime,
+    StreamPathRuntimeFacts,
+)
 from parakeet_stt_daemon.session_orchestrator import SessionOrchestrator
 from parakeet_stt_daemon.tail_trim import SealPathTailTrimmer
 
@@ -63,6 +68,14 @@ class FakeVadAdapter:
         return samples.astype(np.float32, copy=False)
 
 
+class StreamPrivateFieldTrap(SimpleNamespace):
+    def __getattr__(self, name: str) -> Any:
+        private_stream_prefixes = ("_current_" + "stream", "_last_" + "stream")
+        if name.startswith(private_stream_prefixes):
+            raise AssertionError(f"runtime truth probed old Stream path field {name}")
+        raise AttributeError(name)
+
+
 def _build_server(
     *,
     streaming_enabled: bool = True,
@@ -88,11 +101,10 @@ def _build_server(
     orchestrator._active_stream = None
     orchestrator._stream_drain_task = None
     orchestrator._stream_drain_running = False
-    orchestrator._current_stream_chunks_processed = 0
-    orchestrator._current_stream_fallback_reason = None
-    orchestrator._last_stream_path_executed = False
-    orchestrator._last_stream_chunks_processed = 0
-    orchestrator._last_stream_fallback_reason = None
+    orchestrator.stream_path_runtime = StreamPathRuntime.from_settings(
+        orchestrator.settings,
+        streaming_transcriber,
+    )
     orchestrator._last_interim_transcript_runtime_facts = None
     orchestrator._requested_device = "cpu"
     orchestrator._effective_device = "cpu"
@@ -243,6 +255,47 @@ def test_runtime_truth_preserves_missing_optional_device_and_chunk_values() -> N
     assert truth.stream_fallback_reason == "streaming_transcriber_unavailable"
 
 
+def test_runtime_truth_reads_stream_path_interface_instead_of_orchestrator_fields() -> None:
+    runtime_facts = StreamPathRuntimeFacts(
+        streaming_enabled=True,
+        helper_active=True,
+        helper_scope="live_session_only",
+        helper_class_name="InterfaceHelper",
+        fallback_reason="interface:fallback",
+        chunk_secs=1.25,
+        path_executed=True,
+        chunks_processed=3,
+    )
+    orchestrator = cast(
+        SessionOrchestrator,
+        StreamPrivateFieldTrap(
+            settings=SimpleNamespace(
+                streaming_enabled=True,
+                chunk_secs=9.99,
+                overlay_events_enabled=False,
+            ),
+            streaming_transcriber=None,
+            stream_path_runtime_facts_for_runtime=lambda: runtime_facts,
+        ),
+    )
+
+    truth = snapshot(
+        orchestrator,
+        last_trim_outcome=SimpleNamespace(
+            tail_trim_mode="rms",
+            vad_active=False,
+            vad_fallback_reason=None,
+        ),
+    )
+
+    assert truth.stream_helper_active is True
+    assert truth.stream_helper_class_name == "InterfaceHelper"
+    assert truth.stream_path_executed is True
+    assert truth.stream_chunks_processed == 3
+    assert truth.stream_fallback_reason == "interface:fallback"
+    assert truth.chunk_secs == 1.25
+
+
 def test_runtime_truth_ignores_invalid_chunk_secs_values() -> None:
     for chunk_secs in ("not-a-number", "nan", "inf", float("nan"), float("inf"), True):
         orchestrator = cast(
@@ -376,8 +429,9 @@ def test_stream_fallback_reason_none_when_active() -> None:
 def test_status_reports_stream_path_execution_from_last_session() -> None:
     transcriber = FakeStreamingTranscriber(helper_active=True)
     server = _build_server(streaming_transcriber=transcriber)
-    server._last_stream_path_executed = True
-    server._last_stream_chunks_processed = 2
+    server.stream_path_runtime.record_chunk_processed()
+    server.stream_path_runtime.record_chunk_processed()
+    server.stream_path_runtime.record_session_result(active_stream=None)
 
     status = _status(server)
     log_record = _truth(server).to_log_record()
@@ -394,9 +448,7 @@ def test_status_reports_stream_path_execution_from_last_session() -> None:
 def test_status_reports_fallback_when_helper_exists_but_no_stream_work_ran() -> None:
     transcriber = FakeStreamingTranscriber(helper_active=True)
     server = _build_server(streaming_transcriber=transcriber)
-    server._last_stream_path_executed = False
-    server._last_stream_chunks_processed = 0
-    server._last_stream_fallback_reason = "stream_path_not_exercised:no_chunks"
+    server.stream_path_runtime.record_session_result(active_stream=None)
 
     status = _status(server)
     log_record = _truth(server).to_log_record()
@@ -412,9 +464,9 @@ def test_status_reports_fallback_when_helper_exists_but_no_stream_work_ran() -> 
 def test_status_reports_fallback_even_after_stream_path_executed() -> None:
     transcriber = FakeStreamingTranscriber(helper_active=True)
     server = _build_server(streaming_transcriber=transcriber)
-    server._last_stream_path_executed = True
-    server._last_stream_chunks_processed = 1
-    server._last_stream_fallback_reason = "stream_chunk_failed:RuntimeError"
+    server.stream_path_runtime.record_chunk_processed()
+    server.stream_path_runtime.record_current_fallback("stream_chunk_failed:RuntimeError")
+    server.stream_path_runtime.record_session_result(active_stream=None)
 
     status = _status(server)
     truth = _truth(server)
@@ -528,7 +580,8 @@ def test_status_reports_interim_source_fallback_reason() -> None:
 def test_active_session_does_not_inherit_previous_stream_fallback() -> None:
     transcriber = FakeStreamingTranscriber(helper_active=True)
     server = _build_server(streaming_transcriber=transcriber)
-    server._last_stream_fallback_reason = "stream_path_not_exercised:no_chunks"
+    server.stream_path_runtime.record_session_result(active_stream=None)
+    server.stream_path_runtime.reset_current()
     cast(Any, server.sessions)._active = Session(session_id=uuid4(), owner_token=1)
 
     status = _status(server)


### PR DESCRIPTION
Fixes #122.

## Summary
- Adds `StreamPathRuntime` / `StreamPathRuntimeFacts` as the focused Daemon Session interface for Stream path runtime truth.
- Routes SessionOrchestrator Stream path start, feed, stop, cleanup accounting, and `/status` runtime truth through that interface.
- Removes the old `_current_stream_*` / `_last_stream_*` private-field truth wiring and updates tests around the new boundary.

## Compatibility
`/status` Stream path fields and meanings are preserved: `streaming_enabled`, `stream_helper_active`, `stream_helper_scope`, `stream_fallback_reason`, `stream_path_executed`, `stream_chunks_processed`, and `chunk_secs`.

## Verification (#122)
- targeted: `uv run --project parakeet-stt-daemon pytest -q parakeet-stt-daemon/tests/test_streaming_truth.py parakeet-stt-daemon/tests/test_session_orchestrator.py parakeet-stt-daemon/tests/test_session_cleanup.py parakeet-stt-daemon/tests/test_offline_in_memory_transcription.py` -> PASSED (62 passed)
- regression: no old Stream path private runtime truth fields remain in `parakeet-stt-daemon/src` or `parakeet-stt-daemon/tests` -> PASSED
- full suite: `uv run --project parakeet-stt-daemon pytest -q` -> PASSED (204 passed)
- lint: `uv run --project parakeet-stt-daemon ruff check --config parakeet-stt-daemon/pyproject.toml` on changed daemon files -> PASSED
- format: `uv run --project parakeet-stt-daemon ruff format --check --config parakeet-stt-daemon/pyproject.toml` on changed daemon files -> PASSED
- types: `ty check --project parakeet-stt-daemon --error-on-warning` -> PASSED
- dead-code: `uv run deptry .` from `parakeet-stt-daemon/` -> FAILED preexisting unrelated `DEP002` on `onnxruntime`
- build: `uv build --project parakeet-stt-daemon` -> PASSED
- pre-commit: `prek run --files <changed files>` -> PASSED; `prek run --all-files` -> PASSED
- pre-push: `prek run --stage pre-push --all-files` -> PASSED; push hook also passed Python pytest for changed files
- CLI/script smoke: `uv run --project parakeet-stt-daemon parakeet-stt-daemon --check` -> PASSED
- static/security: N/A (no repo security linter applies to this daemon-only refactor)
- migrations: N/A
- UI render: N/A
- destructive/negative: N/A
- review: `coderabbit_review_watch.py local -- --base main` -> clean (exit 0, status: `.git/coderabbit-review/20260521T202857Z/status.json`, findings=0, codex-fallback=no)
- tests added/expanded: `parakeet-stt-daemon/tests/test_streaming_truth.py`, `parakeet-stt-daemon/tests/test_session_orchestrator.py`
- preexisting failures left: `deptry DEP002` on `onnxruntime`
- deferrals: none

## Review Status
- Local CodeRabbit watcher: clean, no fallback.
- PR-side CodeRabbit gate: pending after PR creation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Exposed new public API for querying stream runtime facts, transcriber status, and fallback reasons
  * Improved real-time visibility into streaming session activity and chunk processing progress

* **Refactor**
  * Refactored stream-path runtime tracking with improved state management
  * Enhanced fallback reason reporting with dedicated abstraction
  * Optimized session cleanup and runtime state handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SystemicVoid/parakeet-stt/pull/140?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->