### PR TITLE
Introduce capture session result

### DIFF
--- a/parakeet-stt-daemon/src/parakeet_stt_daemon/audio.py
+++ b/parakeet-stt-daemon/src/parakeet_stt_daemon/audio.py
@@ -4,11 +4,35 @@ from __future__ import annotations
 
 import threading
 from collections import deque
+from dataclasses import dataclass
 from typing import Any
 
 import numpy as np
 import sounddevice as sd
 from loguru import logger
+
+
+@dataclass(frozen=True, slots=True)
+class CaptureSessionResult:
+    """Stop-time audio facts captured for one Session."""
+
+    audio_samples: np.ndarray
+    ready_chunks: list[np.ndarray]
+    tail_buffer: np.ndarray
+    pre_roll_samples: int
+    post_start_samples: int
+
+    @property
+    def captured_samples(self) -> int:
+        return int(self.audio_samples.size)
+
+    @property
+    def ready_chunk_count(self) -> int:
+        return len(self.ready_chunks)
+
+    @property
+    def tail_samples(self) -> int:
+        return int(self.tail_buffer.size)
 
 
 class AudioInput:
@@ -39,6 +63,7 @@ class AudioInput:
         self._max_session_samples = (
             max(1, int(max_session_samples)) if max_session_samples is not None else None
         )
+        self._session_pre_roll_samples = 0
         self._session_samples = 0
         self._session_limit_exceeded = False
         self._stream_chunk_size: int | None = None
@@ -79,6 +104,7 @@ class AudioInput:
         with self._lock:
             pre_roll_chunks = self._bounded_pre_roll_chunks()
             self._session_chunks = pre_roll_chunks
+            self._session_pre_roll_samples = sum(int(chunk.size) for chunk in pre_roll_chunks)
             # Pre-roll is clipped up front so low session caps still start cleanly.
             # The live session budget applies to post-start capture.
             self._session_samples = 0
@@ -114,23 +140,28 @@ class AudioInput:
             self._session_active = False
             self._reset_session_runtime_state()
 
-    def stop_session_with_streaming(self) -> tuple[np.ndarray, list[np.ndarray], np.ndarray]:
-        """Stop accumulation and return captured samples plus streaming slices.
-
-        Returns: (full_audio, ready_chunks, leftover_buffer)
-        """
+    def stop_session_with_streaming(self) -> CaptureSessionResult:
+        """Stop accumulation and return captured samples plus streaming slices."""
         with self._lock:
             self._session_active = False
             chunks = self._session_chunks
             ready = self._stream_ready
             tail = self._stream_buffer.copy()
+            pre_roll_samples = self._session_pre_roll_samples
+            post_start_samples = self._session_samples
             self._reset_session_runtime_state()
         audio = (
             np.concatenate(chunks).astype(self.dtype, copy=False)
             if chunks
             else np.zeros((0,), dtype=self.dtype)
         )
-        return audio, ready, tail
+        return CaptureSessionResult(
+            audio_samples=audio,
+            ready_chunks=ready,
+            tail_buffer=tail,
+            pre_roll_samples=pre_roll_samples,
+            post_start_samples=post_start_samples,
+        )
 
     def session_limit_exceeded(self) -> bool:
         with self._lock:
@@ -260,6 +291,7 @@ class AudioInput:
 
     def _reset_session_runtime_state(self) -> None:
         self._session_chunks = []
+        self._session_pre_roll_samples = 0
         self._session_samples = 0
         self._session_limit_exceeded = False
         self._stream_ready = []
@@ -267,4 +299,4 @@ class AudioInput:
         self._stream_buffer = np.zeros((0,), dtype=np.float32)
 
 
-__all__ = ["AudioInput"]
+__all__ = ["AudioInput", "CaptureSessionResult"]

--- a/parakeet-stt-daemon/src/parakeet_stt_daemon/session_orchestrator.py
+++ b/parakeet-stt-daemon/src/parakeet_stt_daemon/session_orchestrator.py
@@ -280,13 +280,14 @@ class SessionOrchestrator:
                 state=InterimStateValue.PROCESSING,
             )
             audio_stop_started = time.perf_counter()
-            audio_samples, ready_chunks, _tail = self.audio.stop_session_with_streaming()
+            capture_result = self.audio.stop_session_with_streaming()
             await self._stop_stream_drain_loop()
             self._record_stream_runtime_result()
             # Final correctness must come from the capture layer's canonical buffer,
             # not whatever the Stream path managed to mirror into its active stream.
             self._active_stream = None
             audio_stop_ms = int((time.perf_counter() - audio_stop_started) * 1000)
+            audio_samples = capture_result.audio_samples
             audio_duration_raw = len(audio_samples) / self.audio.sample_rate
             audio_ms = int(audio_duration_raw * 1000)
 
@@ -311,7 +312,7 @@ class SessionOrchestrator:
             try:
                 interim_updates = await self._collect_interim_text_updates(
                     session.session_id,
-                    ready_chunks,
+                    capture_result.ready_chunks,
                 )
                 if interim_updates:
                     await self._emit_interim_state(

--- a/parakeet-stt-daemon/tests/test_overlay_event_stream.py
+++ b/parakeet-stt-daemon/tests/test_overlay_event_stream.py
@@ -14,6 +14,7 @@ import numpy as np
 from loguru import logger
 
 from parakeet_stt_daemon import session_orchestrator as orchestrator_module
+from parakeet_stt_daemon.audio import CaptureSessionResult
 from parakeet_stt_daemon.config import ServerSettings
 from parakeet_stt_daemon.events import WebSocketEventSinkState
 from parakeet_stt_daemon.messages import (
@@ -40,10 +41,16 @@ class FakeAudio:
     def start_session(self) -> None:
         return None
 
-    def stop_session_with_streaming(self) -> tuple[np.ndarray, list[np.ndarray], np.ndarray]:
+    def stop_session_with_streaming(self) -> CaptureSessionResult:
         self.stop_calls += 1
         samples = np.ones((1600,), dtype=np.float32)
-        return samples, list(self.ready_chunks), np.zeros((0,), dtype=np.float32)
+        return CaptureSessionResult(
+            audio_samples=samples,
+            ready_chunks=list(self.ready_chunks),
+            tail_buffer=np.zeros((0,), dtype=np.float32),
+            pre_roll_samples=0,
+            post_start_samples=int(samples.size),
+        )
 
     def abort_session(self) -> None:
         self.abort_calls += 1

--- a/parakeet-stt-daemon/tests/test_session_cleanup.py
+++ b/parakeet-stt-daemon/tests/test_session_cleanup.py
@@ -10,7 +10,7 @@ from uuid import UUID, uuid4
 import numpy as np
 from fastapi import WebSocketDisconnect
 
-from parakeet_stt_daemon.audio import AudioInput
+from parakeet_stt_daemon.audio import AudioInput, CaptureSessionResult
 from parakeet_stt_daemon.config import ServerSettings
 from parakeet_stt_daemon.events import EventSink, EventSinkClosed, WebSocketEventSinkState
 from parakeet_stt_daemon.messages import (
@@ -44,10 +44,16 @@ class FakeAudio:
     def abort_session(self) -> None:
         self.abort_calls += 1
 
-    def stop_session_with_streaming(self) -> tuple[np.ndarray, list[np.ndarray], np.ndarray]:
+    def stop_session_with_streaming(self) -> CaptureSessionResult:
         self.stop_calls += 1
         samples = np.ones((1_600,), dtype=np.float32)
-        return samples, [], np.zeros((0,), dtype=np.float32)
+        return CaptureSessionResult(
+            audio_samples=samples,
+            ready_chunks=[],
+            tail_buffer=np.zeros((0,), dtype=np.float32),
+            pre_roll_samples=0,
+            post_start_samples=int(samples.size),
+        )
 
     def take_stream_chunks(self) -> list[object]:
         return []
@@ -223,6 +229,42 @@ def test_audio_input_clips_pre_roll_to_session_sample_limit() -> None:
 
     assert captured.size == 3
     assert np.allclose(captured, np.array([0.2, 0.3, 0.4], dtype=np.float32))
+
+
+def test_audio_input_streaming_stop_returns_capture_session_result_facts() -> None:
+    audio = AudioInput(sample_rate=10, channels=1, pre_roll_seconds=1.0)
+    audio.configure_stream_chunk_size(4)
+    audio._callback(
+        np.array([[0.1], [0.2], [0.3]], dtype=np.float32),
+        frames=3,
+        time=None,
+        status=cast(Any, 0),
+    )
+    audio.start_session()
+    audio._callback(
+        np.array([[0.4], [0.5]], dtype=np.float32),
+        frames=2,
+        time=None,
+        status=cast(Any, 0),
+    )
+
+    result = audio.stop_session_with_streaming()
+
+    assert isinstance(result, CaptureSessionResult)
+    assert np.allclose(
+        result.audio_samples,
+        np.array([0.1, 0.2, 0.3, 0.4, 0.5], dtype=np.float32),
+    )
+    assert result.captured_samples == 5
+    assert result.pre_roll_samples == 3
+    assert result.post_start_samples == 2
+    assert result.ready_chunk_count == 1
+    assert np.allclose(
+        result.ready_chunks[0],
+        np.array([0.1, 0.2, 0.3, 0.4], dtype=np.float32),
+    )
+    assert np.allclose(result.tail_buffer, np.array([0.5], dtype=np.float32))
+    assert result.tail_samples == 1
 
 
 def test_disconnect_cleans_active_session_state() -> None:

--- a/parakeet-stt-daemon/tests/test_session_orchestrator.py
+++ b/parakeet-stt-daemon/tests/test_session_orchestrator.py
@@ -11,6 +11,7 @@ import numpy as np
 from pytest import MonkeyPatch
 
 from parakeet_stt_daemon import session_orchestrator as orchestrator_module
+from parakeet_stt_daemon.audio import CaptureSessionResult
 from parakeet_stt_daemon.config import ServerSettings
 from parakeet_stt_daemon.events import (
     FinalResultEvent,
@@ -56,9 +57,15 @@ class FakeAudio:
     def abort_session(self) -> None:
         self.abort_calls += 1
 
-    def stop_session_with_streaming(self) -> tuple[np.ndarray, list[np.ndarray], np.ndarray]:
+    def stop_session_with_streaming(self) -> CaptureSessionResult:
         self.stop_calls += 1
-        return self.samples, [], np.zeros((0,), dtype=np.float32)
+        return CaptureSessionResult(
+            audio_samples=self.samples,
+            ready_chunks=[],
+            tail_buffer=np.zeros((0,), dtype=np.float32),
+            pre_roll_samples=0,
+            post_start_samples=int(self.samples.size),
+        )
 
     def take_audio_levels(self) -> list[float]:
         self.take_audio_levels_calls += 1
@@ -106,6 +113,7 @@ def _build_orchestrator(
     *,
     streaming_enabled: bool = False,
     max_session_seconds: float = 90.0,
+    samples: np.ndarray | None = None,
     stream_chunks: list[np.ndarray] | None = None,
 ) -> SessionOrchestrator:
     orchestrator = cast(Any, SessionOrchestrator.__new__(SessionOrchestrator))
@@ -117,7 +125,7 @@ def _build_orchestrator(
     )
     orchestrator.settings = settings
     orchestrator.sessions = SessionManager()
-    orchestrator.audio = FakeAudio(stream_chunks=stream_chunks)
+    orchestrator.audio = FakeAudio(samples=samples, stream_chunks=stream_chunks)
     orchestrator.model = object()
     orchestrator.transcriber = object()
     orchestrator._session_lock = asyncio.Lock()
@@ -341,6 +349,33 @@ def test_stop_without_start_emits_session_not_found() -> None:
                 message="No matching active session",
             )
         ]
+
+    asyncio.run(scenario())
+
+
+def test_stop_empty_capture_result_emits_audio_device_error() -> None:
+    async def scenario() -> None:
+        orchestrator = _build_orchestrator(samples=np.zeros((0,), dtype=np.float32))
+        sink = RecordingEventSink()
+        session_id = uuid4()
+        await _start(orchestrator, sink, session_id)
+
+        await orchestrator.stop(
+            StopSessionIntent(
+                session_id=session_id,
+                owner_token=1,
+                event_sink=sink,
+                post_roll_secs=0.0,
+            )
+        )
+
+        errors = _events_of_type(sink, SessionErrorEvent)
+        assert errors
+        assert errors[-1].code == "AUDIO_DEVICE"
+        ended = _events_of_type(sink, SessionEndedEvent)
+        assert ended
+        assert ended[-1].reason == SessionEndReason.ERROR
+        assert _events_of_type(sink, FinalResultEvent) == []
 
     asyncio.run(scenario())
 


### PR DESCRIPTION
## Summary

- introduce `CaptureSessionResult` as the named stop-time audio result from `AudioInput`
- route the daemon stop path through named capture fields for audio samples and ready chunks instead of tuple positions
- preserve Stream path stop, stop-replay interim text, Seal path finalization, and cleanup behavior with expanded tests for empty capture and pre-roll/tail facts

Closes #125

## Verification

- `uv run --project parakeet-stt-daemon pytest -q parakeet-stt-daemon/tests/test_session_orchestrator.py parakeet-stt-daemon/tests/test_session_cleanup.py parakeet-stt-daemon/tests/test_overlay_event_stream.py` -> 56 passed
- deletion search: `rg -n "\w+\s*,\s*\w+\s*,\s*\w+\s*=\s*.*stop_session_with_streaming\(|tuple\[np\.ndarray\s*,\s*list\[np\.ndarray\]\s*,\s*np\.ndarray\]|ready_chunks\s*,\s*_tail|audio_samples\s*,\s*ready_chunks" <daemon/session tests>` -> no matches
- `uv run --project parakeet-stt-daemon pytest -q` -> 208 passed
- `uv run --project parakeet-stt-daemon ruff format --check --config parakeet-stt-daemon/pyproject.toml <changed files>` -> passed
- `uv run --project parakeet-stt-daemon ruff check --config parakeet-stt-daemon/pyproject.toml <changed files>` -> passed
- `ty check --project parakeet-stt-daemon --error-on-warning` -> passed
- `uv build --project parakeet-stt-daemon` -> passed
- `uv run --project parakeet-stt-daemon parakeet-stt-daemon --check` -> passed
- `git diff --check` -> passed
- `prek run --files <changed files>` -> passed
- `prek run --all-files` -> passed
- `prek run --stage pre-push --all-files` -> passed
- push pre-push hook -> passed
- CodeRabbit local watcher `.git/coderabbit-review/20260521T214822Z/status.json` -> clean, 0 findings
- CodeRabbit PR gate `.git/coderabbit-review/20260522T101828Z/gate-summary.json` -> clean
- final classified CodeRabbit PR gate `.git/coderabbit-review/20260522T102244Z/gate-summary.json` with `.git/coderabbit-review/20260522T102244Z/decision-ledger.json` -> clean
- PR check/comment/thread sweep after final gate: CodeRabbit check passed; no review threads; no formal reviews

Known preexisting issue: `cd parakeet-stt-daemon && uv run deptry .` still reports unrelated DEP002 for `onnxruntime`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling for edge cases in audio capture sessions, including better detection and reporting of empty capture scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SystemicVoid/parakeet-stt/pull/143?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
