### PR TITLE
Localize session runtime test setup

### DIFF
--- a/parakeet-stt-daemon/tests/test_overlay_event_stream.py
+++ b/parakeet-stt-daemon/tests/test_overlay_event_stream.py
@@ -24,7 +24,7 @@ from parakeet_stt_daemon.messages import (
     StopSession,
 )
 from parakeet_stt_daemon.server import DaemonServer
-from parakeet_stt_daemon.session import InterimTranscriptRuntime, SessionManager
+from parakeet_stt_daemon.session import SessionManager
 from parakeet_stt_daemon.session_orchestrator import SessionOrchestrator
 
 
@@ -183,10 +183,6 @@ def _build_server(
     orchestrator._last_finalize_ms = None
     orchestrator._last_infer_ms = None
     orchestrator._last_send_ms = None
-    orchestrator.interim_transcript_runtime = InterimTranscriptRuntime.from_settings(
-        settings,
-        sample_rate=orchestrator.audio.sample_rate,
-    )
 
     async def fake_finalize(_audio_samples: np.ndarray) -> tuple[str, int]:
         return "overlay test text", 7

--- a/parakeet-stt-daemon/tests/test_session_cleanup.py
+++ b/parakeet-stt-daemon/tests/test_session_cleanup.py
@@ -22,7 +22,7 @@ from parakeet_stt_daemon.messages import (
     StopSession,
 )
 from parakeet_stt_daemon.server import DaemonServer
-from parakeet_stt_daemon.session import InterimTranscriptRuntime, Session, SessionManager
+from parakeet_stt_daemon.session import Session, SessionManager
 from parakeet_stt_daemon.session_orchestrator import SessionOrchestrator
 
 
@@ -166,10 +166,6 @@ def _build_server() -> DaemonServer:
     orchestrator._last_finalize_ms = None
     orchestrator._last_infer_ms = None
     orchestrator._last_send_ms = None
-    orchestrator.interim_transcript_runtime = InterimTranscriptRuntime.from_settings(
-        settings,
-        sample_rate=orchestrator.audio.sample_rate,
-    )
 
     async def fake_collect_interim_text_updates(
         _session_id: UUID, _ready_chunks: list[object]

--- a/parakeet-stt-daemon/tests/test_session_orchestrator.py
+++ b/parakeet-stt-daemon/tests/test_session_orchestrator.py
@@ -21,7 +21,6 @@ from parakeet_stt_daemon.events import (
 )
 from parakeet_stt_daemon.messages import SessionEndReason
 from parakeet_stt_daemon.session import (
-    InterimTranscriptRuntime,
     SessionManager,
     StreamPathRuntime,
 )
@@ -127,14 +126,6 @@ def _build_orchestrator(
     orchestrator._active_stream = None
     orchestrator._stream_drain_task = None
     orchestrator._stream_drain_running = False
-    orchestrator.stream_path_runtime = StreamPathRuntime.from_settings(
-        settings,
-        orchestrator.streaming_transcriber,
-    )
-    orchestrator.interim_transcript_runtime = InterimTranscriptRuntime.from_settings(
-        settings,
-        sample_rate=orchestrator.audio.sample_rate,
-    )
     orchestrator._session_guard_task = None
     orchestrator._session_guard_running = False
     orchestrator._session_sample_limit = int(max_session_seconds * FakeAudio.sample_rate)
@@ -159,6 +150,10 @@ def _build_orchestrator(
     orchestrator._collect_interim_text_updates = fake_collect_interim_text_updates
     orchestrator._finalise_transcription = fake_finalise
     return cast(SessionOrchestrator, orchestrator)
+
+
+def _stream_runtime(orchestrator: SessionOrchestrator) -> StreamPathRuntime:
+    return orchestrator._stream_path_runtime_for_runtime()
 
 
 T = TypeVar("T")
@@ -223,7 +218,7 @@ def test_start_keeps_stream_drain_loop_when_helper_inactive() -> None:
 
         assert orchestrator._active_stream is None
         assert (
-            orchestrator.stream_path_runtime.facts(active_session=True).fallback_reason
+            _stream_runtime(orchestrator).facts(active_session=True).fallback_reason
             == "init_failed:ImportError"
         )
         assert audio.take_audio_levels_calls > 0

--- a/parakeet-stt-daemon/tests/test_streaming_truth.py
+++ b/parakeet-stt-daemon/tests/test_streaming_truth.py
@@ -109,14 +109,6 @@ def _build_server(
     orchestrator._active_stream = None
     orchestrator._stream_drain_task = None
     orchestrator._stream_drain_running = False
-    orchestrator.stream_path_runtime = StreamPathRuntime.from_settings(
-        orchestrator.settings,
-        streaming_transcriber,
-    )
-    orchestrator.interim_transcript_runtime = InterimTranscriptRuntime.from_settings(
-        orchestrator.settings,
-        sample_rate=orchestrator.audio.sample_rate,
-    )
     orchestrator._requested_device = "cpu"
     orchestrator._effective_device = "cpu"
     orchestrator._last_audio_ms = None
@@ -132,6 +124,14 @@ def _build_server(
         warmup_sample_rate=FakeAudio.sample_rate,
     )
     return cast(SessionOrchestrator, orchestrator)
+
+
+def _stream_runtime(orchestrator: SessionOrchestrator) -> StreamPathRuntime:
+    return orchestrator._stream_path_runtime_for_runtime()
+
+
+def _interim_runtime(orchestrator: SessionOrchestrator) -> InterimTranscriptRuntime:
+    return orchestrator._interim_transcript_runtime_for_runtime()
 
 
 def _status(orchestrator: SessionOrchestrator) -> StatusMessage:
@@ -503,9 +503,10 @@ def test_stream_fallback_reason_none_when_active() -> None:
 def test_status_reports_stream_path_execution_from_last_session() -> None:
     transcriber = FakeStreamingTranscriber(helper_active=True)
     server = _build_server(streaming_transcriber=transcriber)
-    server.stream_path_runtime.record_chunk_processed()
-    server.stream_path_runtime.record_chunk_processed()
-    server.stream_path_runtime.record_session_result(active_stream=None)
+    stream_runtime = _stream_runtime(server)
+    stream_runtime.record_chunk_processed()
+    stream_runtime.record_chunk_processed()
+    stream_runtime.record_session_result(active_stream=None)
 
     status = _status(server)
     log_record = _truth(server).to_log_record()
@@ -522,7 +523,7 @@ def test_status_reports_stream_path_execution_from_last_session() -> None:
 def test_status_reports_fallback_when_helper_exists_but_no_stream_work_ran() -> None:
     transcriber = FakeStreamingTranscriber(helper_active=True)
     server = _build_server(streaming_transcriber=transcriber)
-    server.stream_path_runtime.record_session_result(active_stream=None)
+    _stream_runtime(server).record_session_result(active_stream=None)
 
     status = _status(server)
     log_record = _truth(server).to_log_record()
@@ -538,9 +539,10 @@ def test_status_reports_fallback_when_helper_exists_but_no_stream_work_ran() -> 
 def test_status_reports_fallback_even_after_stream_path_executed() -> None:
     transcriber = FakeStreamingTranscriber(helper_active=True)
     server = _build_server(streaming_transcriber=transcriber)
-    server.stream_path_runtime.record_chunk_processed()
-    server.stream_path_runtime.record_current_fallback("stream_chunk_failed:RuntimeError")
-    server.stream_path_runtime.record_session_result(active_stream=None)
+    stream_runtime = _stream_runtime(server)
+    stream_runtime.record_chunk_processed()
+    stream_runtime.record_current_fallback("stream_chunk_failed:RuntimeError")
+    stream_runtime.record_session_result(active_stream=None)
 
     status = _status(server)
     truth = _truth(server)
@@ -563,12 +565,13 @@ def test_status_and_logs_split_interim_truth_from_stream_path_fallback() -> None
         )
         session_id = uuid4()
         await server.sessions.start_session(session_id, owner_token=1)
-        server.interim_transcript_runtime.reset_session(session_id)
+        interim_runtime = _interim_runtime(server)
+        interim_runtime.reset_session(session_id)
 
         async def transcribe(_samples: np.ndarray) -> str:
             return "visible interim text"
 
-        update = await server.interim_transcript_runtime.accept_live_chunk(
+        update = await interim_runtime.accept_live_chunk(
             session_id,
             np.full((400,), 0.2, dtype=np.float32),
             transcribe,
@@ -600,9 +603,9 @@ def test_status_and_logs_split_interim_truth_from_stream_path_fallback() -> None
         assert log_record["interim_transcript_last_source"] == "live"
         assert log_record["interim_transcript_updates_emitted"] == 1
 
-        server.interim_transcript_runtime.record_last_session(session_id)
+        interim_runtime.record_last_session(session_id)
         await server.sessions.clear(session_id, owner_token=1)
-        server.interim_transcript_runtime.clear_session(session_id)
+        interim_runtime.clear_session(session_id)
 
         idle_status = _status(server)
         idle_log_record = _truth(server).to_log_record()
@@ -620,12 +623,13 @@ def test_status_reports_interim_source_fallback_reason() -> None:
         server = _build_server(streaming_enabled=False, overlay_events_enabled=True)
         session_id = uuid4()
         await server.sessions.start_session(session_id, owner_token=1)
-        server.interim_transcript_runtime.reset_session(session_id)
+        interim_runtime = _interim_runtime(server)
+        interim_runtime.reset_session(session_id)
 
         async def transcribe(_samples: np.ndarray) -> str:
             raise RuntimeError("interim source failed")
 
-        update = await server.interim_transcript_runtime.accept_live_chunk(
+        update = await interim_runtime.accept_live_chunk(
             session_id,
             np.full((400,), 0.2, dtype=np.float32),
             transcribe,
@@ -656,8 +660,9 @@ def test_status_reports_interim_source_fallback_reason() -> None:
 def test_active_session_does_not_inherit_previous_stream_fallback() -> None:
     transcriber = FakeStreamingTranscriber(helper_active=True)
     server = _build_server(streaming_transcriber=transcriber)
-    server.stream_path_runtime.record_session_result(active_stream=None)
-    server.stream_path_runtime.reset_current()
+    stream_runtime = _stream_runtime(server)
+    stream_runtime.record_session_result(active_stream=None)
+    stream_runtime.reset_current()
     cast(Any, server.sessions)._active = Session(session_id=uuid4(), owner_token=1)
 
     status = _status(server)


### PR DESCRIPTION
## Summary

- remove direct Stream path and interim transcript runtime field assignment from the affected SessionOrchestrator test builders
- route stream/interim runtime setup and assertions through focused helpers that use the Session module interfaces
- keep helper fallback, chunk count, live interim, stop-replay interim, and cleanup coverage intact

Closes #124

## Verification

- `uv run --project parakeet-stt-daemon pytest -q parakeet-stt-daemon/tests/test_streaming_truth.py parakeet-stt-daemon/tests/test_session_orchestrator.py parakeet-stt-daemon/tests/test_session_cleanup.py parakeet-stt-daemon/tests/test_overlay_event_stream.py` -> 80 passed
- deletion search: `rg -n "\.stream_path_runtime\s*=|\.interim_transcript_runtime\s*=|\b(server|orchestrator)\.(stream_path_runtime|interim_transcript_runtime)\b" <affected tests>` -> no matches
- `uv run --project parakeet-stt-daemon pytest -q` -> 206 passed
- `uv run --project parakeet-stt-daemon ruff format --check --config parakeet-stt-daemon/pyproject.toml <changed files>` -> passed
- `uv run --project parakeet-stt-daemon ruff check --config parakeet-stt-daemon/pyproject.toml <changed files>` -> passed
- `ty check --project parakeet-stt-daemon --error-on-warning` -> passed
- `uv build --project parakeet-stt-daemon` -> passed
- `uv run --project parakeet-stt-daemon parakeet-stt-daemon --check` -> passed
- `git diff --check` -> passed
- `prek run --files <changed files>` -> passed
- `prek run --all-files` -> passed
- `prek run --stage pre-push --all-files` -> passed
- push pre-push hook -> passed
- CodeRabbit local watcher `.git/coderabbit-review/20260521T212527Z/status.json` -> clean, 0 findings
- final CodeRabbit classified PR gate `.git/coderabbit-review/20260521T213756Z/gate-summary.json` with `.git/coderabbit-review/20260521T213756Z/decision-ledger.json --require-classified` -> clean
- PR sweep: CodeRabbit check passed; no reviews; no review threads; top-level CodeRabbit comment reported no actionable comments

Known preexisting issue: `cd parakeet-stt-daemon && uv run deptry .` still reports unrelated DEP002 for `onnxruntime`.