### PR TITLE
Refactor daemon interim transcript runtime truth

### DIFF
--- a/parakeet-stt-daemon/src/parakeet_stt_daemon/overlay_interim.py
+++ b/parakeet-stt-daemon/src/parakeet_stt_daemon/overlay_interim.py
@@ -265,6 +265,10 @@ class OverlayInterimTranscriptSession:
         self._last_source: InterimTranscriptSource | None = None
         self._source_fallback_reason: str | None = None
 
+    def sync_runtime_config(self, *, sample_rate: int, enabled: bool) -> None:
+        self._sample_rate = int(sample_rate)
+        self._enabled = bool(enabled)
+
     @property
     def runtime_facts(self) -> InterimTranscriptRuntimeFacts:
         live = self._source_state["live"]

--- a/parakeet-stt-daemon/src/parakeet_stt_daemon/session.py
+++ b/parakeet-stt-daemon/src/parakeet_stt_daemon/session.py
@@ -7,8 +7,17 @@ import math
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import StrEnum
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 from uuid import UUID
+
+from .overlay_interim import (
+    InterimTranscriber,
+    InterimTranscriptRuntimeFacts,
+    OverlayInterimTranscriptSession,
+)
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 class SessionState(StrEnum):
@@ -202,6 +211,96 @@ class StreamPathRuntime:
         )
 
 
+class InterimTranscriptRuntime:
+    """Own interim transcript source runtime truth for Daemon Sessions."""
+
+    def __init__(self, *, sample_rate: int, enabled: bool) -> None:
+        self.sample_rate = int(sample_rate)
+        self.enabled = bool(enabled)
+        self._by_session: dict[UUID, OverlayInterimTranscriptSession] = {}
+        self._last_facts: InterimTranscriptRuntimeFacts | None = None
+
+    @classmethod
+    def from_settings(cls, settings: object, *, sample_rate: int) -> InterimTranscriptRuntime:
+        return cls(
+            sample_rate=sample_rate,
+            enabled=bool(getattr(settings, "overlay_events_enabled", False)),
+        )
+
+    def sync_from_runtime(self, *, settings: object, sample_rate: int) -> None:
+        self.sample_rate = int(sample_rate)
+        self.enabled = bool(getattr(settings, "overlay_events_enabled", False))
+        for session in self._by_session.values():
+            session.sync_runtime_config(
+                sample_rate=self.sample_rate,
+                enabled=self.enabled,
+            )
+
+    def reset_session(self, session_id: UUID) -> None:
+        self._by_session[session_id] = self._new_session(session_id)
+
+    def clear_session(self, session_id: UUID) -> None:
+        self._by_session.pop(session_id, None)
+
+    def record_last_session(self, session_id: UUID) -> None:
+        session = self._by_session.get(session_id)
+        self._last_facts = session.runtime_facts if session is not None else self.empty_facts()
+
+    def session_runtime_facts(self, session_id: UUID) -> InterimTranscriptRuntimeFacts:
+        return self._session(session_id).runtime_facts
+
+    def facts(self, *, active_session_id: UUID | None) -> InterimTranscriptRuntimeFacts:
+        if active_session_id is not None:
+            return self._session(active_session_id).runtime_facts
+        return self._last_facts if self._last_facts is not None else self.empty_facts()
+
+    async def accept_live_chunk(
+        self,
+        session_id: UUID,
+        chunk: np.ndarray,
+        transcribe: InterimTranscriber,
+    ) -> str | None:
+        return await self._session(session_id).accept_live_chunk(chunk, transcribe)
+
+    async def collect_stop_replay_updates(
+        self,
+        session_id: UUID,
+        ready_chunks: list[np.ndarray],
+        transcribe: InterimTranscriber,
+    ) -> list[str]:
+        return await self._session(session_id).collect_stop_replay_updates(
+            ready_chunks,
+            transcribe,
+        )
+
+    def empty_facts(self) -> InterimTranscriptRuntimeFacts:
+        return InterimTranscriptRuntimeFacts(
+            enabled=self.enabled,
+            last_source=None,
+            live_chunks_processed=0,
+            live_updates_emitted=0,
+            live_failed=False,
+            stop_replay_chunks_processed=0,
+            stop_replay_updates_emitted=0,
+            stop_replay_failed=False,
+            source_fallback_reason=None,
+        )
+
+    def _session(self, session_id: UUID) -> OverlayInterimTranscriptSession:
+        session = self._by_session.get(session_id)
+        if session is None:
+            session = self._new_session(session_id)
+            self._by_session[session_id] = session
+        return session
+
+    def _new_session(self, session_id: UUID) -> OverlayInterimTranscriptSession:
+        return OverlayInterimTranscriptSession(
+            session_id=session_id,
+            sample_rate=self.sample_rate,
+            enabled=self.enabled,
+        )
+
+
 class SessionManager:
     """Coordinate access to the single active session allowed by the daemon."""
 
@@ -242,6 +341,8 @@ class SessionManager:
 
 
 __all__ = [
+    "InterimTranscriptRuntime",
+    "InterimTranscriptRuntimeFacts",
     "Session",
     "SessionBusyError",
     "SessionManager",

--- a/parakeet-stt-daemon/src/parakeet_stt_daemon/session_orchestrator.py
+++ b/parakeet-stt-daemon/src/parakeet_stt_daemon/session_orchestrator.py
@@ -45,10 +45,6 @@ from .model import (
     _release_cuda_cache,
     load_parakeet_model,
 )
-from .overlay_interim import (
-    InterimTranscriptRuntimeFacts,
-    OverlayInterimTranscriptSession,
-)
 from .runtime_truth_snapshot import (
     RuntimeTruth,
     RuntimeTruthMetrics,
@@ -59,6 +55,8 @@ from .runtime_truth_snapshot import (
     snapshot as runtime_truth_snapshot,
 )
 from .session import (
+    InterimTranscriptRuntime,
+    InterimTranscriptRuntimeFacts,
     Session,
     SessionBusyError,
     SessionManager,
@@ -162,8 +160,10 @@ class SessionOrchestrator:
         if settings.streaming_enabled:
             chunk_samples = int(settings.chunk_secs * self.audio.sample_rate)
             self.audio.configure_stream_chunk_size(chunk_samples)
-        self._interim_transcript_by_session: dict[UUID, OverlayInterimTranscriptSession] = {}
-        self._last_interim_transcript_runtime_facts: InterimTranscriptRuntimeFacts | None = None
+        self.interim_transcript_runtime = InterimTranscriptRuntime.from_settings(
+            settings,
+            sample_rate=self.audio.sample_rate,
+        )
 
     async def start(self, intent: StartSessionIntent) -> None:
         await self._handle_start(intent)
@@ -186,7 +186,7 @@ class SessionOrchestrator:
             )
             return
         try:
-            self._reset_interim_transcript_session(message.session_id)
+            self._interim_transcript_runtime_for_runtime().reset_session(message.session_id)
             self._stream_path_runtime_for_runtime().reset_current()
             self.audio.start_session()
             streaming_transcriber = self.streaming_transcriber
@@ -300,9 +300,10 @@ class SessionOrchestrator:
                 await self._emit_session_ended(
                     event_sink, session.session_id, reason=SessionEndReason.ERROR
                 )
-                self._record_last_interim_transcript_runtime(session.session_id)
-                await self.sessions.clear(session.session_id, owner_token=owner_token)
-                self._clear_overlay_session_runtime(session.session_id)
+                await self._record_last_and_clear_session_runtime(
+                    session.session_id,
+                    owner_token=owner_token,
+                )
                 return
 
             finalize_ms: int | None = None
@@ -340,9 +341,10 @@ class SessionOrchestrator:
                 await self._emit_session_ended(
                     event_sink, session.session_id, reason=SessionEndReason.ERROR
                 )
-                self._record_last_interim_transcript_runtime(session.session_id)
-                await self.sessions.clear(session.session_id, owner_token=owner_token)
-                self._clear_overlay_session_runtime(session.session_id)
+                await self._record_last_and_clear_session_runtime(
+                    session.session_id,
+                    owner_token=owner_token,
+                )
                 return
 
             latency_ms = int((datetime.now(tz=UTC) - session.last_updated).total_seconds() * 1000)
@@ -367,9 +369,10 @@ class SessionOrchestrator:
             await self._emit_session_ended(
                 event_sink, session.session_id, reason=SessionEndReason.FINAL
             )
-            self._record_last_interim_transcript_runtime(session.session_id)
-            await self.sessions.clear(session.session_id, owner_token=owner_token)
-            self._clear_overlay_session_runtime(session.session_id)
+            await self._record_last_and_clear_session_runtime(
+                session.session_id,
+                owner_token=owner_token,
+            )
             self._last_audio_ms = audio_ms
             self._last_audio_stop_ms = audio_stop_ms
             self._last_finalize_ms = finalize_ms
@@ -495,9 +498,10 @@ class SessionOrchestrator:
             await self._stop_stream_drain_loop()
             self._stop_session_guard_loop()
             if active_session_id is not None:
-                self._record_last_interim_transcript_runtime(active_session_id)
-                await self.sessions.clear(active_session_id, owner_token=active_owner_token)
-                self._clear_overlay_session_runtime(active_session_id)
+                await self._record_last_and_clear_session_runtime(
+                    active_session_id,
+                    owner_token=active_owner_token,
+                )
             self._active_stream = None
             self._stream_path_runtime_for_runtime().reset_current()
             if active_session_id is not None and event_sink is not None and session_end_reason:
@@ -680,76 +684,16 @@ class SessionOrchestrator:
                     )
                 raise
 
-    def _clear_overlay_session_runtime(self, session_id: UUID) -> None:
-        interim_sessions = getattr(self, "_interim_transcript_by_session", None)
-        if isinstance(interim_sessions, dict):
-            interim_sessions.pop(session_id, None)
-
-    def _reset_interim_transcript_session(self, session_id: UUID) -> None:
-        interim_sessions = self._interim_transcript_sessions_for_runtime()
-        interim_sessions[session_id] = OverlayInterimTranscriptSession(
-            session_id=session_id,
-            sample_rate=int(self.audio.sample_rate),
-            enabled=bool(self.settings.overlay_events_enabled),
-        )
-
-    def _interim_transcript_sessions_for_runtime(
-        self,
-    ) -> dict[UUID, OverlayInterimTranscriptSession]:
-        interim_sessions = getattr(self, "_interim_transcript_by_session", None)
-        if not isinstance(interim_sessions, dict):
-            interim_sessions = {}
-            self._interim_transcript_by_session = interim_sessions
-        return interim_sessions
-
-    def _interim_transcript_session(self, session_id: UUID) -> OverlayInterimTranscriptSession:
-        interim_sessions = self._interim_transcript_sessions_for_runtime()
-        interim_session = interim_sessions.get(session_id)
-        if interim_session is None:
-            interim_session = OverlayInterimTranscriptSession(
-                session_id=session_id,
-                sample_rate=int(self.audio.sample_rate),
-                enabled=bool(self.settings.overlay_events_enabled),
-            )
-            interim_sessions[session_id] = interim_session
-        return interim_session
-
     def interim_transcript_runtime_facts(
         self,
         session_id: UUID,
     ) -> InterimTranscriptRuntimeFacts:
-        return self._interim_transcript_session(session_id).runtime_facts
+        return self._interim_transcript_runtime_for_runtime().session_runtime_facts(session_id)
 
     def interim_transcript_runtime_facts_for_runtime(self) -> InterimTranscriptRuntimeFacts:
         active = self.sessions.active
-        if active is not None:
-            return self._interim_transcript_session(active.session_id).runtime_facts
-        last_facts = getattr(self, "_last_interim_transcript_runtime_facts", None)
-        if isinstance(last_facts, InterimTranscriptRuntimeFacts):
-            return last_facts
-        return self._empty_interim_transcript_runtime_facts()
-
-    def _record_last_interim_transcript_runtime(self, session_id: UUID) -> None:
-        interim_sessions = self._interim_transcript_sessions_for_runtime()
-        interim_session = interim_sessions.get(session_id)
-        if interim_session is None:
-            self._last_interim_transcript_runtime_facts = (
-                self._empty_interim_transcript_runtime_facts()
-            )
-            return
-        self._last_interim_transcript_runtime_facts = interim_session.runtime_facts
-
-    def _empty_interim_transcript_runtime_facts(self) -> InterimTranscriptRuntimeFacts:
-        return InterimTranscriptRuntimeFacts(
-            enabled=bool(self.settings.overlay_events_enabled),
-            last_source=None,
-            live_chunks_processed=0,
-            live_updates_emitted=0,
-            live_failed=False,
-            stop_replay_chunks_processed=0,
-            stop_replay_updates_emitted=0,
-            stop_replay_failed=False,
-            source_fallback_reason=None,
+        return self._interim_transcript_runtime_for_runtime().facts(
+            active_session_id=active.session_id if active is not None else None
         )
 
     async def _emit_interim_state(
@@ -774,7 +718,8 @@ class SessionOrchestrator:
         session_id: UUID,
         ready_chunks: list[np.ndarray],
     ) -> list[str]:
-        return await self._interim_transcript_session(session_id).collect_stop_replay_updates(
+        return await self._interim_transcript_runtime_for_runtime().collect_stop_replay_updates(
+            session_id,
             ready_chunks,
             self._transcribe_samples_serialized,
         )
@@ -819,12 +764,24 @@ class SessionOrchestrator:
         session_id: UUID,
         chunk: np.ndarray,
     ) -> None:
-        update = await self._interim_transcript_session(session_id).accept_live_chunk(
+        update = await self._interim_transcript_runtime_for_runtime().accept_live_chunk(
+            session_id,
             chunk,
             self._transcribe_samples_serialized,
         )
         if update is not None:
             await self._emit_interim_text(event_sink, session_id, text=update)
+
+    async def _record_last_and_clear_session_runtime(
+        self,
+        session_id: UUID,
+        *,
+        owner_token: int | None,
+    ) -> None:
+        interim_runtime = self._interim_transcript_runtime_for_runtime()
+        interim_runtime.record_last_session(session_id)
+        await self.sessions.clear(session_id, owner_token=owner_token)
+        interim_runtime.clear_session(session_id)
 
     def runtime_truth(self, *, overlay_events_enabled: bool) -> RuntimeTruth:
         return runtime_truth_snapshot(
@@ -990,6 +947,19 @@ class SessionOrchestrator:
                 settings=self.settings,
                 streaming_transcriber=getattr(self, "streaming_transcriber", None),
             )
+        return runtime
+
+    def _interim_transcript_runtime_for_runtime(self) -> InterimTranscriptRuntime:
+        runtime = getattr(self, "interim_transcript_runtime", None)
+        sample_rate = int(getattr(self.audio, "sample_rate", 16_000))
+        if not isinstance(runtime, InterimTranscriptRuntime):
+            runtime = InterimTranscriptRuntime.from_settings(
+                self.settings,
+                sample_rate=sample_rate,
+            )
+            self.interim_transcript_runtime = runtime
+        else:
+            runtime.sync_from_runtime(settings=self.settings, sample_rate=sample_rate)
         return runtime
 
 

--- a/parakeet-stt-daemon/tests/test_overlay_event_stream.py
+++ b/parakeet-stt-daemon/tests/test_overlay_event_stream.py
@@ -24,7 +24,7 @@ from parakeet_stt_daemon.messages import (
     StopSession,
 )
 from parakeet_stt_daemon.server import DaemonServer
-from parakeet_stt_daemon.session import SessionManager
+from parakeet_stt_daemon.session import InterimTranscriptRuntime, SessionManager
 from parakeet_stt_daemon.session_orchestrator import SessionOrchestrator
 
 
@@ -183,7 +183,10 @@ def _build_server(
     orchestrator._last_finalize_ms = None
     orchestrator._last_infer_ms = None
     orchestrator._last_send_ms = None
-    orchestrator._interim_transcript_by_session = {}
+    orchestrator.interim_transcript_runtime = InterimTranscriptRuntime.from_settings(
+        settings,
+        sample_rate=orchestrator.audio.sample_rate,
+    )
 
     async def fake_finalize(_audio_samples: np.ndarray) -> tuple[str, int]:
         return "overlay test text", 7

--- a/parakeet-stt-daemon/tests/test_session_cleanup.py
+++ b/parakeet-stt-daemon/tests/test_session_cleanup.py
@@ -22,7 +22,7 @@ from parakeet_stt_daemon.messages import (
     StopSession,
 )
 from parakeet_stt_daemon.server import DaemonServer
-from parakeet_stt_daemon.session import Session, SessionManager
+from parakeet_stt_daemon.session import InterimTranscriptRuntime, Session, SessionManager
 from parakeet_stt_daemon.session_orchestrator import SessionOrchestrator
 
 
@@ -166,7 +166,10 @@ def _build_server() -> DaemonServer:
     orchestrator._last_finalize_ms = None
     orchestrator._last_infer_ms = None
     orchestrator._last_send_ms = None
-    orchestrator._interim_transcript_by_session = {}
+    orchestrator.interim_transcript_runtime = InterimTranscriptRuntime.from_settings(
+        settings,
+        sample_rate=orchestrator.audio.sample_rate,
+    )
 
     async def fake_collect_interim_text_updates(
         _session_id: UUID, _ready_chunks: list[object]

--- a/parakeet-stt-daemon/tests/test_session_orchestrator.py
+++ b/parakeet-stt-daemon/tests/test_session_orchestrator.py
@@ -20,7 +20,11 @@ from parakeet_stt_daemon.events import (
     SessionWarningEvent,
 )
 from parakeet_stt_daemon.messages import SessionEndReason
-from parakeet_stt_daemon.session import SessionManager, StreamPathRuntime
+from parakeet_stt_daemon.session import (
+    InterimTranscriptRuntime,
+    SessionManager,
+    StreamPathRuntime,
+)
 from parakeet_stt_daemon.session_orchestrator import (
     AbortSessionIntent,
     SessionOrchestrator,
@@ -127,6 +131,10 @@ def _build_orchestrator(
         settings,
         orchestrator.streaming_transcriber,
     )
+    orchestrator.interim_transcript_runtime = InterimTranscriptRuntime.from_settings(
+        settings,
+        sample_rate=orchestrator.audio.sample_rate,
+    )
     orchestrator._session_guard_task = None
     orchestrator._session_guard_running = False
     orchestrator._session_sample_limit = int(max_session_seconds * FakeAudio.sample_rate)
@@ -138,7 +146,6 @@ def _build_orchestrator(
     orchestrator._last_finalize_ms = None
     orchestrator._last_infer_ms = None
     orchestrator._last_send_ms = None
-    orchestrator._interim_transcript_by_session = {}
     orchestrator._vad_enabled = False
 
     async def fake_collect_interim_text_updates(

--- a/parakeet-stt-daemon/tests/test_streaming_truth.py
+++ b/parakeet-stt-daemon/tests/test_streaming_truth.py
@@ -13,6 +13,8 @@ from parakeet_stt_daemon.config import ServerSettings
 from parakeet_stt_daemon.messages import StatusMessage
 from parakeet_stt_daemon.runtime_truth_snapshot import RuntimeTruth, snapshot
 from parakeet_stt_daemon.session import (
+    InterimTranscriptRuntime,
+    InterimTranscriptRuntimeFacts,
     Session,
     SessionManager,
     StreamPathRuntime,
@@ -68,11 +70,17 @@ class FakeVadAdapter:
         return samples.astype(np.float32, copy=False)
 
 
-class StreamPrivateFieldTrap(SimpleNamespace):
+class RuntimeTruthPrivateFieldTrap(SimpleNamespace):
     def __getattr__(self, name: str) -> Any:
         private_stream_prefixes = ("_current_" + "stream", "_last_" + "stream")
         if name.startswith(private_stream_prefixes):
             raise AssertionError(f"runtime truth probed old Stream path field {name}")
+        private_interim_fields = (
+            "_interim_transcript_by_session",
+            "_last_interim_transcript_runtime_facts",
+        )
+        if name in private_interim_fields:
+            raise AssertionError(f"runtime truth probed old interim transcript field {name}")
         raise AttributeError(name)
 
 
@@ -105,7 +113,10 @@ def _build_server(
         orchestrator.settings,
         streaming_transcriber,
     )
-    orchestrator._last_interim_transcript_runtime_facts = None
+    orchestrator.interim_transcript_runtime = InterimTranscriptRuntime.from_settings(
+        orchestrator.settings,
+        sample_rate=orchestrator.audio.sample_rate,
+    )
     orchestrator._requested_device = "cpu"
     orchestrator._effective_device = "cpu"
     orchestrator._last_audio_ms = None
@@ -113,7 +124,6 @@ def _build_server(
     orchestrator._last_finalize_ms = None
     orchestrator._last_infer_ms = None
     orchestrator._last_send_ms = None
-    orchestrator._interim_transcript_by_session = {}
     orchestrator._vad_enabled = vad_enabled
     orchestrator.tail_trimmer = SealPathTailTrimmer(
         vad_enabled=vad_enabled,
@@ -268,7 +278,7 @@ def test_runtime_truth_reads_stream_path_interface_instead_of_orchestrator_field
     )
     orchestrator = cast(
         SessionOrchestrator,
-        StreamPrivateFieldTrap(
+        RuntimeTruthPrivateFieldTrap(
             settings=SimpleNamespace(
                 streaming_enabled=True,
                 chunk_secs=9.99,
@@ -294,6 +304,70 @@ def test_runtime_truth_reads_stream_path_interface_instead_of_orchestrator_field
     assert truth.stream_chunks_processed == 3
     assert truth.stream_fallback_reason == "interface:fallback"
     assert truth.chunk_secs == 1.25
+
+
+def test_runtime_truth_reads_interim_interface_instead_of_orchestrator_fields() -> None:
+    interim_facts = InterimTranscriptRuntimeFacts(
+        enabled=True,
+        last_source="stop_replay",
+        live_chunks_processed=2,
+        live_updates_emitted=1,
+        live_failed=False,
+        stop_replay_chunks_processed=3,
+        stop_replay_updates_emitted=2,
+        stop_replay_failed=True,
+        source_fallback_reason="stop_replay_transcribe_error:RuntimeError",
+    )
+    orchestrator = cast(
+        SessionOrchestrator,
+        RuntimeTruthPrivateFieldTrap(
+            settings=SimpleNamespace(
+                streaming_enabled=False,
+                chunk_secs=None,
+                overlay_events_enabled=True,
+            ),
+            streaming_transcriber=None,
+            interim_transcript_runtime_facts_for_runtime=lambda: interim_facts,
+        ),
+    )
+
+    truth = snapshot(
+        orchestrator,
+        last_trim_outcome=SimpleNamespace(
+            tail_trim_mode="rms",
+            vad_active=False,
+            vad_fallback_reason=None,
+        ),
+    )
+
+    assert truth.interim_transcript_enabled is True
+    assert truth.interim_transcript_last_source == "stop_replay"
+    assert truth.interim_transcript_live_chunks_processed == 2
+    assert truth.interim_transcript_stop_replay_chunks_processed == 3
+    assert truth.interim_transcript_updates_emitted == 3
+    assert truth.interim_transcript_live_updates_emitted == 1
+    assert truth.interim_transcript_stop_replay_updates_emitted == 2
+    assert truth.interim_transcript_live_failed is False
+    assert truth.interim_transcript_stop_replay_failed is True
+    assert (
+        truth.interim_transcript_source_fallback_reason
+        == "stop_replay_transcribe_error:RuntimeError"
+    )
+
+
+def test_interim_runtime_syncs_cached_session_config() -> None:
+    runtime = InterimTranscriptRuntime(sample_rate=16_000, enabled=False)
+    session_id = uuid4()
+    runtime.reset_session(session_id)
+
+    assert runtime.session_runtime_facts(session_id).enabled is False
+
+    runtime.sync_from_runtime(
+        settings=SimpleNamespace(overlay_events_enabled=True),
+        sample_rate=8_000,
+    )
+
+    assert runtime.session_runtime_facts(session_id).enabled is True
 
 
 def test_runtime_truth_ignores_invalid_chunk_secs_values() -> None:
@@ -489,12 +563,13 @@ def test_status_and_logs_split_interim_truth_from_stream_path_fallback() -> None
         )
         session_id = uuid4()
         await server.sessions.start_session(session_id, owner_token=1)
-        server._reset_interim_transcript_session(session_id)
+        server.interim_transcript_runtime.reset_session(session_id)
 
         async def transcribe(_samples: np.ndarray) -> str:
             return "visible interim text"
 
-        update = await server._interim_transcript_session(session_id).accept_live_chunk(
+        update = await server.interim_transcript_runtime.accept_live_chunk(
+            session_id,
             np.full((400,), 0.2, dtype=np.float32),
             transcribe,
         )
@@ -525,9 +600,9 @@ def test_status_and_logs_split_interim_truth_from_stream_path_fallback() -> None
         assert log_record["interim_transcript_last_source"] == "live"
         assert log_record["interim_transcript_updates_emitted"] == 1
 
-        server._record_last_interim_transcript_runtime(session_id)
+        server.interim_transcript_runtime.record_last_session(session_id)
         await server.sessions.clear(session_id, owner_token=1)
-        server._clear_overlay_session_runtime(session_id)
+        server.interim_transcript_runtime.clear_session(session_id)
 
         idle_status = _status(server)
         idle_log_record = _truth(server).to_log_record()
@@ -545,12 +620,13 @@ def test_status_reports_interim_source_fallback_reason() -> None:
         server = _build_server(streaming_enabled=False, overlay_events_enabled=True)
         session_id = uuid4()
         await server.sessions.start_session(session_id, owner_token=1)
-        server._reset_interim_transcript_session(session_id)
+        server.interim_transcript_runtime.reset_session(session_id)
 
         async def transcribe(_samples: np.ndarray) -> str:
             raise RuntimeError("interim source failed")
 
-        update = await server._interim_transcript_session(session_id).accept_live_chunk(
+        update = await server.interim_transcript_runtime.accept_live_chunk(
+            session_id,
             np.full((400,), 0.2, dtype=np.float32),
             transcribe,
         )


### PR DESCRIPTION
Closes #123.

## Summary
- Add `InterimTranscriptRuntime` in the Session module to own per-session interim transcript source lifecycle, active/last facts, live updates, stop-replay updates, and empty runtime defaults.
- Route `SessionOrchestrator` start/stop/cleanup/live-interim/stop-replay/status fact calls through that interface instead of private interim dict/cache helpers.
- Update status/runtime truth tests and daemon test helpers to use the new interface, including a private-field trap that proves `/status` does not read the old shallow interim runtime fields.
- Sync cached overlay interim sessions when the runtime wrapper refreshes sample-rate/enabled settings, and centralize record-last-then-clear ordering in one helper, addressing CodeRabbit feedback from earlier PR heads.

## Verification (#123)
- scope: Move live and stop-replay interim transcript source lifecycle and runtime facts behind a focused Session module interface consumed by SessionOrchestrator and `/status`.
- branch: `issue/123-interim-source-runtime-truth`
- commit: `a6a9c03`
- targeted: `uv run --project parakeet-stt-daemon pytest -q parakeet-stt-daemon/tests/test_streaming_truth.py parakeet-stt-daemon/tests/test_session_orchestrator.py parakeet-stt-daemon/tests/test_session_cleanup.py parakeet-stt-daemon/tests/test_overlay_event_stream.py parakeet-stt-daemon/tests/test_overlay_interim_stabilizer.py` -> PASSED (90 passed)
- focused fix: `uv run --project parakeet-stt-daemon pytest -q parakeet-stt-daemon/tests/test_streaming_truth.py parakeet-stt-daemon/tests/test_overlay_interim_stabilizer.py` -> PASSED (36 passed)
- regression: `rg -n "_interim_transcript_by_session|_last_interim_transcript_runtime_facts|_reset_interim_transcript_session|_interim_transcript_sessions_for_runtime|_interim_transcript_session|_record_last_interim_transcript_runtime|_empty_interim_transcript_runtime_facts" parakeet-stt-daemon/src parakeet-stt-daemon/tests/test_session_orchestrator.py parakeet-stt-daemon/tests/test_session_cleanup.py parakeet-stt-daemon/tests/test_overlay_event_stream.py` -> PASSED (no matches)
- full suite: `uv run --project parakeet-stt-daemon pytest -q` -> PASSED (206 passed)
- lint/format: `uv run --project parakeet-stt-daemon ruff format --check --config parakeet-stt-daemon/pyproject.toml <changed files>`; `uv run --project parakeet-stt-daemon ruff check --config parakeet-stt-daemon/pyproject.toml <changed files>` -> PASSED
- types: `ty check --project parakeet-stt-daemon --error-on-warning` -> PASSED
- build: `uv build --project parakeet-stt-daemon` -> PASSED
- pre-commit/pre-push: `prek run --files <changed files>`; `prek run --all-files`; `prek run --stage pre-push --all-files`; push pre-push hook -> PASSED
- CLI/script/manual checks: `uv run --project parakeet-stt-daemon parakeet-stt-daemon --check`; `git diff --check` -> PASSED
- review: CodeRabbit local watcher `.git/coderabbit-review/20260521T205056Z/status.json` -> clean (0 findings); first PR gate finding fixed; final classified PR gate `.git/coderabbit-review/20260521T211255Z/gate-summary.json` with `.git/coderabbit-review/20260521T211255Z/decision-ledger.json` -> clean (0 findings)
- PR checks/comments: `gh pr checks 141 --watch --interval 10` -> PASSED; review thread resolved; final comment/review sweep found no unresolved actionable findings
- tests added/expanded: `parakeet-stt-daemon/tests/test_streaming_truth.py`; orchestrator/cleanup/overlay test helpers updated to use `InterimTranscriptRuntime`
- preexisting failures left: `cd parakeet-stt-daemon && uv run deptry .` -> FAILED, unrelated `DEP002` for `onnxruntime`
- deferrals: none

## Compatibility
`/status` field names and meanings are unchanged. Live Overlay interim text can still be emitted independently of Stream path helper availability, and stop-replay accounting remains separate from live source accounting.
