### PR TITLE
refactor(client): extract focus routing adapter

### DIFF
--- a/parakeet-ptt/src/app.rs
+++ b/parakeet-ptt/src/app.rs
@@ -19,14 +19,15 @@ use tracing::{debug, info, warn};
 use crate::audio_feedback::AudioFeedback;
 use crate::client::WsClient;
 use crate::client_session::{
-    classify_error_code, handle_server_message, ClientSessionRuntime, SessionIntent,
+    classify_error_code, handle_server_message, ClientFocusRouter, ClientSessionRuntime,
+    SessionIntent,
 };
 use crate::config::ClientConfig;
 use crate::hotkey::{
     ensure_input_access, parse_pre_modifier_key_names, spawn_hotkey_loop, HotkeyEvent,
     HotkeyIntent, HotkeyTasks,
 };
-use crate::injector::{injector_metrics_snapshot, ParentFocusCapture};
+use crate::injector::injector_metrics_snapshot;
 use crate::injector_runtime::{
     build_injection_runner, spawn_injector_worker, EnqueueFailure, InjectionErrorKind,
     InjectionJob, InjectionJobRunner, InjectionOrigin, InjectionReport, InjectorWorkerHandle,
@@ -35,7 +36,7 @@ use crate::injector_runtime::{
 use crate::llm::{sanitize_model_answer, LlmAnswerer, LlmProgress};
 use crate::overlay_router::{OverlayRouter, OverlaySink};
 use crate::protocol::{start_message, stop_message, ClientMessage, DaemonStatus, ServerMessage};
-use crate::surface_focus::{WaylandFocusCache, WaylandFocusObservation};
+use crate::surface_focus::WaylandFocusCache;
 
 type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
@@ -420,8 +421,8 @@ pub async fn run(config: ClientConfig, ports: ClientPorts) -> Result<()> {
     );
     let hotkey_runtime = hotkey_source.start(&config)?;
     let (injector_worker, mut injection_reports) = spawn_injector_worker(injection_runner);
-    let focus_cache_for_parent_capture = focus_cache.clone();
-    let mut overlay_router = OverlayRouter::new(overlay_sink, focus_cache);
+    let mut focus_router = ClientFocusRouter::new(focus_cache);
+    let mut overlay_router = OverlayRouter::new(overlay_sink);
     spawn_event_loop_lag_monitor();
 
     let mut session_runtime = ClientSessionRuntime::new();
@@ -469,16 +470,18 @@ pub async fn run(config: ClientConfig, ports: ClientPorts) -> Result<()> {
                                             warn!("ignoring hotkey down while LLM response is in progress");
                                             let (busy_session, busy_seq) =
                                                 session_runtime.note_llm_busy_overlay_rejection();
-                                            overlay_router.route_llm_answer_state(
+                                            overlay_router.route_llm_answer_state_with_output_hint(
                                                 busy_session,
                                                 busy_seq,
                                                 "LLM busy; wait for current answer".to_string(),
+                                                || focus_router.next_overlay_output_hint(),
                                             );
                                             overlay_router.route_session_ended(
                                                 None,
                                                 busy_session,
                                                 Some("busy".to_string()),
                                             );
+                                            focus_router.reset_overlay_target();
                                             hotkey_intent_diagnostics.note_llm_busy_reject();
                                             hotkey_intent_diagnostics.maybe_log_summary("hotkey_down_busy");
                                             continue;
@@ -505,14 +508,8 @@ pub async fn run(config: ClientConfig, ports: ClientPorts) -> Result<()> {
                                             let message = stop_message(session_id);
                                             send_message(daemon.as_mut(), &message).await?;
                                             let stop_sent_at = TokioInstant::now();
-                                            let parent_focus = capture_parent_focus(
-                                                focus_cache_for_parent_capture.as_ref(),
-                                            );
-                                            session_runtime.record_stop_message_sent(
-                                                session_id,
-                                                parent_focus,
-                                                stop_sent_at,
-                                            );
+                                            focus_router.record_stop_target(session_id, stop_sent_at);
+                                            session_runtime.record_stop_message_sent(session_id, stop_sent_at);
                                             info!(session = %session_id, "stop_session sent (hotkey up)");
                                         } else {
                                             hotkey_intent_diagnostics.note_hotkey_up_ignored();
@@ -571,10 +568,11 @@ pub async fn run(config: ClientConfig, ports: ClientPorts) -> Result<()> {
                                                 );
                                                 let seq =
                                                     session_runtime.start_llm_answer(session_id);
-                                                overlay_router.route_llm_answer_state(
+                                                overlay_router.route_llm_answer_state_with_output_hint(
                                                     session_id,
                                                     seq,
                                                     "Generating answer...".to_string(),
+                                                    || focus_router.next_overlay_output_hint(),
                                                 );
                                                 let answerer = Arc::clone(&llm_answerer);
                                                 let progress_tx = llm_tx.clone();
@@ -596,6 +594,7 @@ pub async fn run(config: ClientConfig, ports: ClientPorts) -> Result<()> {
                                                 handle_server_message(
                                                     known,
                                                     &mut session_runtime,
+                                                    &mut focus_router,
                                                     &mut overlay_router,
                                                     &injector_worker,
                                                 ).await?;
@@ -626,10 +625,11 @@ pub async fn run(config: ClientConfig, ports: ClientPorts) -> Result<()> {
                                         if let Some(update) =
                                             session_runtime.record_llm_delta(session_id, delta)
                                         {
-                                            overlay_router.route_llm_answer_delta(
+                                            overlay_router.route_llm_answer_delta_with_output_hint(
                                                 session_id,
                                                 update.seq,
                                                 update.text,
+                                                || focus_router.next_overlay_output_hint(),
                                             );
                                         }
                                     }
@@ -650,6 +650,7 @@ pub async fn run(config: ClientConfig, ports: ClientPorts) -> Result<()> {
                                             session_id,
                                             completion.session_end_reason.clone(),
                                         );
+                                        focus_router.reset_overlay_target();
                                         let fallback_transcript = transcript.clone();
                                         let response_text = match result {
                                             Ok(answer) => {
@@ -704,7 +705,10 @@ pub async fn run(config: ClientConfig, ports: ClientPorts) -> Result<()> {
                                                     completion.hotkey_up_elapsed_ms_at_enqueue,
                                                     completion.stop_message_elapsed_ms_at_enqueue,
                                                 )
-                                                .with_parent_focus(completion.parent_focus),
+                                                .with_parent_focus(
+                                                    focus_router
+                                                        .take_parent_focus_for_enqueue(session_id),
+                                                ),
                                             )
                                             .await
                                         {
@@ -734,6 +738,7 @@ pub async fn run(config: ClientConfig, ports: ClientPorts) -> Result<()> {
                 }
                 hotkey_intent_diagnostics.log_summary("daemon_connection_drop");
                 session_runtime.reset_for_connection_drop();
+                focus_router.reset_for_connection_drop();
                 warn!("Reconnecting to daemon after drop");
             }
             Err(err) => {
@@ -856,43 +861,6 @@ fn handle_injection_report(
     }
 
     overlay_router.route_injection_complete(report.session_id, success);
-}
-
-fn capture_parent_focus(focus_cache: Option<&WaylandFocusCache>) -> Option<ParentFocusCapture> {
-    let cache = focus_cache?;
-    match cache.observe(30_000, 500) {
-        WaylandFocusObservation::Fresh {
-            snapshot,
-            cache_age_ms,
-        } => Some(ParentFocusCapture {
-            snapshot: Some(snapshot),
-            source_selected: "wayland_cache".to_string(),
-            wayland_cache_age_ms: Some(cache_age_ms),
-            wayland_fallback_reason: None,
-            captured_elapsed_ms: Some(0),
-        }),
-        WaylandFocusObservation::LowConfidence {
-            snapshot,
-            cache_age_ms,
-            reason,
-        } => Some(ParentFocusCapture {
-            snapshot: Some(snapshot),
-            source_selected: "wayland_cache_low_confidence".to_string(),
-            wayland_cache_age_ms: Some(cache_age_ms),
-            wayland_fallback_reason: Some(reason.to_string()),
-            captured_elapsed_ms: Some(0),
-        }),
-        WaylandFocusObservation::Unavailable {
-            reason,
-            cache_age_ms,
-        } => Some(ParentFocusCapture {
-            snapshot: None,
-            source_selected: "wayland_unavailable".to_string(),
-            wayland_cache_age_ms: cache_age_ms,
-            wayland_fallback_reason: Some(reason.to_string()),
-            captured_elapsed_ms: Some(0),
-        }),
-    }
 }
 
 fn session_intent_from_hotkey(intent: HotkeyIntent) -> SessionIntent {
@@ -1573,7 +1541,7 @@ mod tests {
         let (worker, _reports) = spawn_injector_worker_with_capacity(injector, 4);
         let session_id = Uuid::new_v4();
         let (overlay_sink, seen_overlay_events) = RecordingOverlaySink::shared();
-        let mut overlay_router = OverlayRouter::new(overlay_sink, None);
+        let mut overlay_router = OverlayRouter::new(overlay_sink);
 
         handle_injection_report(
             &worker,

--- a/parakeet-ptt/src/client_session.rs
+++ b/parakeet-ptt/src/client_session.rs
@@ -2,7 +2,7 @@
 //!
 //! This Module owns per-Session Client runtime state and how Daemon
 //! `ServerMessage` values affect Client PTT state, Overlay routing, Injection
-//! enqueueing, LLM progress, and parent-focus handoff.
+//! enqueueing, LLM progress, and focus-routing handoff.
 
 use std::collections::HashMap;
 
@@ -19,11 +19,15 @@ use crate::injector_runtime::{
 use crate::overlay_router::{OverlayRouter, OverlaySink};
 use crate::protocol::ServerMessage;
 use crate::state::PttState;
+use crate::surface_focus::{WaylandFocusCache, WaylandFocusObservation};
+
+const PARENT_FOCUS_STALE_MS: u64 = 30_000;
+const PARENT_FOCUS_TRANSITION_GRACE_MS: u64 = 500;
 
 #[derive(Debug, Clone)]
-pub(crate) struct CapturedParentFocus {
-    pub(crate) focus: ParentFocusCapture,
-    pub(crate) captured_at: TokioInstant,
+struct CapturedParentFocus {
+    focus: ParentFocusCapture,
+    captured_at: TokioInstant,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -33,11 +37,17 @@ pub(crate) enum SessionIntent {
 }
 
 #[derive(Debug)]
+pub(crate) struct ClientFocusRouter {
+    focus_cache: Option<WaylandFocusCache>,
+    parent_focus_by_session: HashMap<Uuid, CapturedParentFocus>,
+    last_overlay_output_name: Option<String>,
+}
+
+#[derive(Debug)]
 pub(crate) struct ClientSessionRuntime {
     state: PttState,
     active_intent: Option<SessionIntent>,
     llm: LlmSessionRuntime,
-    parent_focus_by_session: HashMap<Uuid, CapturedParentFocus>,
     last_hotkey_up_at: Option<TokioInstant>,
     last_stop_message: Option<(Uuid, TokioInstant)>,
 }
@@ -65,7 +75,130 @@ pub(crate) struct LlmCompletionContext {
     pub(crate) state_label: &'static str,
     pub(crate) hotkey_up_elapsed_ms_at_enqueue: Option<u64>,
     pub(crate) stop_message_elapsed_ms_at_enqueue: Option<u64>,
-    pub(crate) parent_focus: Option<ParentFocusCapture>,
+}
+
+impl ClientFocusRouter {
+    pub(crate) fn new(focus_cache: Option<WaylandFocusCache>) -> Self {
+        Self {
+            focus_cache,
+            parent_focus_by_session: HashMap::new(),
+            last_overlay_output_name: None,
+        }
+    }
+
+    pub(crate) fn record_stop_target(&mut self, session_id: Uuid, captured_at: TokioInstant) {
+        if let Some(focus) = self.capture_parent_focus() {
+            self.parent_focus_by_session
+                .insert(session_id, CapturedParentFocus { focus, captured_at });
+        }
+    }
+
+    pub(crate) fn take_parent_focus_for_enqueue(
+        &mut self,
+        session_id: Uuid,
+    ) -> Option<ParentFocusCapture> {
+        self.parent_focus_by_session
+            .remove(&session_id)
+            .map(|captured| {
+                let mut focus = captured.focus;
+                focus.captured_elapsed_ms = Some(captured.captured_at.elapsed().as_millis() as u64);
+                focus
+            })
+    }
+
+    pub(crate) fn clear_session(&mut self, session_id: Uuid) {
+        self.parent_focus_by_session.remove(&session_id);
+    }
+
+    pub(crate) fn reset_for_connection_drop(&mut self) {
+        self.parent_focus_by_session.clear();
+        self.reset_overlay_target();
+    }
+
+    pub(crate) fn reset_overlay_target(&mut self) {
+        self.last_overlay_output_name = None;
+    }
+
+    pub(crate) fn next_overlay_output_hint(&mut self) -> Option<String> {
+        let output_name = self.focus_cache.as_ref()?.current_output_name();
+        self.next_overlay_output_hint_from(output_name)
+    }
+
+    fn next_overlay_output_hint_from(&mut self, output_name: Option<String>) -> Option<String> {
+        let output_name = output_name?;
+        if self.last_overlay_output_name.as_deref() == Some(output_name.as_str()) {
+            return None;
+        }
+
+        self.last_overlay_output_name = Some(output_name.clone());
+        Some(output_name)
+    }
+
+    fn capture_parent_focus(&self) -> Option<ParentFocusCapture> {
+        let cache = self.focus_cache.as_ref()?;
+        Some(parent_focus_from_observation(cache.observe(
+            PARENT_FOCUS_STALE_MS,
+            PARENT_FOCUS_TRANSITION_GRACE_MS,
+        )))
+    }
+
+    #[cfg(test)]
+    fn record_parent_focus_for_tests(
+        &mut self,
+        session_id: Uuid,
+        focus: ParentFocusCapture,
+        captured_at: TokioInstant,
+    ) {
+        self.parent_focus_by_session
+            .insert(session_id, CapturedParentFocus { focus, captured_at });
+    }
+
+    #[cfg(test)]
+    fn next_overlay_output_hint_for_tests(&mut self, output_name: Option<&str>) -> Option<String> {
+        self.next_overlay_output_hint_from(output_name.map(str::to_string))
+    }
+}
+
+impl Default for ClientFocusRouter {
+    fn default() -> Self {
+        Self::new(None)
+    }
+}
+
+fn parent_focus_from_observation(observation: WaylandFocusObservation) -> ParentFocusCapture {
+    match observation {
+        WaylandFocusObservation::Fresh {
+            snapshot,
+            cache_age_ms,
+        } => ParentFocusCapture {
+            snapshot: Some(snapshot),
+            source_selected: "wayland_cache".to_string(),
+            wayland_cache_age_ms: Some(cache_age_ms),
+            wayland_fallback_reason: None,
+            captured_elapsed_ms: Some(0),
+        },
+        WaylandFocusObservation::LowConfidence {
+            snapshot,
+            cache_age_ms,
+            reason,
+        } => ParentFocusCapture {
+            snapshot: Some(snapshot),
+            source_selected: "wayland_cache_low_confidence".to_string(),
+            wayland_cache_age_ms: Some(cache_age_ms),
+            wayland_fallback_reason: Some(reason.to_string()),
+            captured_elapsed_ms: Some(0),
+        },
+        WaylandFocusObservation::Unavailable {
+            reason,
+            cache_age_ms,
+        } => ParentFocusCapture {
+            snapshot: None,
+            source_selected: "wayland_unavailable".to_string(),
+            wayland_cache_age_ms: cache_age_ms,
+            wayland_fallback_reason: Some(reason.to_string()),
+            captured_elapsed_ms: Some(0),
+        },
+    }
 }
 
 impl ClientSessionRuntime {
@@ -74,7 +207,6 @@ impl ClientSessionRuntime {
             state: PttState::new(),
             active_intent: None,
             llm: LlmSessionRuntime::default(),
-            parent_focus_by_session: HashMap::new(),
             last_hotkey_up_at: None,
             last_stop_message: None,
         }
@@ -90,23 +222,9 @@ impl ClientSessionRuntime {
         self.state.stop_listening()
     }
 
-    pub(crate) fn record_stop_message_sent(
-        &mut self,
-        session_id: Uuid,
-        parent_focus: Option<ParentFocusCapture>,
-        sent_at: TokioInstant,
-    ) {
+    pub(crate) fn record_stop_message_sent(&mut self, session_id: Uuid, sent_at: TokioInstant) {
         self.last_hotkey_up_at = Some(sent_at);
         self.last_stop_message = Some((session_id, sent_at));
-        if let Some(focus) = parent_focus {
-            self.parent_focus_by_session.insert(
-                session_id,
-                CapturedParentFocus {
-                    focus,
-                    captured_at: sent_at,
-                },
-            );
-        }
     }
 
     pub(crate) fn reset(&mut self) {
@@ -117,7 +235,6 @@ impl ClientSessionRuntime {
     pub(crate) fn reset_for_connection_drop(&mut self) {
         self.reset();
         self.llm.clear();
-        self.parent_focus_by_session.clear();
         self.last_hotkey_up_at = None;
         self.last_stop_message = None;
     }
@@ -217,7 +334,6 @@ impl ClientSessionRuntime {
             state_label: self.state_label(),
             hotkey_up_elapsed_ms_at_enqueue: elapsed_ms_since(self.last_hotkey_up_at),
             stop_message_elapsed_ms_at_enqueue: self.stop_message_elapsed_ms_at_enqueue(session_id),
-            parent_focus: self.take_parent_focus_for_enqueue(session_id),
         })
     }
 
@@ -233,20 +349,6 @@ impl ClientSessionRuntime {
             state_at_receive = self.state_label(),
             "ignoring final result for non-active session"
         );
-    }
-
-    fn take_parent_focus_for_enqueue(&mut self, session_id: Uuid) -> Option<ParentFocusCapture> {
-        self.parent_focus_by_session
-            .remove(&session_id)
-            .map(|captured| {
-                let mut focus = captured.focus;
-                focus.captured_elapsed_ms = Some(captured.captured_at.elapsed().as_millis() as u64);
-                focus
-            })
-    }
-
-    fn remove_parent_focus(&mut self, session_id: Uuid) {
-        self.parent_focus_by_session.remove(&session_id);
     }
 
     fn stop_message_elapsed_ms_at_enqueue(&self, session_id: Uuid) -> Option<u64> {
@@ -288,12 +390,14 @@ impl LlmSessionRuntime {
 pub(crate) async fn handle_server_message<S: OverlaySink>(
     message: ServerMessage,
     runtime: &mut ClientSessionRuntime,
+    focus_router: &mut ClientFocusRouter,
     overlay_router: &mut OverlayRouter<S>,
     injector_worker: &InjectorWorkerHandle,
 ) -> Result<()> {
     match message {
         ServerMessage::SessionStarted { session_id, .. } => {
             info!(session = %session_id, "session started ack");
+            focus_router.reset_overlay_target();
             overlay_router.note_session_started(session_id);
         }
         ServerMessage::FinalResult {
@@ -329,7 +433,7 @@ pub(crate) async fn handle_server_message<S: OverlaySink>(
                             hotkey_up_elapsed_ms_at_enqueue,
                             stop_message_elapsed_ms_at_enqueue,
                         )
-                        .with_parent_focus(runtime.take_parent_focus_for_enqueue(session_id)),
+                        .with_parent_focus(focus_router.take_parent_focus_for_enqueue(session_id)),
                 )
                 .await
             {
@@ -367,7 +471,7 @@ pub(crate) async fn handle_server_message<S: OverlaySink>(
                 message
             );
             if let Some(session_id) = session_id {
-                runtime.remove_parent_focus(session_id);
+                focus_router.clear_session(session_id);
             }
             runtime.reset();
         }
@@ -376,11 +480,12 @@ pub(crate) async fn handle_server_message<S: OverlaySink>(
             seq,
             state: interim_state,
         } => {
-            overlay_router.route_daemon_interim_state(
+            overlay_router.route_daemon_interim_state_with_output_hint(
                 runtime.active_session_id(),
                 session_id,
                 seq,
                 interim_state,
+                || focus_router.next_overlay_output_hint(),
             );
         }
         ServerMessage::InterimText {
@@ -388,11 +493,12 @@ pub(crate) async fn handle_server_message<S: OverlaySink>(
             seq,
             text,
         } => {
-            overlay_router.route_daemon_interim_text(
+            overlay_router.route_daemon_interim_text_with_output_hint(
                 runtime.active_session_id(),
                 session_id,
                 seq,
                 text,
+                || focus_router.next_overlay_output_hint(),
             );
         }
         ServerMessage::AudioLevel {
@@ -402,8 +508,12 @@ pub(crate) async fn handle_server_message<S: OverlaySink>(
             overlay_router.route_audio_level(runtime.active_session_id(), session_id, level_db);
         }
         ServerMessage::SessionEnded { session_id, reason } => {
-            runtime.remove_parent_focus(session_id);
+            let ends_active_session = runtime.active_session_id() == Some(session_id);
+            focus_router.clear_session(session_id);
             overlay_router.route_session_ended(runtime.active_session_id(), session_id, reason);
+            if ends_active_session {
+                focus_router.reset_overlay_target();
+            }
         }
         ServerMessage::SessionWarning {
             session_id,
@@ -466,7 +576,6 @@ mod tests {
     use std::time::{Duration, Instant};
 
     use crate::config::OverlayMode;
-    use crate::injector::ParentFocusCapture;
     use crate::injector_runtime::{
         spawn_injector_worker_with_capacity, InjectionJob, InjectionJobRunner, InjectionRunError,
         InjectionRunOutput, InjectorWorkerHandle,
@@ -479,12 +588,16 @@ mod tests {
         RuntimeOverlaySink,
     };
     use crate::protocol::ServerMessage;
+    use crate::surface_focus::{FocusSnapshot, WaylandFocusObservation};
     use anyhow::anyhow;
     use tokio::sync::mpsc;
     use tokio::time::{timeout, Instant as TokioInstant};
     use uuid::Uuid;
 
-    use super::{handle_server_message, ClientSessionRuntime, LlmDeltaOverlay, SessionIntent};
+    use super::{
+        handle_server_message, parent_focus_from_observation, ClientFocusRouter,
+        ClientSessionRuntime, LlmDeltaOverlay, SessionIntent,
+    };
 
     struct SlowRunner {
         calls: Arc<AtomicU64>,
@@ -538,7 +651,15 @@ mod tests {
         overlay_router: &mut OverlayRouter<S>,
         injector_worker: &InjectorWorkerHandle,
     ) -> anyhow::Result<()> {
-        handle_server_message(message, runtime, overlay_router, injector_worker).await
+        let mut focus_router = ClientFocusRouter::default();
+        handle_server_message(
+            message,
+            runtime,
+            &mut focus_router,
+            overlay_router,
+            injector_worker,
+        )
+        .await
     }
 
     fn runtime_waiting_for_result() -> (ClientSessionRuntime, Uuid) {
@@ -555,18 +676,113 @@ mod tests {
         runtime
             .stop_listening()
             .expect("state should stop listening");
-        runtime.record_stop_message_sent(session_id, None, stopped_at);
+        runtime.record_stop_message_sent(session_id, stopped_at);
         (runtime, session_id)
     }
 
-    fn test_parent_focus() -> ParentFocusCapture {
-        ParentFocusCapture {
-            snapshot: None,
-            source_selected: "test".to_string(),
-            wayland_cache_age_ms: None,
-            wayland_fallback_reason: None,
-            captured_elapsed_ms: None,
+    fn test_focus_snapshot(output_name: Option<&str>) -> FocusSnapshot {
+        FocusSnapshot {
+            app_name: Some("Code".to_string()),
+            object_name: Some("editor".to_string()),
+            object_path: Some("/com/system76/Cosmic/Window/1".to_string()),
+            service_name: Some(":1.42".to_string()),
+            output_name: output_name.map(str::to_string),
+            focused: true,
+            active: true,
+            resolver: "test".to_string(),
         }
+    }
+
+    #[test]
+    fn client_focus_router_maps_parent_focus_for_injection() {
+        let session_id = Uuid::new_v4();
+        let parent_focus = parent_focus_from_observation(WaylandFocusObservation::LowConfidence {
+            snapshot: test_focus_snapshot(Some("DP-1")),
+            cache_age_ms: 17,
+            reason: "within_transition_grace",
+        });
+        let mut focus_router = ClientFocusRouter::default();
+        focus_router.record_parent_focus_for_tests(
+            session_id,
+            parent_focus,
+            TokioInstant::now() - Duration::from_millis(25),
+        );
+
+        let routed = focus_router
+            .take_parent_focus_for_enqueue(session_id)
+            .expect("captured parent focus should be available for Injection");
+
+        assert_eq!(routed.source_selected, "wayland_cache_low_confidence");
+        assert_eq!(routed.wayland_cache_age_ms, Some(17));
+        assert_eq!(
+            routed.wayland_fallback_reason.as_deref(),
+            Some("within_transition_grace")
+        );
+        assert_eq!(
+            routed
+                .snapshot
+                .as_ref()
+                .and_then(|snapshot| snapshot.output_name.as_deref()),
+            Some("DP-1")
+        );
+        assert!(
+            routed.captured_elapsed_ms.unwrap_or_default() >= 25,
+            "captured elapsed should reflect time between stop capture and enqueue"
+        );
+        assert!(focus_router
+            .take_parent_focus_for_enqueue(session_id)
+            .is_none());
+    }
+
+    #[test]
+    fn client_focus_router_deduplicates_overlay_output_hints_until_reset() {
+        let mut focus_router = ClientFocusRouter::default();
+
+        assert_eq!(
+            focus_router.next_overlay_output_hint_for_tests(Some("DP-1")),
+            Some("DP-1".to_string())
+        );
+        assert_eq!(
+            focus_router.next_overlay_output_hint_for_tests(Some("DP-1")),
+            None
+        );
+        assert_eq!(
+            focus_router.next_overlay_output_hint_for_tests(Some("HDMI-A-1")),
+            Some("HDMI-A-1".to_string())
+        );
+
+        focus_router.reset_overlay_target();
+
+        assert_eq!(
+            focus_router.next_overlay_output_hint_for_tests(Some("HDMI-A-1")),
+            Some("HDMI-A-1".to_string())
+        );
+    }
+
+    #[test]
+    fn client_focus_router_output_hint_feeds_overlay_router() {
+        let seen_overlay_events = Arc::new(Mutex::new(Vec::<OverlayEvent>::new()));
+        let mut focus_router = ClientFocusRouter::default();
+        let mut overlay_router = OverlayRouter::new(RecordingOverlaySink {
+            seen: Arc::clone(&seen_overlay_events),
+        });
+
+        if let Some(output_name) = focus_router.next_overlay_output_hint_for_tests(Some("DP-1")) {
+            overlay_router.route_output_hint(output_name);
+        }
+        if let Some(output_name) = focus_router.next_overlay_output_hint_for_tests(Some("DP-1")) {
+            overlay_router.route_output_hint(output_name);
+        }
+
+        assert_eq!(
+            seen_overlay_events
+                .lock()
+                .expect("overlay recording lock should be available")
+                .as_slice(),
+            &[OverlayEvent::OutputHint {
+                output_name: "DP-1".to_string(),
+            }]
+        );
     }
 
     #[test]
@@ -576,11 +792,7 @@ mod tests {
             .begin_listening(SessionIntent::LlmQuery)
             .expect("llm session should start");
         runtime.stop_listening().expect("llm session should stop");
-        runtime.record_stop_message_sent(
-            session_id,
-            Some(test_parent_focus()),
-            TokioInstant::now(),
-        );
+        runtime.record_stop_message_sent(session_id, TokioInstant::now());
         assert_eq!(
             runtime.defer_session_end_if_needed(&ServerMessage::SessionEnded {
                 session_id,
@@ -619,11 +831,7 @@ mod tests {
             .begin_listening(SessionIntent::LlmQuery)
             .expect("llm session should start");
         runtime.stop_listening().expect("llm session should stop");
-        runtime.record_stop_message_sent(
-            session_id,
-            Some(test_parent_focus()),
-            TokioInstant::now(),
-        );
+        runtime.record_stop_message_sent(session_id, TokioInstant::now());
         assert_eq!(
             runtime.defer_session_end_if_needed(&ServerMessage::SessionEnded {
                 session_id,
@@ -649,7 +857,6 @@ mod tests {
         assert_eq!(completion.state_label, "idle");
         assert!(completion.hotkey_up_elapsed_ms_at_enqueue.is_some());
         assert!(completion.stop_message_elapsed_ms_at_enqueue.is_some());
-        assert!(completion.parent_focus.is_some());
         assert!(!runtime.is_llm_busy());
         assert!(runtime.finish_llm_answer(session_id).is_none());
     }
@@ -662,7 +869,7 @@ mod tests {
         });
         let (worker, mut reports) = spawn_injector_worker_with_capacity(injector, 4);
         let (mut runtime, session_id) = runtime_waiting_for_result();
-        let mut overlay_router = OverlayRouter::new(NoopOverlaySink, None);
+        let mut overlay_router = OverlayRouter::new(NoopOverlaySink);
 
         handle_server_message_for_tests(
             ServerMessage::FinalResult {
@@ -703,7 +910,8 @@ mod tests {
         let (worker, mut reports) = spawn_injector_worker_with_capacity(injector, 4);
         let stop_message_at = TokioInstant::now() - Duration::from_millis(40);
         let (mut runtime, session_id) = runtime_waiting_for_result_with_timing(stop_message_at);
-        let mut overlay_router = OverlayRouter::new(NoopOverlaySink, None);
+        let mut focus_router = ClientFocusRouter::default();
+        let mut overlay_router = OverlayRouter::new(NoopOverlaySink);
 
         handle_server_message(
             ServerMessage::FinalResult {
@@ -715,6 +923,7 @@ mod tests {
                 confidence: Some(0.92),
             },
             &mut runtime,
+            &mut focus_router,
             &mut overlay_router,
             &worker,
         )
@@ -762,7 +971,7 @@ mod tests {
         let (worker, mut reports) = spawn_injector_worker_with_capacity(injector, 4);
         let (mut runtime, active_session_id) = runtime_waiting_for_result();
         let stale_session_id = Uuid::new_v4();
-        let mut overlay_router = OverlayRouter::new(NoopOverlaySink, None);
+        let mut overlay_router = OverlayRouter::new(NoopOverlaySink);
 
         handle_server_message_for_tests(
             ServerMessage::FinalResult {
@@ -802,7 +1011,7 @@ mod tests {
         let (worker, mut reports) = spawn_injector_worker_with_capacity(slow_injector, 8);
 
         let (mut runtime, session_id) = runtime_waiting_for_result();
-        let mut overlay_router = OverlayRouter::new(NoopOverlaySink, None);
+        let mut overlay_router = OverlayRouter::new(NoopOverlaySink);
         let message = ServerMessage::FinalResult {
             session_id,
             text: "hello from daemon".to_string(),
@@ -835,12 +1044,9 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     async fn interim_overlay_messages_route_without_injection_enqueue() {
         let seen_overlay_events = Arc::new(Mutex::new(Vec::<OverlayEvent>::new()));
-        let mut overlay_router = OverlayRouter::new(
-            RecordingOverlaySink {
-                seen: Arc::clone(&seen_overlay_events),
-            },
-            None,
-        );
+        let mut overlay_router = OverlayRouter::new(RecordingOverlaySink {
+            seen: Arc::clone(&seen_overlay_events),
+        });
         let injector_seen = Arc::new(Mutex::new(Vec::<String>::new()));
         let injector = Arc::new(RecordingRunner {
             seen: Arc::clone(&injector_seen),
@@ -925,12 +1131,9 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     async fn mixed_stream_enqueues_exactly_one_final_result() {
         let seen_overlay_events = Arc::new(Mutex::new(Vec::<OverlayEvent>::new()));
-        let mut overlay_router = OverlayRouter::new(
-            RecordingOverlaySink {
-                seen: Arc::clone(&seen_overlay_events),
-            },
-            None,
-        );
+        let mut overlay_router = OverlayRouter::new(RecordingOverlaySink {
+            seen: Arc::clone(&seen_overlay_events),
+        });
         let seen_injection = Arc::new(Mutex::new(Vec::<String>::new()));
         let injector = Arc::new(RecordingRunner {
             seen: Arc::clone(&seen_injection),
@@ -1023,8 +1226,7 @@ mod tests {
             Duration::ZERO,
         );
         let manager_metrics = Arc::clone(manager.metrics());
-        let mut overlay_router =
-            OverlayRouter::new(RuntimeOverlaySink::Process(Box::new(manager)), None);
+        let mut overlay_router = OverlayRouter::new(RuntimeOverlaySink::Process(Box::new(manager)));
 
         let seen_injection = Arc::new(Mutex::new(Vec::<String>::new()));
         let injector = Arc::new(RecordingRunner {
@@ -1122,8 +1324,7 @@ mod tests {
             Duration::ZERO,
         );
         let manager_metrics = Arc::clone(manager.metrics());
-        let mut overlay_router =
-            OverlayRouter::new(RuntimeOverlaySink::Process(Box::new(manager)), None);
+        let mut overlay_router = OverlayRouter::new(RuntimeOverlaySink::Process(Box::new(manager)));
 
         let seen_injection = Arc::new(Mutex::new(Vec::<String>::new()));
         let injector = Arc::new(RecordingRunner {
@@ -1223,8 +1424,7 @@ mod tests {
             Duration::ZERO,
         );
         let manager_metrics = Arc::clone(manager.metrics());
-        let mut overlay_router =
-            OverlayRouter::new(RuntimeOverlaySink::Process(Box::new(manager)), None);
+        let mut overlay_router = OverlayRouter::new(RuntimeOverlaySink::Process(Box::new(manager)));
 
         let seen_injection = Arc::new(Mutex::new(Vec::<String>::new()));
         let injector = Arc::new(RecordingRunner {
@@ -1336,12 +1536,9 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     async fn daemon_interim_text_requires_active_session_and_fresh_sequence() {
         let seen_overlay_events = Arc::new(Mutex::new(Vec::<OverlayEvent>::new()));
-        let mut overlay_router = OverlayRouter::new(
-            RecordingOverlaySink {
-                seen: Arc::clone(&seen_overlay_events),
-            },
-            None,
-        );
+        let mut overlay_router = OverlayRouter::new(RecordingOverlaySink {
+            seen: Arc::clone(&seen_overlay_events),
+        });
         let injector = Arc::new(RecordingRunner {
             seen: Arc::new(Mutex::new(Vec::new())),
         });

--- a/parakeet-ptt/src/overlay_router.rs
+++ b/parakeet-ptt/src/overlay_router.rs
@@ -194,19 +194,15 @@ pub(crate) struct OverlayRouter<S: OverlaySink> {
     metrics: Arc<OverlayRoutingMetrics>,
     active_session_id: Option<Uuid>,
     last_seq_by_producer: HashMap<OverlayTextProducer, u64>,
-    focus_cache: Option<WaylandFocusCache>,
-    last_output_name: Option<String>,
 }
 
 impl<S: OverlaySink> OverlayRouter<S> {
-    pub(crate) fn new(sink: S, focus_cache: Option<WaylandFocusCache>) -> Self {
+    pub(crate) fn new(sink: S) -> Self {
         Self {
             sink,
             metrics: Arc::new(OverlayRoutingMetrics::default()),
             active_session_id: None,
             last_seq_by_producer: HashMap::new(),
-            focus_cache,
-            last_output_name: None,
         }
     }
 
@@ -219,16 +215,47 @@ impl<S: OverlaySink> OverlayRouter<S> {
         if self.active_session_id != Some(session_id) {
             self.active_session_id = Some(session_id);
             self.last_seq_by_producer.clear();
-            self.last_output_name = None;
         }
     }
 
+    #[cfg(test)]
+    pub(crate) fn route_output_hint(&mut self, output_name: String) {
+        self.route_optional_output_hint(Some(output_name));
+    }
+
+    fn route_optional_output_hint(&mut self, output_name: Option<String>) {
+        let Some(output_name) = output_name else {
+            return;
+        };
+
+        self.sink
+            .on_overlay_event(OverlayEvent::OutputHint { output_name });
+    }
+
+    #[cfg(test)]
     pub(crate) fn route_daemon_interim_state(
         &mut self,
         expected_session_id: Option<Uuid>,
         session_id: Uuid,
         seq: u64,
         state: String,
+    ) {
+        self.route_daemon_interim_state_with_output_hint(
+            expected_session_id,
+            session_id,
+            seq,
+            state,
+            || None,
+        );
+    }
+
+    pub(crate) fn route_daemon_interim_state_with_output_hint(
+        &mut self,
+        expected_session_id: Option<Uuid>,
+        session_id: Uuid,
+        seq: u64,
+        state: String,
+        output_hint: impl FnOnce() -> Option<String>,
     ) {
         let Some(expected_session_id) = expected_session_id else {
             self.metrics.note_session_mismatch_drop();
@@ -245,15 +272,34 @@ impl<S: OverlaySink> OverlayRouter<S> {
             seq,
             state,
             OverlayTextProducer::DaemonSttInterim,
+            output_hint,
         );
     }
 
+    #[cfg(test)]
     pub(crate) fn route_daemon_interim_text(
         &mut self,
         expected_session_id: Option<Uuid>,
         session_id: Uuid,
         seq: u64,
         text: String,
+    ) {
+        self.route_daemon_interim_text_with_output_hint(
+            expected_session_id,
+            session_id,
+            seq,
+            text,
+            || None,
+        );
+    }
+
+    pub(crate) fn route_daemon_interim_text_with_output_hint(
+        &mut self,
+        expected_session_id: Option<Uuid>,
+        session_id: Uuid,
+        seq: u64,
+        text: String,
+        output_hint: impl FnOnce() -> Option<String>,
     ) {
         let Some(expected_session_id) = expected_session_id else {
             self.metrics.note_session_mismatch_drop();
@@ -270,26 +316,46 @@ impl<S: OverlaySink> OverlayRouter<S> {
             seq,
             text,
             OverlayTextProducer::DaemonSttInterim,
+            output_hint,
         );
     }
 
-    pub(crate) fn route_llm_answer_state(&mut self, session_id: Uuid, seq: u64, state: String) {
+    pub(crate) fn route_llm_answer_state_with_output_hint(
+        &mut self,
+        session_id: Uuid,
+        seq: u64,
+        state: String,
+        output_hint: impl FnOnce() -> Option<String>,
+    ) {
         self.route_interim_state(
             None,
             session_id,
             seq,
             state,
             OverlayTextProducer::LlmAnswerDelta,
+            output_hint,
         );
     }
 
+    #[cfg(test)]
     pub(crate) fn route_llm_answer_delta(&mut self, session_id: Uuid, seq: u64, text: String) {
+        self.route_llm_answer_delta_with_output_hint(session_id, seq, text, || None);
+    }
+
+    pub(crate) fn route_llm_answer_delta_with_output_hint(
+        &mut self,
+        session_id: Uuid,
+        seq: u64,
+        text: String,
+        output_hint: impl FnOnce() -> Option<String>,
+    ) {
         self.route_interim_text(
             None,
             session_id,
             seq,
             text,
             OverlayTextProducer::LlmAnswerDelta,
+            output_hint,
         );
     }
 
@@ -326,7 +392,6 @@ impl<S: OverlaySink> OverlayRouter<S> {
         if self.active_session_id == Some(session_id) {
             self.active_session_id = None;
             self.last_seq_by_producer.clear();
-            self.last_output_name = None;
         }
     }
 
@@ -337,6 +402,7 @@ impl<S: OverlaySink> OverlayRouter<S> {
         seq: u64,
         state: String,
         producer: OverlayTextProducer,
+        output_hint: impl FnOnce() -> Option<String>,
     ) {
         if !self.allow_session(expected_session_id, session_id)
             || !self.accept_seq(session_id, seq, &producer)
@@ -350,7 +416,7 @@ impl<S: OverlaySink> OverlayRouter<S> {
             overlay_text_producer = producer.as_str(),
             "routing overlay interim state"
         );
-        self.maybe_emit_output_hint();
+        self.route_optional_output_hint(output_hint());
         self.sink.on_overlay_event(OverlayEvent::InterimState {
             producer,
             session_id,
@@ -367,6 +433,7 @@ impl<S: OverlaySink> OverlayRouter<S> {
         seq: u64,
         text: String,
         producer: OverlayTextProducer,
+        output_hint: impl FnOnce() -> Option<String>,
     ) {
         if !self.allow_session(expected_session_id, session_id)
             || !self.accept_seq(session_id, seq, &producer)
@@ -381,7 +448,7 @@ impl<S: OverlaySink> OverlayRouter<S> {
             text_chars = text.chars().count(),
             "routing overlay interim text"
         );
-        self.maybe_emit_output_hint();
+        self.route_optional_output_hint(output_hint());
         self.sink.on_overlay_event(OverlayEvent::InterimText {
             producer,
             session_id,
@@ -404,24 +471,6 @@ impl<S: OverlaySink> OverlayRouter<S> {
         }
         self.sink
             .on_overlay_event(OverlayEvent::SessionWarning { session_id });
-    }
-
-    fn maybe_emit_output_hint(&mut self) {
-        let Some(focus_cache) = self.focus_cache.as_ref() else {
-            return;
-        };
-
-        let Some(output_name) = focus_cache.current_output_name() else {
-            return;
-        };
-
-        if self.last_output_name.as_deref() == Some(output_name.as_str()) {
-            return;
-        }
-
-        self.last_output_name = Some(output_name.clone());
-        self.sink
-            .on_overlay_event(OverlayEvent::OutputHint { output_name });
     }
 
     fn allow_session(&self, expected_session_id: Option<Uuid>, incoming_session_id: Uuid) -> bool {
@@ -507,7 +556,7 @@ mod tests {
     fn stale_interim_sequences_are_dropped_near_router() {
         let session_id = Uuid::new_v4();
         let (sink, seen) = RecordingOverlaySink::new();
-        let mut router = OverlayRouter::new(sink, None);
+        let mut router = OverlayRouter::new(sink);
         router.note_session_started(session_id);
 
         router.route_daemon_interim_text(Some(session_id), session_id, 10, "newest".to_string());
@@ -537,7 +586,7 @@ mod tests {
     fn daemon_interim_requires_active_client_session() {
         let session_id = Uuid::new_v4();
         let (sink, seen) = RecordingOverlaySink::new();
-        let mut router = OverlayRouter::new(sink, None);
+        let mut router = OverlayRouter::new(sink);
 
         router.route_daemon_interim_state(None, session_id, 1, "listening".to_string());
         router.route_daemon_interim_text(None, session_id, 2, "late daemon".to_string());
@@ -560,7 +609,7 @@ mod tests {
         let active_session_id = Uuid::new_v4();
         let stale_session_id = Uuid::new_v4();
         let (sink, seen) = RecordingOverlaySink::new();
-        let mut router = OverlayRouter::new(sink, None);
+        let mut router = OverlayRouter::new(sink);
         router.note_session_started(active_session_id);
 
         router.route_daemon_interim_text(
@@ -600,7 +649,7 @@ mod tests {
     fn daemon_and_llm_overlay_text_sequences_are_independent() {
         let session_id = Uuid::new_v4();
         let (sink, seen) = RecordingOverlaySink::new();
-        let mut router = OverlayRouter::new(sink, None);
+        let mut router = OverlayRouter::new(sink);
         router.note_session_started(session_id);
 
         router.route_daemon_interim_text(
@@ -658,7 +707,7 @@ mod tests {
         let active_session_id = Uuid::new_v4();
         let inactive_session_id = Uuid::new_v4();
         let (sink, seen) = RecordingOverlaySink::new();
-        let mut router = OverlayRouter::new(sink, None);
+        let mut router = OverlayRouter::new(sink);
         router.note_session_started(active_session_id);
 
         router.route_session_warning(inactive_session_id);


### PR DESCRIPTION
## Summary

- Adds `ClientFocusRouter` to own Wayland focus lookup, per-session parent-focus captures, and Overlay output-hint state for the Client.
- Removes app-loop focus capture plumbing and stops `OverlayRouter` from owning the focus cache directly.
- Routes Overlay output hints only after `OverlayRouter` accepts the event, preserving stale/mismatched event filtering while passing Injection parent focus through the focused router at enqueue time.

Closes #129.

## Verification

- `cargo check --manifest-path parakeet-ptt/Cargo.toml --all-targets` -> passed
- `cargo fmt --manifest-path parakeet-ptt/Cargo.toml --check` -> passed
- `cargo clippy --manifest-path parakeet-ptt/Cargo.toml --all-targets --all-features -- -D warnings` -> passed
- `cargo test --manifest-path parakeet-ptt/Cargo.toml -q` -> passed: 87 + 153 + 12 tests
- `prek run --files parakeet-ptt/src/app.rs parakeet-ptt/src/client_session.rs parakeet-ptt/src/overlay_router.rs` -> passed
- `prek run --stage pre-push --files parakeet-ptt/src/app.rs parakeet-ptt/src/client_session.rs parakeet-ptt/src/overlay_router.rs` -> passed
- `prek run --all-files` -> passed
- `prek run --stage pre-push --all-files` -> passed
- push pre-push hook -> passed
- deletion search for old app-loop focus capture / OverlayRouter focus-cache plumbing -> no matches
- `git diff --check` -> passed

## Review

- Pre-PR local watcher: CodeRabbit local CLI errored; scoped Codex fallback for `--base main` found no actionable correctness issues.
  - Status: `.git/coderabbit-review/20260522T125222Z/status.json`
  - Report: `.git/coderabbit-review/20260522T125222Z/codex-review.md`
- PR gate: CodeRabbit local CLI errored; same-head local Codex fallback found no actionable regressions, and remote CodeRabbit completed clean.
  - Local fallback: `.git/coderabbit-review/20260522T125846Z/local-review/status.json`
  - Local report: `.git/coderabbit-review/20260522T125846Z/local-review/codex-review.md`
  - Gate summary: `.git/coderabbit-review/20260522T125846Z/gate-summary.json`
  - Decision ledger: `.git/coderabbit-review/20260522T125846Z/decision-ledger.json`
- Final classified gate: `coderabbit_review_watch.py gate --pr 147 --no-local-review --decisions .git/coderabbit-review/20260522T125846Z/decision-ledger.json --require-classified` -> clean, remote verdict `completed_clean`, no actionable findings.
  - Gate summary: `.git/coderabbit-review/20260522T130514Z/gate-summary.json`
  - Decision ledger: `.git/coderabbit-review/20260522T130514Z/decision-ledger.json`
- PR feedback sweep found no review threads, review comments, or actionable CodeRabbit findings. CodeRabbit's top-level comment reported no actionable comments; its docstring coverage note was non-blocking and the final gate remained clean.