### PR TITLE
Extract seal path finalization runtime

### DIFF
--- a/parakeet-stt-daemon/src/parakeet_stt_daemon/runtime_truth_snapshot.py
+++ b/parakeet-stt-daemon/src/parakeet_stt_daemon/runtime_truth_snapshot.py
@@ -8,7 +8,7 @@ from typing import Any, Literal
 
 from .messages import StatusMessage
 from .overlay_interim import InterimTranscriptRuntimeFacts, InterimTranscriptSource
-from .session import SessionState, StreamPathRuntimeFacts
+from .session import SealPathRuntimeFacts, SessionState, StreamPathRuntimeFacts
 from .tail_trim import TailTrimMode
 
 StreamHelperScope = Literal["live_session_only"]
@@ -208,7 +208,7 @@ def snapshot(
 ) -> RuntimeTruth:
     settings = orchestrator.settings
     stream_path = stream_path or _stream_path_facts(orchestrator)
-    seal_path = seal_path or SealPathFacts()
+    seal_path = seal_path or _seal_path_facts(orchestrator)
     tail_trim = _tail_trim_facts(orchestrator, last_trim_outcome)
     device_info = device_info or _device_info(orchestrator)
     overlay_enabled = (
@@ -349,6 +349,21 @@ def _stream_path_facts(orchestrator: Any) -> StreamPathFacts:
         path_executed=False,
         chunks_processed=0,
     )
+
+
+def _seal_path_facts(orchestrator: Any) -> SealPathFacts:
+    getter = getattr(orchestrator, "seal_path_runtime_facts_for_runtime", None)
+    if callable(getter):
+        try:
+            runtime_facts = getter()
+        except Exception:  # noqa: BLE001
+            runtime_facts = None
+        if isinstance(runtime_facts, SealPathRuntimeFacts):
+            return SealPathFacts(
+                finalization_mode=runtime_facts.finalization_mode,
+                final_audio_source=runtime_facts.final_audio_source,
+            )
+    return SealPathFacts()
 
 
 def _tail_trim_facts(orchestrator: Any, last_trim_outcome: object | None) -> TailTrimFacts:

--- a/parakeet-stt-daemon/src/parakeet_stt_daemon/session.py
+++ b/parakeet-stt-daemon/src/parakeet_stt_daemon/session.py
@@ -4,17 +4,23 @@ from __future__ import annotations
 
 import asyncio
 import math
+import time
+from collections.abc import Awaitable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import StrEnum
-from typing import TYPE_CHECKING, Literal
+from functools import partial
+from typing import TYPE_CHECKING, Literal, Protocol
 from uuid import UUID
+
+from loguru import logger
 
 from .overlay_interim import (
     InterimTranscriber,
     InterimTranscriptRuntimeFacts,
     OverlayInterimTranscriptSession,
 )
+from .tail_trim import SealPathTailTrimmer, TailTrimOutcome
 
 if TYPE_CHECKING:
     import numpy as np
@@ -56,6 +62,17 @@ class SessionNotFoundError(RuntimeError):
 
 
 StreamHelperScope = Literal["live_session_only"]
+FinalizationMode = Literal["offline_seal"]
+FinalAudioSource = Literal["canonical_session_audio"]
+SealPathErrorCode = Literal["AUDIO_DEVICE", "MODEL"]
+
+
+class SealPathTranscriber(Protocol):
+    def __call__(self, samples: np.ndarray) -> Awaitable[str]: ...
+
+
+class DeviceCacheReleaser(Protocol):
+    def __call__(self, device: str, /) -> None: ...
 
 
 @dataclass(frozen=True, slots=True)
@@ -68,6 +85,175 @@ class StreamPathRuntimeFacts:
     chunk_secs: float | None
     path_executed: bool
     chunks_processed: int
+
+
+@dataclass(frozen=True, slots=True)
+class SealPathRuntimeFacts:
+    finalization_mode: FinalizationMode = "offline_seal"
+    final_audio_source: FinalAudioSource = "canonical_session_audio"
+
+
+@dataclass(frozen=True, slots=True)
+class SealPathRuntimeMetrics:
+    audio_stop_ms: int | None = None
+    finalize_ms: int | None = None
+    infer_ms: int | None = None
+    send_ms: int | None = None
+    last_audio_ms: int | None = None
+    last_infer_ms: int | None = None
+    last_send_ms: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class SealPathFinalizationResult:
+    text: str
+    audio_ms: int
+    audio_duration_raw: float
+    finalize_ms: int
+    infer_ms: int
+
+
+@dataclass(frozen=True, slots=True)
+class SealPathFinalizationFailure:
+    code: SealPathErrorCode
+    message: str
+    exception: Exception | None = None
+
+
+SealPathFinalizationOutcome = SealPathFinalizationResult | SealPathFinalizationFailure
+
+
+class SealPathRuntime:
+    """Own Seal path finalization and last final runtime facts."""
+
+    def __init__(
+        self,
+        *,
+        sample_rate: int,
+        tail_trimmer: SealPathTailTrimmer,
+        release_device_cache: DeviceCacheReleaser,
+    ) -> None:
+        self.sample_rate = int(sample_rate)
+        self.tail_trimmer = tail_trimmer
+        self.release_device_cache = release_device_cache
+        self._metrics = SealPathRuntimeMetrics()
+        self._last_failure: SealPathFinalizationFailure | None = None
+
+    def sync_from_runtime(
+        self,
+        *,
+        sample_rate: int,
+        tail_trimmer: SealPathTailTrimmer,
+        release_device_cache: DeviceCacheReleaser,
+    ) -> None:
+        self.sample_rate = int(sample_rate)
+        self.tail_trimmer = tail_trimmer
+        self.release_device_cache = release_device_cache
+
+    @property
+    def last_tail_trim_outcome(self) -> TailTrimOutcome:
+        return self.tail_trimmer.last_outcome
+
+    @property
+    def last_failure(self) -> SealPathFinalizationFailure | None:
+        return self._last_failure
+
+    def facts(self) -> SealPathRuntimeFacts:
+        return SealPathRuntimeFacts()
+
+    def metrics(self) -> SealPathRuntimeMetrics:
+        return self._metrics
+
+    def prepare_tail_trimmer(self) -> None:
+        self.tail_trimmer.prepare()
+
+    async def finalize(
+        self,
+        audio_samples: np.ndarray,
+        transcribe: SealPathTranscriber,
+        *,
+        effective_device: str,
+    ) -> SealPathFinalizationOutcome:
+        audio_duration_raw = len(audio_samples) / self.sample_rate
+        audio_ms = int(audio_duration_raw * 1000)
+        if audio_samples.size == 0:
+            failure = SealPathFinalizationFailure(
+                code="AUDIO_DEVICE",
+                message="No audio captured for session",
+            )
+            self._last_failure = failure
+            return failure
+
+        finalize_started = time.perf_counter()
+        cache_released = False
+        try:
+            loop = asyncio.get_running_loop()
+            trim_outcome = await loop.run_in_executor(
+                None,
+                partial(self.tail_trimmer.trim, audio_samples, self.sample_rate),
+            )
+            trimmed = trim_outcome.samples
+            if trimmed.size == 0:
+                logger.info("Skipping offline transcription: silence trimming removed all samples")
+                self._release_device_cache(effective_device)
+                cache_released = True
+                self._last_failure = None
+                return SealPathFinalizationResult(
+                    text="",
+                    audio_ms=audio_ms,
+                    audio_duration_raw=audio_duration_raw,
+                    finalize_ms=int((time.perf_counter() - finalize_started) * 1000),
+                    infer_ms=0,
+                )
+
+            infer_started = time.perf_counter()
+            try:
+                text = await transcribe(trimmed)
+                infer_ms = int((time.perf_counter() - infer_started) * 1000)
+            finally:
+                self._release_device_cache(effective_device)
+                cache_released = True
+            self._last_failure = None
+            return SealPathFinalizationResult(
+                text=text,
+                audio_ms=audio_ms,
+                audio_duration_raw=audio_duration_raw,
+                finalize_ms=int((time.perf_counter() - finalize_started) * 1000),
+                infer_ms=infer_ms,
+            )
+        except Exception as exc:  # noqa: BLE001 - returned to orchestrator as model failure
+            if not cache_released:
+                self._release_device_cache(effective_device)
+            failure = SealPathFinalizationFailure(
+                code="MODEL",
+                message="Transcription failed",
+                exception=exc,
+            )
+            self._last_failure = failure
+            return failure
+
+    def _release_device_cache(self, effective_device: str) -> None:
+        try:
+            self.release_device_cache(effective_device)
+        except Exception as exc:  # noqa: BLE001 - cache cleanup is best effort
+            logger.warning("Failed to release device cache for {}: {}", effective_device, exc)
+
+    def record_success(
+        self,
+        result: SealPathFinalizationResult,
+        *,
+        audio_stop_ms: int,
+        send_ms: int,
+    ) -> None:
+        self._metrics = SealPathRuntimeMetrics(
+            audio_stop_ms=audio_stop_ms,
+            finalize_ms=result.finalize_ms,
+            infer_ms=result.infer_ms,
+            send_ms=send_ms,
+            last_audio_ms=result.audio_ms,
+            last_infer_ms=result.infer_ms,
+            last_send_ms=send_ms,
+        )
 
 
 class StreamPathRuntime:
@@ -343,6 +529,14 @@ class SessionManager:
 __all__ = [
     "InterimTranscriptRuntime",
     "InterimTranscriptRuntimeFacts",
+    "SealPathErrorCode",
+    "SealPathFinalizationFailure",
+    "SealPathFinalizationOutcome",
+    "SealPathFinalizationResult",
+    "SealPathRuntime",
+    "SealPathRuntimeFacts",
+    "SealPathRuntimeMetrics",
+    "SealPathTranscriber",
     "Session",
     "SessionBusyError",
     "SessionManager",

--- a/parakeet-stt-daemon/src/parakeet_stt_daemon/session_orchestrator.py
+++ b/parakeet-stt-daemon/src/parakeet_stt_daemon/session_orchestrator.py
@@ -57,6 +57,11 @@ from .runtime_truth_snapshot import (
 from .session import (
     InterimTranscriptRuntime,
     InterimTranscriptRuntimeFacts,
+    SealPathFinalizationFailure,
+    SealPathFinalizationResult,
+    SealPathRuntime,
+    SealPathRuntimeFacts,
+    SealPathRuntimeMetrics,
     Session,
     SessionBusyError,
     SessionManager,
@@ -146,16 +151,16 @@ class SessionOrchestrator:
         )
         self._session_guard_task: asyncio.Task | None = None
         self._session_guard_running = False
-        self._last_audio_ms: int | None = None
-        self._last_audio_stop_ms: int | None = None
-        self._last_finalize_ms: int | None = None
-        self._last_infer_ms: int | None = None
-        self._last_send_ms: int | None = None
         self._vad_enabled = bool(settings.vad_enabled)
         self.tail_trimmer = SealPathTailTrimmer(
             vad_enabled=self._vad_enabled,
             silence_floor_db=float(settings.silence_floor_db),
             warmup_sample_rate=sample_rate,
+        )
+        self.seal_path_runtime = SealPathRuntime(
+            sample_rate=sample_rate,
+            tail_trimmer=self.tail_trimmer,
+            release_device_cache=_release_cuda_cache,
         )
         if settings.streaming_enabled:
             chunk_samples = int(settings.chunk_secs * self.audio.sample_rate)
@@ -288,27 +293,7 @@ class SessionOrchestrator:
             self._active_stream = None
             audio_stop_ms = int((time.perf_counter() - audio_stop_started) * 1000)
             audio_samples = capture_result.audio_samples
-            audio_duration_raw = len(audio_samples) / self.audio.sample_rate
-            audio_ms = int(audio_duration_raw * 1000)
-
-            if audio_samples.size == 0:
-                await self._send_error(
-                    event_sink,
-                    session.session_id,
-                    "AUDIO_DEVICE",
-                    "No audio captured for session",
-                )
-                await self._emit_session_ended(
-                    event_sink, session.session_id, reason=SessionEndReason.ERROR
-                )
-                await self._record_last_and_clear_session_runtime(
-                    session.session_id,
-                    owner_token=owner_token,
-                )
-                return
-
-            finalize_ms: int | None = None
-            infer_ms: int | None = None
+            finalization: SealPathFinalizationResult | SealPathFinalizationFailure
             try:
                 interim_updates = await self._collect_interim_text_updates(
                     session.session_id,
@@ -331,13 +316,36 @@ class SessionOrchestrator:
                     session.session_id,
                     state=InterimStateValue.FINALIZING,
                 )
-                finalize_started = time.perf_counter()
-                text, infer_ms = await self._finalise_transcription(audio_samples)
-                finalize_ms = int((time.perf_counter() - finalize_started) * 1000)
+                finalization = await self._seal_path_runtime_for_runtime().finalize(
+                    audio_samples,
+                    self._transcribe_samples_serialized,
+                    effective_device=str(getattr(self, "_effective_device", self.settings.device)),
+                )
             except Exception as exc:  # noqa: BLE001
                 logger.exception("Failed to transcribe session {}: {}", session.session_id, exc)
                 await self._send_error(
                     event_sink, session.session_id, "MODEL", "Transcription failed"
+                )
+                await self._emit_session_ended(
+                    event_sink, session.session_id, reason=SessionEndReason.ERROR
+                )
+                await self._record_last_and_clear_session_runtime(
+                    session.session_id,
+                    owner_token=owner_token,
+                )
+                return
+            if isinstance(finalization, SealPathFinalizationFailure):
+                if finalization.exception is not None:
+                    logger.opt(exception=finalization.exception).error(
+                        "Failed to transcribe session {}: {}",
+                        session.session_id,
+                        finalization.exception,
+                    )
+                await self._send_error(
+                    event_sink,
+                    session.session_id,
+                    finalization.code,
+                    finalization.message,
                 )
                 await self._emit_session_ended(
                     event_sink, session.session_id, reason=SessionEndReason.ERROR
@@ -356,9 +364,9 @@ class SessionOrchestrator:
             await event_sink.emit(
                 FinalResultEvent(
                     session_id=session.session_id,
-                    text=text,
+                    text=finalization.text,
                     latency_ms=latency_ms,
-                    audio_ms=audio_ms,
+                    audio_ms=finalization.audio_ms,
                     lang=self.settings.language,
                     confidence=None,
                     tail_trim_mode=runtime_truth.tail_trim_mode,
@@ -374,26 +382,30 @@ class SessionOrchestrator:
                 session.session_id,
                 owner_token=owner_token,
             )
-            self._last_audio_ms = audio_ms
-            self._last_audio_stop_ms = audio_stop_ms
-            self._last_finalize_ms = finalize_ms
-            self._last_infer_ms = infer_ms
-            self._last_send_ms = send_ms
+            self._seal_path_runtime_for_runtime().record_success(
+                finalization,
+                audio_stop_ms=audio_stop_ms,
+                send_ms=send_ms,
+            )
 
             # Diagnostic logging for truncation investigation
-            text_len = len(text)
-            chars_per_sec = text_len / audio_duration_raw if audio_duration_raw > 0 else 0
+            text_len = len(finalization.text)
+            chars_per_sec = (
+                text_len / finalization.audio_duration_raw
+                if finalization.audio_duration_raw > 0
+                else 0
+            )
             logger.info(
                 "Session {} completed: audio_raw={:.2f}s, audio_ms={}, audio_stop_ms={}, "
                 "latency_ms={}, finalize_ms={}, infer_ms={}, send_ms={}, text_len={}, "
                 "chars_per_sec={:.1f}, runtime_truth={}",
                 session.session_id,
-                audio_duration_raw,
-                audio_ms,
+                finalization.audio_duration_raw,
+                finalization.audio_ms,
                 audio_stop_ms,
                 latency_ms,
-                finalize_ms,
-                infer_ms,
+                finalization.finalize_ms,
+                finalization.infer_ms,
                 send_ms,
                 text_len,
                 chars_per_sec,
@@ -785,9 +797,10 @@ class SessionOrchestrator:
         interim_runtime.clear_session(session_id)
 
     def runtime_truth(self, *, overlay_events_enabled: bool) -> RuntimeTruth:
+        seal_path_runtime = self._seal_path_runtime_for_runtime()
         return runtime_truth_snapshot(
             self,
-            last_trim_outcome=self._tail_trimmer_for_runtime().last_outcome,
+            last_trim_outcome=seal_path_runtime.last_tail_trim_outcome,
             overlay_events_enabled=overlay_events_enabled,
         )
 
@@ -810,21 +823,28 @@ class SessionOrchestrator:
         overlay_events_emitted: int,
         overlay_events_dropped: int,
     ) -> RuntimeTruthMetrics:
+        seal_metrics = self._seal_path_runtime_for_runtime().metrics()
         return RuntimeTruthMetrics(
             gpu_mem_mb=self._gpu_mem_mb(),
             overlay_events_emitted=overlay_events_emitted,
             overlay_events_dropped=overlay_events_dropped,
-            audio_stop_ms=getattr(self, "_last_audio_stop_ms", None),
-            finalize_ms=getattr(self, "_last_finalize_ms", None),
-            infer_ms=getattr(self, "_last_infer_ms", None),
-            send_ms=getattr(self, "_last_send_ms", None),
-            last_audio_ms=getattr(self, "_last_audio_ms", None),
-            last_infer_ms=getattr(self, "_last_infer_ms", None),
-            last_send_ms=getattr(self, "_last_send_ms", None),
+            audio_stop_ms=seal_metrics.audio_stop_ms,
+            finalize_ms=seal_metrics.finalize_ms,
+            infer_ms=seal_metrics.infer_ms,
+            send_ms=seal_metrics.send_ms,
+            last_audio_ms=seal_metrics.last_audio_ms,
+            last_infer_ms=seal_metrics.last_infer_ms,
+            last_send_ms=seal_metrics.last_send_ms,
         )
 
     def prepare_vad(self) -> None:
-        self._tail_trimmer_for_runtime().prepare()
+        self._seal_path_runtime_for_runtime().prepare_tail_trimmer()
+
+    def seal_path_runtime_facts_for_runtime(self) -> SealPathRuntimeFacts:
+        return self._seal_path_runtime_for_runtime().facts()
+
+    def seal_path_runtime_metrics_for_runtime(self) -> SealPathRuntimeMetrics:
+        return self._seal_path_runtime_for_runtime().metrics()
 
     def _tail_trimmer_for_runtime(self) -> SealPathTailTrimmer:
         tail_trimmer = getattr(self, "tail_trimmer", None)
@@ -857,28 +877,6 @@ class SessionOrchestrator:
 
         reserved_bytes = torch.cuda.memory_reserved(device_index or 0)
         return int(reserved_bytes / (1024 * 1024))
-
-    async def _finalise_transcription(self, audio_samples: np.ndarray) -> tuple[str, int]:
-        # The full capture buffer is the only authoritative source for final decode.
-        loop = asyncio.get_running_loop()
-        tail_trimmer = self._tail_trimmer_for_runtime()
-        trim_outcome = await loop.run_in_executor(
-            None,
-            partial(tail_trimmer.trim, audio_samples, self.audio.sample_rate),
-        )
-        trimmed = trim_outcome.samples
-        effective_device = str(getattr(self, "_effective_device", self.settings.device))
-        if trimmed.size == 0:
-            logger.info("Skipping offline transcription: silence trimming removed all samples")
-            _release_cuda_cache(effective_device)
-            return "", 0
-        infer_started = time.perf_counter()
-        try:
-            text = await self._transcribe_samples_serialized(trimmed)
-            infer_ms = int((time.perf_counter() - infer_started) * 1000)
-            return text, infer_ms
-        finally:
-            _release_cuda_cache(effective_device)
 
     def _record_stream_runtime_result(self) -> None:
         self._stream_path_runtime_for_runtime().record_session_result(
@@ -961,6 +959,25 @@ class SessionOrchestrator:
             self.interim_transcript_runtime = runtime
         else:
             runtime.sync_from_runtime(settings=self.settings, sample_rate=sample_rate)
+        return runtime
+
+    def _seal_path_runtime_for_runtime(self) -> SealPathRuntime:
+        runtime = getattr(self, "seal_path_runtime", None)
+        sample_rate = int(getattr(self.audio, "sample_rate", 16_000))
+        tail_trimmer = self._tail_trimmer_for_runtime()
+        if not isinstance(runtime, SealPathRuntime):
+            runtime = SealPathRuntime(
+                sample_rate=sample_rate,
+                tail_trimmer=tail_trimmer,
+                release_device_cache=_release_cuda_cache,
+            )
+            self.seal_path_runtime = runtime
+        else:
+            runtime.sync_from_runtime(
+                sample_rate=sample_rate,
+                tail_trimmer=tail_trimmer,
+                release_device_cache=runtime.release_device_cache,
+            )
         return runtime
 
 

--- a/parakeet-stt-daemon/tests/test_offline_in_memory_transcription.py
+++ b/parakeet-stt-daemon/tests/test_offline_in_memory_transcription.py
@@ -12,10 +12,12 @@ from typing import Any, cast
 import numpy as np
 import pytest
 
-from parakeet_stt_daemon import session_orchestrator as orchestrator_module
-from parakeet_stt_daemon.config import ServerSettings
 from parakeet_stt_daemon.model import ParakeetTranscriber
-from parakeet_stt_daemon.session_orchestrator import SessionOrchestrator
+from parakeet_stt_daemon.session import (
+    SealPathFinalizationFailure,
+    SealPathFinalizationResult,
+    SealPathRuntime,
+)
 from parakeet_stt_daemon.tail_trim import SealPathTailTrimmer, TailTrimOutcome
 
 
@@ -51,19 +53,6 @@ class _RecordingTranscriber:
         return "offline text"
 
 
-class _ExplodingStreamSession:
-    def __init__(self) -> None:
-        self.feed_calls: list[np.ndarray] = []
-        self.finalize_called = False
-
-    def feed(self, chunk: np.ndarray) -> None:
-        self.feed_calls.append(chunk.copy())
-
-    def finalize(self) -> str:
-        self.finalize_called = True
-        raise AssertionError("final transcript should not read from streaming mirror")
-
-
 def _tail_trimmer_with_trim(
     trim: Callable[[np.ndarray, int], TailTrimOutcome],
 ) -> SealPathTailTrimmer:
@@ -74,6 +63,27 @@ def _tail_trimmer_with_trim(
 
 def _identity_tail_trim(samples: np.ndarray, _sample_rate: int) -> TailTrimOutcome:
     return TailTrimOutcome(samples, "rms", False, None)
+
+
+def _runtime(
+    trim: Callable[[np.ndarray, int], TailTrimOutcome] = _identity_tail_trim,
+    *,
+    released_devices: list[str] | None = None,
+) -> SealPathRuntime:
+    return SealPathRuntime(
+        sample_rate=16_000,
+        tail_trimmer=_tail_trimmer_with_trim(trim),
+        release_device_cache=(
+            released_devices.append if released_devices is not None else lambda _device: None
+        ),
+    )
+
+
+def _async_transcriber(transcriber: _RecordingTranscriber):
+    async def transcribe(samples: np.ndarray) -> str:
+        return transcriber.transcribe_samples(samples, sample_rate=16_000)
+
+    return transcribe
 
 
 def test_transcribe_samples_uses_array_path_when_supported() -> None:
@@ -140,41 +150,40 @@ def test_transcribe_samples_empty_audio_returns_empty_string_without_model_call(
     assert model.calls == []
 
 
-def test_server_offline_finalize_uses_in_memory_transcriber() -> None:
+def test_seal_path_finalize_uses_in_memory_transcriber_and_records_timing() -> None:
     async def scenario() -> None:
-        server = cast(Any, SessionOrchestrator.__new__(SessionOrchestrator))
-        server.settings = ServerSettings(device="cpu", streaming_enabled=False)
-        server.audio = SimpleNamespace(sample_rate=16_000)
-        server.transcriber = _RecordingTranscriber()
-        server.streaming_transcriber = None
-        server._active_stream = None
-
+        runtime = _runtime()
+        transcriber = _RecordingTranscriber()
         samples = np.array([0.2, 0.1, 0.05], dtype=np.float32)
-        typed_server = cast(SessionOrchestrator, server)
-        text, infer_ms = await typed_server._finalise_transcription(samples)
+        outcome = await runtime.finalize(
+            samples,
+            _async_transcriber(transcriber),
+            effective_device="cpu",
+        )
 
-        assert text == "offline text"
-        assert infer_ms >= 0
-        recording = server.transcriber
-        assert len(recording.calls) == 1
-        forwarded_samples, forwarded_rate = recording.calls[0]
+        assert isinstance(outcome, SealPathFinalizationResult)
+        assert outcome.text == "offline text"
+        assert outcome.infer_ms >= 0
+        assert outcome.finalize_ms >= outcome.infer_ms
+        runtime.record_success(outcome, audio_stop_ms=9, send_ms=4)
+        metrics = runtime.metrics()
+        assert metrics.audio_stop_ms == 9
+        assert metrics.finalize_ms == outcome.finalize_ms
+        assert metrics.infer_ms == outcome.infer_ms
+        assert metrics.send_ms == 4
+        assert metrics.last_audio_ms == outcome.audio_ms
+        assert metrics.last_infer_ms == outcome.infer_ms
+        assert metrics.last_send_ms == 4
+        assert len(transcriber.calls) == 1
+        forwarded_samples, forwarded_rate = transcriber.calls[0]
         assert forwarded_rate == 16_000
         assert forwarded_samples.size > 0
 
     asyncio.run(scenario())
 
 
-def test_server_offline_finalize_skips_model_call_when_trimmed_audio_empty(monkeypatch) -> None:
+def test_seal_path_finalize_skips_model_call_when_trimmed_audio_empty() -> None:
     async def scenario() -> None:
-        server = cast(Any, SessionOrchestrator.__new__(SessionOrchestrator))
-        server.settings = ServerSettings(device="cuda", streaming_enabled=False)
-        server.audio = SimpleNamespace(sample_rate=16_000)
-        server.transcriber = _RecordingTranscriber()
-        server.streaming_transcriber = None
-        server._active_stream = None
-        server._vad_enabled = False
-        server._effective_device = "cuda"
-
         def trim_empty(_samples: np.ndarray, _sample_rate: int) -> TailTrimOutcome:
             return TailTrimOutcome(
                 np.zeros((0,), dtype=np.float32),
@@ -183,70 +192,55 @@ def test_server_offline_finalize_skips_model_call_when_trimmed_audio_empty(monke
                 None,
             )
 
-        server.tail_trimmer = _tail_trimmer_with_trim(trim_empty)
         released_devices: list[str] = []
-
-        monkeypatch.setattr(
-            orchestrator_module,
-            "_release_cuda_cache",
-            lambda device: released_devices.append(device),
+        runtime = _runtime(trim_empty, released_devices=released_devices)
+        transcriber = _RecordingTranscriber()
+        samples = np.array([0.2, 0.1, 0.05], dtype=np.float32)
+        outcome = await runtime.finalize(
+            samples,
+            _async_transcriber(transcriber),
+            effective_device="cuda",
         )
 
-        samples = np.array([0.2, 0.1, 0.05], dtype=np.float32)
-        typed_server = cast(SessionOrchestrator, server)
-        text, infer_ms = await typed_server._finalise_transcription(samples)
-
-        assert text == ""
-        assert infer_ms == 0
-        assert server.transcriber.calls == []
+        assert isinstance(outcome, SealPathFinalizationResult)
+        assert outcome.text == ""
+        assert outcome.infer_ms == 0
+        assert transcriber.calls == []
         assert released_devices == ["cuda"]
 
     asyncio.run(scenario())
 
 
-def test_server_finalize_uses_canonical_audio_even_when_stream_session_exists() -> None:
+def test_seal_path_finalize_forwards_canonical_audio_samples() -> None:
     async def scenario() -> None:
-        server = cast(Any, SessionOrchestrator.__new__(SessionOrchestrator))
-        server.settings = ServerSettings(device="cpu", streaming_enabled=True)
-        server.audio = SimpleNamespace(sample_rate=16_000)
-        server.transcriber = _RecordingTranscriber()
-        server.streaming_transcriber = object()
-        server._active_stream = _ExplodingStreamSession()
-        server.tail_trimmer = _tail_trimmer_with_trim(_identity_tail_trim)
-
+        runtime = _runtime()
+        transcriber = _RecordingTranscriber()
         samples = np.array([0.2, 0.1, 0.05, 0.4], dtype=np.float32)
-        typed_server = cast(SessionOrchestrator, server)
-        text, infer_ms = await typed_server._finalise_transcription(samples)
+        outcome = await runtime.finalize(
+            samples,
+            _async_transcriber(transcriber),
+            effective_device="cpu",
+        )
 
-        assert text == "offline text"
-        assert infer_ms >= 0
-        recording = server.transcriber
-        assert len(recording.calls) == 1
-        forwarded_samples, forwarded_rate = recording.calls[0]
+        assert isinstance(outcome, SealPathFinalizationResult)
+        assert outcome.text == "offline text"
+        assert outcome.infer_ms >= 0
+        assert len(transcriber.calls) == 1
+        forwarded_samples, forwarded_rate = transcriber.calls[0]
         assert forwarded_rate == 16_000
         np.testing.assert_array_equal(forwarded_samples, samples)
-        stream = server._active_stream
-        assert stream.feed_calls == []
-        assert stream.finalize_called is False
 
     asyncio.run(scenario())
 
 
-def test_server_finalize_offloads_tail_trim_off_event_loop() -> None:
+def test_seal_path_finalize_offloads_tail_trim_off_event_loop() -> None:
     async def scenario() -> None:
-        server = cast(Any, SessionOrchestrator.__new__(SessionOrchestrator))
-        server.settings = ServerSettings(device="cpu", streaming_enabled=False)
-        server.audio = SimpleNamespace(sample_rate=16_000)
-        server.transcriber = _RecordingTranscriber()
-        server.streaming_transcriber = None
-        server._active_stream = None
-
         def slow_trim(samples: np.ndarray, _sample_rate: int) -> TailTrimOutcome:
             time.sleep(0.12)
             return TailTrimOutcome(samples, "rms", False, None)
 
-        server.tail_trimmer = _tail_trimmer_with_trim(slow_trim)
-
+        runtime = _runtime(slow_trim)
+        transcriber = _RecordingTranscriber()
         progress = asyncio.Event()
 
         async def ticker() -> None:
@@ -254,46 +248,88 @@ def test_server_finalize_offloads_tail_trim_off_event_loop() -> None:
             progress.set()
 
         finalize_task = asyncio.create_task(
-            cast(SessionOrchestrator, server)._finalise_transcription(
-                np.array([0.2, 0.1, 0.05], dtype=np.float32)
+            runtime.finalize(
+                np.array([0.2, 0.1, 0.05], dtype=np.float32),
+                _async_transcriber(transcriber),
+                effective_device="cpu",
             )
         )
         ticker_task = asyncio.create_task(ticker())
 
         await asyncio.wait_for(progress.wait(), timeout=0.05)
-        text, infer_ms = await finalize_task
+        outcome = await finalize_task
         await ticker_task
 
-        assert text == "offline text"
-        assert infer_ms >= 0
+        assert isinstance(outcome, SealPathFinalizationResult)
+        assert outcome.text == "offline text"
+        assert outcome.infer_ms >= 0
 
     asyncio.run(scenario())
 
 
-def test_server_finalize_releases_cuda_cache_after_model_call(monkeypatch) -> None:
+def test_seal_path_finalize_releases_cuda_cache_after_model_call() -> None:
     async def scenario() -> None:
-        server = cast(Any, SessionOrchestrator.__new__(SessionOrchestrator))
-        server.settings = ServerSettings(device="cuda", streaming_enabled=False)
-        server.audio = SimpleNamespace(sample_rate=16_000)
-        server.transcriber = _RecordingTranscriber()
-        server.streaming_transcriber = None
-        server._active_stream = None
-        server._effective_device = "cuda"
-        server.tail_trimmer = _tail_trimmer_with_trim(_identity_tail_trim)
         released_devices: list[str] = []
+        runtime = _runtime(released_devices=released_devices)
+        transcriber = _RecordingTranscriber()
 
-        monkeypatch.setattr(
-            orchestrator_module,
-            "_release_cuda_cache",
-            lambda device: released_devices.append(device),
+        outcome = await runtime.finalize(
+            np.array([0.2, 0.1, 0.05], dtype=np.float32),
+            _async_transcriber(transcriber),
+            effective_device="cuda",
         )
 
-        text, infer_ms = await cast(SessionOrchestrator, server)._finalise_transcription(
-            np.array([0.2, 0.1, 0.05], dtype=np.float32)
-        )
-
-        assert text == "offline text"
-        assert infer_ms >= 0
+        assert isinstance(outcome, SealPathFinalizationResult)
+        assert outcome.text == "offline text"
+        assert outcome.infer_ms >= 0
         assert released_devices == ["cuda"]
+
+    asyncio.run(scenario())
+
+
+def test_seal_path_finalize_releases_cuda_cache_when_tail_trim_fails() -> None:
+    async def scenario() -> None:
+        def fail_trim(_samples: np.ndarray, _sample_rate: int) -> TailTrimOutcome:
+            raise RuntimeError("trim failed")
+
+        released_devices: list[str] = []
+        runtime = _runtime(fail_trim, released_devices=released_devices)
+        transcriber = _RecordingTranscriber()
+
+        outcome = await runtime.finalize(
+            np.array([0.2, 0.1, 0.05], dtype=np.float32),
+            _async_transcriber(transcriber),
+            effective_device="cuda",
+        )
+
+        assert isinstance(outcome, SealPathFinalizationFailure)
+        assert outcome.code == "MODEL"
+        assert transcriber.calls == []
+        assert released_devices == ["cuda"]
+
+    asyncio.run(scenario())
+
+
+def test_seal_path_finalize_preserves_result_when_cache_release_fails() -> None:
+    async def scenario() -> None:
+        def fail_release(_device: str) -> None:
+            raise RuntimeError("cache release failed")
+
+        runtime = SealPathRuntime(
+            sample_rate=16_000,
+            tail_trimmer=_tail_trimmer_with_trim(_identity_tail_trim),
+            release_device_cache=fail_release,
+        )
+        transcriber = _RecordingTranscriber()
+
+        outcome = await runtime.finalize(
+            np.array([0.2, 0.1, 0.05], dtype=np.float32),
+            _async_transcriber(transcriber),
+            effective_device="cuda",
+        )
+
+        assert isinstance(outcome, SealPathFinalizationResult)
+        assert outcome.text == "offline text"
+        assert runtime.last_failure is None
 
     asyncio.run(scenario())

--- a/parakeet-stt-daemon/tests/test_overlay_event_stream.py
+++ b/parakeet-stt-daemon/tests/test_overlay_event_stream.py
@@ -25,8 +25,13 @@ from parakeet_stt_daemon.messages import (
     StopSession,
 )
 from parakeet_stt_daemon.server import DaemonServer
-from parakeet_stt_daemon.session import SessionManager
+from parakeet_stt_daemon.session import (
+    SealPathFinalizationResult,
+    SealPathRuntime,
+    SessionManager,
+)
 from parakeet_stt_daemon.session_orchestrator import SessionOrchestrator
+from parakeet_stt_daemon.tail_trim import SealPathTailTrimmer
 
 
 class FakeAudio:
@@ -144,6 +149,33 @@ class SerializingTranscriber:
                 self.active_calls -= 1
 
 
+class FakeSealPathRuntime(SealPathRuntime):
+    def __init__(self, text: str = "overlay test text") -> None:
+        super().__init__(
+            sample_rate=16_000,
+            tail_trimmer=SealPathTailTrimmer(vad_enabled=False, silence_floor_db=-40.0),
+            release_device_cache=lambda _device: None,
+        )
+        self.text = text
+
+    async def finalize(
+        self,
+        audio_samples: np.ndarray,
+        transcribe,
+        *,
+        effective_device: str,
+    ) -> SealPathFinalizationResult:
+        del transcribe, effective_device
+        audio_duration_raw = len(audio_samples) / self.sample_rate
+        return SealPathFinalizationResult(
+            text=self.text,
+            audio_ms=int(audio_duration_raw * 1000),
+            audio_duration_raw=audio_duration_raw,
+            finalize_ms=0,
+            infer_ms=7,
+        )
+
+
 def _build_server(
     *,
     overlay_events_enabled: bool,
@@ -185,16 +217,8 @@ def _build_server(
     orchestrator._session_age_limit_ms = 90_000
     orchestrator._requested_device = "cpu"
     orchestrator._effective_device = "cpu"
-    orchestrator._last_audio_ms = None
-    orchestrator._last_audio_stop_ms = None
-    orchestrator._last_finalize_ms = None
-    orchestrator._last_infer_ms = None
-    orchestrator._last_send_ms = None
-
-    async def fake_finalize(_audio_samples: np.ndarray) -> tuple[str, int]:
-        return "overlay test text", 7
-
-    orchestrator._finalise_transcription = fake_finalize
+    orchestrator.tail_trimmer = SealPathTailTrimmer(vad_enabled=False, silence_floor_db=-40.0)
+    orchestrator.seal_path_runtime = FakeSealPathRuntime()
     return cast(DaemonServer, server)
 
 
@@ -893,12 +917,15 @@ def test_stop_path_serializes_live_interim_and_final_decode(monkeypatch) -> None
         server = _build_server(overlay_events_enabled=True)
         transcriber = SerializingTranscriber()
         _set_dynamic_attr(server.orchestrator, "transcriber", transcriber)
+        tail_trimmer = SealPathTailTrimmer(vad_enabled=False, silence_floor_db=-40.0)
+        _set_dynamic_attr(server.orchestrator, "tail_trimmer", tail_trimmer)
         _set_dynamic_attr(
             server.orchestrator,
-            "_finalise_transcription",
-            SessionOrchestrator._finalise_transcription.__get__(
-                server.orchestrator,
-                SessionOrchestrator,
+            "seal_path_runtime",
+            SealPathRuntime(
+                sample_rate=16_000,
+                tail_trimmer=tail_trimmer,
+                release_device_cache=lambda _device: None,
             ),
         )
         websocket = FakeWebSocket()

--- a/parakeet-stt-daemon/tests/test_session_cleanup.py
+++ b/parakeet-stt-daemon/tests/test_session_cleanup.py
@@ -22,7 +22,7 @@ from parakeet_stt_daemon.messages import (
     StopSession,
 )
 from parakeet_stt_daemon.server import DaemonServer
-from parakeet_stt_daemon.session import Session, SessionManager
+from parakeet_stt_daemon.session import SealPathFinalizationResult, Session, SessionManager
 from parakeet_stt_daemon.session_orchestrator import SessionOrchestrator
 
 
@@ -96,6 +96,12 @@ class FakeStreamingTranscriber:
         return object()
 
 
+class FakeTranscriber:
+    def transcribe_samples(self, _samples: np.ndarray, *, sample_rate: int = 16_000) -> str:
+        del sample_rate
+        return "final text"
+
+
 class FakeWebSocket:
     def __init__(self, incoming: list[dict | Exception]) -> None:
         self._incoming = incoming
@@ -154,7 +160,7 @@ def _build_server() -> DaemonServer:
     orchestrator.sessions = SessionManager()
     orchestrator.audio = FakeAudio()
     orchestrator.model = object()
-    orchestrator.transcriber = object()
+    orchestrator.transcriber = FakeTranscriber()
     orchestrator._session_lock = asyncio.Lock()
     orchestrator._inference_lock = asyncio.Lock()
     orchestrator.streaming_transcriber = None
@@ -167,22 +173,13 @@ def _build_server() -> DaemonServer:
     orchestrator._session_age_limit_ms = 90_000
     orchestrator._requested_device = "cpu"
     orchestrator._effective_device = "cpu"
-    orchestrator._last_audio_ms = None
-    orchestrator._last_audio_stop_ms = None
-    orchestrator._last_finalize_ms = None
-    orchestrator._last_infer_ms = None
-    orchestrator._last_send_ms = None
 
     async def fake_collect_interim_text_updates(
         _session_id: UUID, _ready_chunks: list[object]
     ) -> list[str]:
         return []
 
-    async def fake_finalize(_audio_samples: np.ndarray) -> tuple[str, int]:
-        return "final text", 7
-
     orchestrator._collect_interim_text_updates = fake_collect_interim_text_updates
-    orchestrator._finalise_transcription = fake_finalize
     return cast(DaemonServer, server)
 
 
@@ -558,11 +555,17 @@ def test_status_reports_runtime_truth_and_last_timings() -> None:
         server.orchestrator.streaming_transcriber = cast(
             Any, FakeStreamingTranscriber(helper_active=False)
         )
-        server.orchestrator._last_audio_ms = 1200
-        server.orchestrator._last_audio_stop_ms = 9
-        server.orchestrator._last_finalize_ms = 120
-        server.orchestrator._last_infer_ms = 85
-        server.orchestrator._last_send_ms = 4
+        server.orchestrator._seal_path_runtime_for_runtime().record_success(
+            SealPathFinalizationResult(
+                text="final text",
+                audio_ms=1200,
+                audio_duration_raw=1.2,
+                finalize_ms=120,
+                infer_ms=85,
+            ),
+            audio_stop_ms=9,
+            send_ms=4,
+        )
         session_id = uuid4()
         await server.orchestrator.sessions.start_session(session_id, owner_token=1)
 

--- a/parakeet-stt-daemon/tests/test_session_orchestrator.py
+++ b/parakeet-stt-daemon/tests/test_session_orchestrator.py
@@ -22,6 +22,9 @@ from parakeet_stt_daemon.events import (
 )
 from parakeet_stt_daemon.messages import SessionEndReason
 from parakeet_stt_daemon.session import (
+    SealPathFinalizationFailure,
+    SealPathFinalizationResult,
+    SealPathRuntime,
     SessionManager,
     StreamPathRuntime,
 )
@@ -31,6 +34,7 @@ from parakeet_stt_daemon.session_orchestrator import (
     StartSessionIntent,
     StopSessionIntent,
 )
+from parakeet_stt_daemon.tail_trim import SealPathTailTrimmer
 
 
 class FakeAudio:
@@ -109,6 +113,48 @@ class FakeStreamingTranscriber:
         return FakeStreamSession()
 
 
+class FakeTranscriber:
+    def __init__(self, text: str = "final text") -> None:
+        self.text = text
+        self.calls: list[tuple[np.ndarray, int]] = []
+
+    def transcribe_samples(self, samples: np.ndarray, *, sample_rate: int = 16_000) -> str:
+        self.calls.append((samples.copy(), sample_rate))
+        return self.text
+
+
+class FakeSealPathRuntime(SealPathRuntime):
+    def __init__(self, text: str = "final text") -> None:
+        super().__init__(
+            sample_rate=16_000,
+            tail_trimmer=SealPathTailTrimmer(vad_enabled=False, silence_floor_db=-40.0),
+            release_device_cache=lambda _device: None,
+        )
+        self.text = text
+
+    async def finalize(
+        self,
+        audio_samples: np.ndarray,
+        transcribe,
+        *,
+        effective_device: str,
+    ) -> SealPathFinalizationResult | SealPathFinalizationFailure:
+        del transcribe, effective_device
+        if audio_samples.size == 0:
+            return SealPathFinalizationFailure(
+                code="AUDIO_DEVICE",
+                message="No audio captured for session",
+            )
+        audio_duration_raw = len(audio_samples) / self.sample_rate
+        return SealPathFinalizationResult(
+            text=self.text,
+            audio_ms=int(audio_duration_raw * 1000),
+            audio_duration_raw=audio_duration_raw,
+            finalize_ms=0,
+            infer_ms=7,
+        )
+
+
 def _build_orchestrator(
     *,
     streaming_enabled: bool = False,
@@ -127,7 +173,7 @@ def _build_orchestrator(
     orchestrator.sessions = SessionManager()
     orchestrator.audio = FakeAudio(samples=samples, stream_chunks=stream_chunks)
     orchestrator.model = object()
-    orchestrator.transcriber = object()
+    orchestrator.transcriber = FakeTranscriber()
     orchestrator._session_lock = asyncio.Lock()
     orchestrator._inference_lock = asyncio.Lock()
     orchestrator.streaming_transcriber = FakeStreamingTranscriber() if streaming_enabled else None
@@ -140,23 +186,16 @@ def _build_orchestrator(
     orchestrator._session_age_limit_ms = int(max_session_seconds * 1000)
     orchestrator._requested_device = "cpu"
     orchestrator._effective_device = "cpu"
-    orchestrator._last_audio_ms = None
-    orchestrator._last_audio_stop_ms = None
-    orchestrator._last_finalize_ms = None
-    orchestrator._last_infer_ms = None
-    orchestrator._last_send_ms = None
     orchestrator._vad_enabled = False
+    orchestrator.tail_trimmer = SealPathTailTrimmer(vad_enabled=False, silence_floor_db=-40.0)
+    orchestrator.seal_path_runtime = FakeSealPathRuntime()
 
     async def fake_collect_interim_text_updates(
         _session_id: UUID, _ready_chunks: list[np.ndarray]
     ) -> list[str]:
         return []
 
-    async def fake_finalise(_audio_samples: np.ndarray) -> tuple[str, int]:
-        return "final text", 7
-
     orchestrator._collect_interim_text_updates = fake_collect_interim_text_updates
-    orchestrator._finalise_transcription = fake_finalise
     return cast(SessionOrchestrator, orchestrator)
 
 

--- a/parakeet-stt-daemon/tests/test_streaming_truth.py
+++ b/parakeet-stt-daemon/tests/test_streaming_truth.py
@@ -15,6 +15,9 @@ from parakeet_stt_daemon.runtime_truth_snapshot import RuntimeTruth, snapshot
 from parakeet_stt_daemon.session import (
     InterimTranscriptRuntime,
     InterimTranscriptRuntimeFacts,
+    SealPathFinalizationResult,
+    SealPathRuntime,
+    SealPathRuntimeFacts,
     Session,
     SessionManager,
     StreamPathRuntime,
@@ -81,6 +84,15 @@ class RuntimeTruthPrivateFieldTrap(SimpleNamespace):
         )
         if name in private_interim_fields:
             raise AssertionError(f"runtime truth probed old interim transcript field {name}")
+        private_seal_fields = (
+            "_last_audio_ms",
+            "_last_audio_stop_ms",
+            "_last_finalize_ms",
+            "_last_infer_ms",
+            "_last_send_ms",
+        )
+        if name in private_seal_fields:
+            raise AssertionError(f"runtime truth probed old Seal path field {name}")
         raise AttributeError(name)
 
 
@@ -111,17 +123,17 @@ def _build_server(
     orchestrator._stream_drain_running = False
     orchestrator._requested_device = "cpu"
     orchestrator._effective_device = "cpu"
-    orchestrator._last_audio_ms = None
-    orchestrator._last_audio_stop_ms = None
-    orchestrator._last_finalize_ms = None
-    orchestrator._last_infer_ms = None
-    orchestrator._last_send_ms = None
     orchestrator._vad_enabled = vad_enabled
     orchestrator.tail_trimmer = SealPathTailTrimmer(
         vad_enabled=vad_enabled,
         silence_floor_db=float(orchestrator.settings.silence_floor_db),
         vad_adapter=FakeVadAdapter(),
         warmup_sample_rate=FakeAudio.sample_rate,
+    )
+    orchestrator.seal_path_runtime = SealPathRuntime(
+        sample_rate=FakeAudio.sample_rate,
+        tail_trimmer=orchestrator.tail_trimmer,
+        release_device_cache=lambda _device: None,
     )
     return cast(SessionOrchestrator, orchestrator)
 
@@ -353,6 +365,37 @@ def test_runtime_truth_reads_interim_interface_instead_of_orchestrator_fields() 
         truth.interim_transcript_source_fallback_reason
         == "stop_replay_transcribe_error:RuntimeError"
     )
+
+
+def test_runtime_truth_reads_seal_path_interface() -> None:
+    runtime_facts = SealPathRuntimeFacts(
+        finalization_mode="offline_seal",
+        final_audio_source="canonical_session_audio",
+    )
+    orchestrator = cast(
+        SessionOrchestrator,
+        RuntimeTruthPrivateFieldTrap(
+            settings=SimpleNamespace(
+                streaming_enabled=False,
+                chunk_secs=None,
+                overlay_events_enabled=False,
+            ),
+            streaming_transcriber=None,
+            seal_path_runtime_facts_for_runtime=lambda: runtime_facts,
+        ),
+    )
+
+    truth = snapshot(
+        orchestrator,
+        last_trim_outcome=SimpleNamespace(
+            tail_trim_mode="rms",
+            vad_active=False,
+            vad_fallback_reason=None,
+        ),
+    )
+
+    assert truth.finalization_mode == "offline_seal"
+    assert truth.final_audio_source == "canonical_session_audio"
 
 
 def test_interim_runtime_syncs_cached_session_config() -> None:
@@ -709,14 +752,44 @@ def test_status_last_timings_none_before_first_session() -> None:
     assert status.last_send_ms is None
 
 
+def test_seal_path_runtime_sync_preserves_injected_cache_releaser() -> None:
+    """Existing Seal runtime refreshes without replacing injected cleanup hooks."""
+    server = _build_server(streaming_enabled=False)
+    calls: list[str] = []
+
+    def release_device_cache(device: str) -> None:
+        calls.append(device)
+
+    runtime = SealPathRuntime(
+        sample_rate=8_000,
+        tail_trimmer=SealPathTailTrimmer(vad_enabled=False, silence_floor_db=-40.0),
+        release_device_cache=release_device_cache,
+    )
+    server.seal_path_runtime = runtime
+
+    synced = server._seal_path_runtime_for_runtime()
+    synced.release_device_cache("cuda:0")
+
+    assert synced is runtime
+    assert synced.sample_rate == FakeAudio.sample_rate
+    assert synced.tail_trimmer is server.tail_trimmer
+    assert calls == ["cuda:0"]
+
+
 def test_status_last_timings_populated_after_session() -> None:
     """Timing fields reflect last session values."""
     server = _build_server(streaming_enabled=False)
-    server._last_audio_ms = 2500
-    server._last_audio_stop_ms = 12
-    server._last_finalize_ms = 180
-    server._last_infer_ms = 120
-    server._last_send_ms = 3
+    server._seal_path_runtime_for_runtime().record_success(
+        SealPathFinalizationResult(
+            text="final text",
+            audio_ms=2500,
+            audio_duration_raw=2.5,
+            finalize_ms=180,
+            infer_ms=120,
+        ),
+        audio_stop_ms=12,
+        send_ms=3,
+    )
 
     status = _status(server)
     assert status.audio_stop_ms == 12


### PR DESCRIPTION
## Summary

- introduce `SealPathRuntime` as the Session module interface for Seal path finalization, final runtime facts, last timing metrics, tail trim, and device-cache cleanup
- route `SessionOrchestrator` stop-time finalization through named Seal path outcomes instead of inline final transcription and private `_last_*` timing fields
- keep empty capture, model failure, tail/VAD trim, final result, session-ended ordering, Stream path runtime truth, injected cleanup hooks, and cleanup-failure behavior covered by updated tests

Closes #126

## Verification

- `uv run --project parakeet-stt-daemon pytest -q parakeet-stt-daemon/tests/test_offline_in_memory_transcription.py parakeet-stt-daemon/tests/test_session_orchestrator.py parakeet-stt-daemon/tests/test_session_cleanup.py parakeet-stt-daemon/tests/test_overlay_event_stream.py parakeet-stt-daemon/tests/test_streaming_truth.py` -> 96 passed
- `uv run --project parakeet-stt-daemon pytest -q` -> 212 passed
- deletion search: `rg -n "_finalise_transcription|_last_audio_ms|_last_audio_stop_ms|_last_finalize_ms|_last_infer_ms|_last_send_ms|finalize_started|tail_trimmer\.trim" parakeet-stt-daemon/src/parakeet_stt_daemon/session_orchestrator.py parakeet-stt-daemon/src/parakeet_stt_daemon/runtime_truth_snapshot.py` -> no matches
- `uv run --project parakeet-stt-daemon ruff format --check <changed files>` -> passed
- `uv run --project parakeet-stt-daemon ruff check <changed files>` -> passed
- `ty check --project parakeet-stt-daemon --error-on-warning` -> passed
- `uv build --project parakeet-stt-daemon` -> passed
- `uv run --project parakeet-stt-daemon parakeet-stt-daemon --check` -> passed
- `git diff --check` -> passed
- `prek run --files <changed files>` -> passed
- `prek run --all-files` -> passed
- `prek run --stage pre-push --all-files` -> passed
- push pre-push hook -> passed
- CodeRabbit local watcher `.git/coderabbit-review/20260522T104129Z/status.json` -> clean before initial PR review
- CodeRabbit PR gate `.git/coderabbit-review/20260522T104518Z/gate-summary.json` -> found two actionable findings; both fixed
- CodeRabbit local watcher `.git/coderabbit-review/20260522T105506Z/status.json` -> clean after fixing initial findings
- final classified CodeRabbit PR gate `.git/coderabbit-review/issue126-final-gate/gate-summary.json` with `.git/coderabbit-review/issue126-final-gate/decision-ledger.json` and `--require-classified` -> clean
- PR check/comment/thread sweep: CodeRabbit check passed; CodeRabbit finding threads resolved; no live actionable findings remain

Known preexisting issue: `cd parakeet-stt-daemon && uv run deptry .` still reports unrelated DEP002 for `onnxruntime`.
