### PR TITLE
refactor(client): deepen llm query runtime

### DIFF
--- a/parakeet-ptt/src/app.rs
+++ b/parakeet-ptt/src/app.rs
@@ -20,7 +20,8 @@ use crate::audio_feedback::AudioFeedback;
 use crate::client::WsClient;
 use crate::client_session::{
     classify_error_code, handle_server_message, ClientFocusRouter, ClientInjectionDispatcher,
-    ClientSessionRuntime, LlmAnswerInjection, SessionIntent,
+    ClientLlmQueryRuntime, ClientSessionRuntime, LlmProgressOutcome, LlmQueryRequest,
+    SessionIntent,
 };
 use crate::config::ClientConfig;
 use crate::hotkey::{
@@ -31,7 +32,7 @@ use crate::injector_runtime::{
     build_injection_runner, spawn_injector_worker, InjectionJob, InjectionJobRunner,
     InjectionOrigin, INJECTION_ENQUEUE_TIMEOUT_MS,
 };
-use crate::llm::{sanitize_model_answer, LlmAnswerer, LlmProgress};
+use crate::llm::LlmAnswerer;
 use crate::overlay_router::{OverlayRouter, OverlaySink};
 use crate::protocol::{start_message, stop_message, ClientMessage, DaemonStatus, ServerMessage};
 use crate::surface_focus::WaylandFocusCache;
@@ -448,7 +449,7 @@ pub async fn run(config: ClientConfig, ports: ClientPorts) -> Result<()> {
     fetch_status_once(&config).await;
 
     let mut backoff = TokioDuration::from_millis(500);
-    let (llm_tx, mut llm_rx) = mpsc::unbounded_channel::<LlmProgress>();
+    let mut llm_query_runtime = ClientLlmQueryRuntime::new(Arc::clone(&llm_answerer));
     let mut hotkey_intent_diagnostics = HotkeyIntentDiagnostics::default();
 
     loop {
@@ -465,19 +466,18 @@ pub async fn run(config: ClientConfig, ports: ClientPorts) -> Result<()> {
                                     HotkeyEvent::Down { intent } => {
                                         let intent = session_intent_from_hotkey(intent);
                                         hotkey_intent_diagnostics.note_hotkey_down(intent);
-                                        if session_runtime.is_llm_busy() {
+                                        if llm_query_runtime.is_busy() {
                                             warn!("ignoring hotkey down while LLM response is in progress");
-                                            let (busy_session, busy_seq) =
-                                                session_runtime.note_llm_busy_overlay_rejection();
+                                            let busy = llm_query_runtime.note_busy_overlay_rejection();
                                             overlay_router.route_llm_answer_state_with_output_hint(
-                                                busy_session,
-                                                busy_seq,
-                                                "LLM busy; wait for current answer".to_string(),
+                                                busy.session_id,
+                                                busy.seq,
+                                                busy.state,
                                                 || focus_router.next_overlay_output_hint(),
                                             );
                                             overlay_router.route_session_ended(
                                                 None,
-                                                busy_session,
+                                                busy.session_id,
                                                 Some("busy".to_string()),
                                             );
                                             focus_router.reset_overlay_target();
@@ -495,7 +495,7 @@ pub async fn run(config: ClientConfig, ports: ClientPorts) -> Result<()> {
                                                 state = session_runtime.state_label(),
                                                 active_session = ?session_runtime.active_session_id(),
                                                 active_intent = ?session_runtime.active_intent(),
-                                                llm_busy = session_runtime.is_llm_busy(),
+                                                llm_busy = llm_query_runtime.is_busy(),
                                                 "ignoring hotkey down because client is not idle"
                                             );
                                         }
@@ -516,7 +516,7 @@ pub async fn run(config: ClientConfig, ports: ClientPorts) -> Result<()> {
                                                 state = session_runtime.state_label(),
                                                 active_session = ?session_runtime.active_session_id(),
                                                 active_intent = ?session_runtime.active_intent(),
-                                                llm_busy = session_runtime.is_llm_busy(),
+                                                llm_busy = llm_query_runtime.is_busy(),
                                                 "ignoring hotkey up because no listening session is active"
                                             );
                                         }
@@ -528,7 +528,10 @@ pub async fn run(config: ClientConfig, ports: ClientPorts) -> Result<()> {
                                 match next {
                                     Ok(Some(message)) => {
                                         if let Some(session_id) =
-                                            session_runtime.defer_session_end_if_needed(&message)
+                                            llm_query_runtime.defer_session_end_if_needed(
+                                                &message,
+                                                &session_runtime,
+                                            )
                                         {
                                             debug!(
                                                 session = %session_id,
@@ -559,35 +562,21 @@ pub async fn run(config: ClientConfig, ports: ClientPorts) -> Result<()> {
                                                 ..
                                             } if session_runtime.active_intent()
                                                 == Some(SessionIntent::LlmQuery) => {
-                                                info!(
-                                                    session = %session_id,
-                                                    daemon_latency_ms = latency_ms,
-                                                    audio_ms,
-                                                    "final result received in llm_query mode"
+                                                let started = llm_query_runtime.start_answer(
+                                                    LlmQueryRequest::new(
+                                                        session_id,
+                                                        text,
+                                                        latency_ms,
+                                                        audio_ms,
+                                                    ),
+                                                    &mut session_runtime,
                                                 );
-                                                let seq =
-                                                    session_runtime.start_llm_answer(session_id);
                                                 overlay_router.route_llm_answer_state_with_output_hint(
-                                                    session_id,
-                                                    seq,
-                                                    "Generating answer...".to_string(),
+                                                    started.session_id,
+                                                    started.seq,
+                                                    started.state,
                                                     || focus_router.next_overlay_output_hint(),
                                                 );
-                                                let answerer = Arc::clone(&llm_answerer);
-                                                let progress_tx = llm_tx.clone();
-                                                tokio::spawn(async move {
-                                                    let llm_result = answerer
-                                                        .answer(session_id, text.clone(), progress_tx.clone())
-                                                        .await
-                                                        .map_err(|err| format!("{err:#}"));
-                                                    let _ = progress_tx.send(LlmProgress::Finished {
-                                                        session_id,
-                                                        transcript: text,
-                                                        daemon_latency_ms: latency_ms,
-                                                        daemon_audio_ms: audio_ms,
-                                                        result: llm_result,
-                                                    });
-                                                });
                                             }
                                             known => {
                                                 handle_server_message(
@@ -617,78 +606,31 @@ pub async fn run(config: ClientConfig, ports: ClientPorts) -> Result<()> {
                                     &audio_feedback,
                                 );
                             }
-                            Some(progress) = llm_rx.recv() => {
-                                match progress {
-                                    LlmProgress::Delta { session_id, delta } => {
-                                        if let Some(update) =
-                                            session_runtime.record_llm_delta(session_id, delta)
-                                        {
-                                            overlay_router.route_llm_answer_delta_with_output_hint(
-                                                session_id,
-                                                update.seq,
-                                                update.text,
-                                                || focus_router.next_overlay_output_hint(),
-                                            );
-                                        }
+                            Some(progress) = llm_query_runtime.recv_progress() => {
+                                match llm_query_runtime.handle_progress(progress, &mut session_runtime) {
+                                    LlmProgressOutcome::Delta(update) => {
+                                        overlay_router.route_llm_answer_delta_with_output_hint(
+                                            update.session_id,
+                                            update.seq,
+                                            update.text,
+                                            || focus_router.next_overlay_output_hint(),
+                                        );
                                     }
-                                    LlmProgress::Finished {
-                                        session_id,
-                                        transcript,
-                                        daemon_latency_ms,
-                                        daemon_audio_ms,
-                                        result,
-                                    } => {
-                                        let Some(completion) =
-                                            session_runtime.finish_llm_answer(session_id)
-                                        else {
-                                            continue;
-                                        };
+                                    LlmProgressOutcome::Finished(answer) => {
                                         overlay_router.route_session_ended(
                                             None,
-                                            session_id,
-                                            completion.session_end_reason.clone(),
+                                            answer.session_id,
+                                            answer.session_end_reason.clone(),
                                         );
                                         focus_router.reset_overlay_target();
-                                        let fallback_transcript = transcript.clone();
-                                        let response_text = match result {
-                                            Ok(answer) => {
-                                                let sanitized = sanitize_model_answer(&answer);
-                                                info!(
-                                                    session = %session_id,
-                                                    answer_chars = sanitized.chars().count(),
-                                                    "llm response completed"
-                                                );
-                                                sanitized
-                                            }
-                                            Err(error) => {
-                                                warn!(
-                                                    session = %session_id,
-                                                    error = %error,
-                                                    "llm generation failed; falling back to raw transcript"
-                                                );
-                                                fallback_transcript.clone()
-                                            }
-                                        };
-
-                                        let to_inject = if response_text.trim().is_empty() {
-                                            warn!(session = %session_id, "llm response empty after sanitization; falling back to transcript");
-                                            fallback_transcript
-                                        } else {
-                                            response_text
-                                        };
                                         injection_dispatcher
                                             .dispatch_llm_answer(
-                                                LlmAnswerInjection::new(
-                                                    session_id,
-                                                    to_inject,
-                                                    daemon_latency_ms,
-                                                    daemon_audio_ms,
-                                                    completion,
-                                                ),
+                                                answer.injection,
                                                 &mut focus_router,
                                             )
                                             .await;
                                     }
+                                    LlmProgressOutcome::Ignored => {}
                                 }
                             }
                         }
@@ -701,6 +643,7 @@ pub async fn run(config: ClientConfig, ports: ClientPorts) -> Result<()> {
                 }
                 hotkey_intent_diagnostics.log_summary("daemon_connection_drop");
                 session_runtime.reset_for_connection_drop();
+                llm_query_runtime.reset_for_connection_drop();
                 focus_router.reset_for_connection_drop();
                 warn!("Reconnecting to daemon after drop");
             }

--- a/parakeet-ptt/src/client_session.rs
+++ b/parakeet-ptt/src/client_session.rs
@@ -6,8 +6,10 @@
 
 use std::collections::HashMap;
 use std::sync::atomic::Ordering;
+use std::sync::Arc;
 
 use anyhow::Result;
+use tokio::sync::mpsc;
 use tokio::time::Instant as TokioInstant;
 use tracing::{debug, info, warn};
 use uuid::Uuid;
@@ -18,6 +20,7 @@ use crate::injector_runtime::{
     EnqueueFailure, InjectionErrorKind, InjectionJob, InjectionOrigin, InjectionReport,
     InjectorWorkerHandle, INJECTION_ENQUEUE_TIMEOUT_MS, INJECTION_QUEUE_CAPACITY,
 };
+use crate::llm::{sanitize_model_answer, LlmAnswerer, LlmProgress};
 use crate::overlay_router::{OverlayRouter, OverlaySink};
 use crate::protocol::ServerMessage;
 use crate::state::PttState;
@@ -50,11 +53,17 @@ pub(crate) struct ClientInjectionDispatcher {
     worker: InjectorWorkerHandle,
 }
 
+pub(crate) struct ClientLlmQueryRuntime {
+    answerer: Arc<dyn LlmAnswerer>,
+    progress_tx: mpsc::UnboundedSender<LlmProgress>,
+    progress_rx: mpsc::UnboundedReceiver<LlmProgress>,
+    state: LlmSessionRuntime,
+}
+
 #[derive(Debug)]
 pub(crate) struct ClientSessionRuntime {
     state: PttState,
     active_intent: Option<SessionIntent>,
-    llm: LlmSessionRuntime,
     last_hotkey_up_at: Option<TokioInstant>,
     last_stop_message: Option<(Uuid, TokioInstant)>,
 }
@@ -71,8 +80,16 @@ struct LlmSessionRuntime {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct LlmDeltaOverlay {
+    pub(crate) session_id: Uuid,
     pub(crate) seq: u64,
     pub(crate) text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LlmStateOverlay {
+    pub(crate) session_id: Uuid,
+    pub(crate) seq: u64,
+    pub(crate) state: String,
 }
 
 #[derive(Debug, Clone)]
@@ -107,6 +124,28 @@ pub(crate) enum InjectionDispatchOutcome {
     QueueTimeout,
     WorkerGone,
     SkippedStaleSession,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct LlmQueryRequest {
+    session_id: Uuid,
+    transcript: String,
+    daemon_latency_ms: u64,
+    daemon_audio_ms: u64,
+}
+
+#[derive(Debug)]
+pub(crate) struct LlmCompletedAnswer {
+    pub(crate) session_id: Uuid,
+    pub(crate) session_end_reason: Option<String>,
+    pub(crate) injection: LlmAnswerInjection,
+}
+
+#[derive(Debug)]
+pub(crate) enum LlmProgressOutcome {
+    Delta(LlmDeltaOverlay),
+    Finished(LlmCompletedAnswer),
+    Ignored,
 }
 
 impl ClientFocusRouter {
@@ -223,6 +262,245 @@ impl LlmAnswerInjection {
             daemon_audio_ms,
             completion,
         }
+    }
+}
+
+impl LlmQueryRequest {
+    pub(crate) fn new(
+        session_id: Uuid,
+        transcript: String,
+        daemon_latency_ms: u64,
+        daemon_audio_ms: u64,
+    ) -> Self {
+        Self {
+            session_id,
+            transcript,
+            daemon_latency_ms,
+            daemon_audio_ms,
+        }
+    }
+}
+
+impl ClientLlmQueryRuntime {
+    pub(crate) fn new(answerer: Arc<dyn LlmAnswerer>) -> Self {
+        let (progress_tx, progress_rx) = mpsc::unbounded_channel();
+        Self {
+            answerer,
+            progress_tx,
+            progress_rx,
+            state: LlmSessionRuntime::default(),
+        }
+    }
+
+    pub(crate) fn is_busy(&self) -> bool {
+        self.state.busy
+    }
+
+    pub(crate) fn note_busy_overlay_rejection(&mut self) -> LlmStateOverlay {
+        self.state.busy_overlay_seq = self.state.busy_overlay_seq.saturating_add(1);
+        LlmStateOverlay {
+            session_id: Uuid::nil(),
+            seq: self.state.busy_overlay_seq,
+            state: "LLM busy; wait for current answer".to_string(),
+        }
+    }
+
+    pub(crate) fn defer_session_end_if_needed(
+        &mut self,
+        message: &ServerMessage,
+        runtime: &ClientSessionRuntime,
+    ) -> Option<Uuid> {
+        let ServerMessage::SessionEnded { session_id, reason } = message else {
+            return None;
+        };
+
+        let waiting_for_llm_final = runtime.active_intent() == Some(SessionIntent::LlmQuery)
+            && runtime.active_session_id() == Some(*session_id);
+        let llm_generation_running = self.state.in_flight_session == Some(*session_id);
+
+        if waiting_for_llm_final || llm_generation_running {
+            self.state
+                .deferred_session_end
+                .insert(*session_id, reason.clone());
+            Some(*session_id)
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn start_answer(
+        &mut self,
+        request: LlmQueryRequest,
+        runtime: &mut ClientSessionRuntime,
+    ) -> LlmStateOverlay {
+        let LlmQueryRequest {
+            session_id,
+            transcript,
+            daemon_latency_ms,
+            daemon_audio_ms,
+        } = request;
+        info!(
+            session = %session_id,
+            daemon_latency_ms,
+            audio_ms = daemon_audio_ms,
+            "final result received in llm_query mode"
+        );
+        self.state.busy = true;
+        self.state.in_flight_session = Some(session_id);
+        let seq = self.state.next_seq(session_id);
+        runtime.reset();
+
+        let answerer = Arc::clone(&self.answerer);
+        let progress_tx = self.progress_tx.clone();
+        tokio::spawn(async move {
+            let llm_result = answerer
+                .answer(session_id, transcript.clone(), progress_tx.clone())
+                .await
+                .map_err(|err| format!("{err:#}"));
+            let _ = progress_tx.send(LlmProgress::Finished {
+                session_id,
+                transcript,
+                daemon_latency_ms,
+                daemon_audio_ms,
+                result: llm_result,
+            });
+        });
+
+        LlmStateOverlay {
+            session_id,
+            seq,
+            state: "Generating answer...".to_string(),
+        }
+    }
+
+    pub(crate) async fn recv_progress(&mut self) -> Option<LlmProgress> {
+        self.progress_rx.recv().await
+    }
+
+    pub(crate) fn handle_progress(
+        &mut self,
+        progress: LlmProgress,
+        runtime: &mut ClientSessionRuntime,
+    ) -> LlmProgressOutcome {
+        match progress {
+            LlmProgress::Delta { session_id, delta } => self
+                .record_delta(session_id, delta)
+                .map_or(LlmProgressOutcome::Ignored, LlmProgressOutcome::Delta),
+            LlmProgress::Finished {
+                session_id,
+                transcript,
+                daemon_latency_ms,
+                daemon_audio_ms,
+                result,
+            } => {
+                let Some(completion) = self.finish_answer(session_id, runtime) else {
+                    return LlmProgressOutcome::Ignored;
+                };
+                let fallback_transcript = transcript.clone();
+                let response_text = match result {
+                    Ok(answer) => {
+                        let sanitized = sanitize_model_answer(&answer);
+                        info!(
+                            session = %session_id,
+                            answer_chars = sanitized.chars().count(),
+                            "llm response completed"
+                        );
+                        sanitized
+                    }
+                    Err(error) => {
+                        warn!(
+                            session = %session_id,
+                            error = %error,
+                            "llm generation failed; falling back to raw transcript"
+                        );
+                        fallback_transcript.clone()
+                    }
+                };
+
+                let to_inject = if response_text.trim().is_empty() {
+                    warn!(
+                        session = %session_id,
+                        "llm response empty after sanitization; falling back to transcript"
+                    );
+                    fallback_transcript
+                } else {
+                    response_text
+                };
+                LlmProgressOutcome::Finished(LlmCompletedAnswer {
+                    session_id,
+                    session_end_reason: completion.session_end_reason.clone(),
+                    injection: LlmAnswerInjection::new(
+                        session_id,
+                        to_inject,
+                        daemon_latency_ms,
+                        daemon_audio_ms,
+                        completion,
+                    ),
+                })
+            }
+        }
+    }
+
+    pub(crate) fn reset_for_connection_drop(&mut self) {
+        self.state.clear();
+    }
+
+    fn record_delta(&mut self, session_id: Uuid, delta: String) -> Option<LlmDeltaOverlay> {
+        if self.state.in_flight_session != Some(session_id) {
+            debug!(
+                session = %session_id,
+                in_flight_session = ?self.state.in_flight_session,
+                "ignoring stale llm delta for non-active session"
+            );
+            return None;
+        }
+
+        let text = {
+            let entry = self.state.overlay_text.entry(session_id).or_default();
+            entry.push_str(&delta);
+            entry.clone()
+        };
+        let seq = self.state.next_seq(session_id);
+        Some(LlmDeltaOverlay {
+            session_id,
+            seq,
+            text,
+        })
+    }
+
+    fn finish_answer(
+        &mut self,
+        session_id: Uuid,
+        runtime: &ClientSessionRuntime,
+    ) -> Option<LlmCompletionContext> {
+        if self.state.in_flight_session != Some(session_id) {
+            warn!(
+                session = %session_id,
+                in_flight_session = ?self.state.in_flight_session,
+                "ignoring stale llm completion for non-active session"
+            );
+            self.state.clear_session(session_id);
+            return None;
+        }
+
+        self.state.busy = false;
+        self.state.in_flight_session = None;
+        self.state.seq.remove(&session_id);
+        self.state.overlay_text.remove(&session_id);
+        let session_end_reason = self
+            .state
+            .deferred_session_end
+            .remove(&session_id)
+            .flatten();
+        let session_end_was_deferred = session_end_reason.is_some();
+        Some(LlmCompletionContext {
+            session_end_reason,
+            session_end_was_deferred,
+            state_label: runtime.state_label(),
+            hotkey_up_elapsed_ms_at_enqueue: elapsed_ms_since(runtime.last_hotkey_up_at),
+            stop_message_elapsed_ms_at_enqueue: runtime
+                .stop_message_elapsed_ms_at_enqueue(session_id),
+        })
     }
 }
 
@@ -618,7 +896,6 @@ impl ClientSessionRuntime {
         Self {
             state: PttState::new(),
             active_intent: None,
-            llm: LlmSessionRuntime::default(),
             last_hotkey_up_at: None,
             last_stop_message: None,
         }
@@ -646,7 +923,6 @@ impl ClientSessionRuntime {
 
     pub(crate) fn reset_for_connection_drop(&mut self) {
         self.reset();
-        self.llm.clear();
         self.last_hotkey_up_at = None;
         self.last_stop_message = None;
     }
@@ -661,92 +937,6 @@ impl ClientSessionRuntime {
 
     pub(crate) fn state_label(&self) -> &'static str {
         state_label(&self.state)
-    }
-
-    pub(crate) fn is_llm_busy(&self) -> bool {
-        self.llm.busy
-    }
-
-    pub(crate) fn note_llm_busy_overlay_rejection(&mut self) -> (Uuid, u64) {
-        self.llm.busy_overlay_seq = self.llm.busy_overlay_seq.saturating_add(1);
-        (Uuid::nil(), self.llm.busy_overlay_seq)
-    }
-
-    pub(crate) fn defer_session_end_if_needed(&mut self, message: &ServerMessage) -> Option<Uuid> {
-        let ServerMessage::SessionEnded { session_id, reason } = message else {
-            return None;
-        };
-
-        let waiting_for_llm_final = self.active_intent == Some(SessionIntent::LlmQuery)
-            && self.active_session_id() == Some(*session_id);
-        let llm_generation_running = self.llm.in_flight_session == Some(*session_id);
-
-        if waiting_for_llm_final || llm_generation_running {
-            self.llm
-                .deferred_session_end
-                .insert(*session_id, reason.clone());
-            Some(*session_id)
-        } else {
-            None
-        }
-    }
-
-    pub(crate) fn start_llm_answer(&mut self, session_id: Uuid) -> u64 {
-        self.llm.busy = true;
-        self.llm.in_flight_session = Some(session_id);
-        let seq = self.llm.next_seq(session_id);
-        self.state.reset();
-        self.active_intent = None;
-        seq
-    }
-
-    pub(crate) fn record_llm_delta(
-        &mut self,
-        session_id: Uuid,
-        delta: String,
-    ) -> Option<LlmDeltaOverlay> {
-        if self.llm.in_flight_session != Some(session_id) {
-            debug!(
-                session = %session_id,
-                in_flight_session = ?self.llm.in_flight_session,
-                "ignoring stale llm delta for non-active session"
-            );
-            return None;
-        }
-
-        let text = {
-            let entry = self.llm.overlay_text.entry(session_id).or_default();
-            entry.push_str(&delta);
-            entry.clone()
-        };
-        let seq = self.llm.next_seq(session_id);
-        Some(LlmDeltaOverlay { seq, text })
-    }
-
-    pub(crate) fn finish_llm_answer(&mut self, session_id: Uuid) -> Option<LlmCompletionContext> {
-        if self.llm.in_flight_session != Some(session_id) {
-            warn!(
-                session = %session_id,
-                in_flight_session = ?self.llm.in_flight_session,
-                "ignoring stale llm completion for non-active session"
-            );
-            self.llm.clear_session(session_id);
-            return None;
-        }
-
-        self.llm.busy = false;
-        self.llm.in_flight_session = None;
-        self.llm.seq.remove(&session_id);
-        self.llm.overlay_text.remove(&session_id);
-        let session_end_reason = self.llm.deferred_session_end.remove(&session_id).flatten();
-        let session_end_was_deferred = session_end_reason.is_some();
-        Some(LlmCompletionContext {
-            session_end_reason,
-            session_end_was_deferred,
-            state_label: self.state_label(),
-            hotkey_up_elapsed_ms_at_enqueue: elapsed_ms_since(self.last_hotkey_up_at),
-            stop_message_elapsed_ms_at_enqueue: self.stop_message_elapsed_ms_at_enqueue(session_id),
-        })
     }
 
     pub(crate) fn final_result_belongs_to_active_session(&self, session_id: Uuid) -> bool {
@@ -946,6 +1136,8 @@ pub(crate) fn classify_error_code(code: &str) -> &'static str {
 #[cfg(test)]
 mod tests {
     use std::collections::VecDeque;
+    use std::future::Future;
+    use std::pin::Pin;
     use std::sync::atomic::{AtomicU64, Ordering};
     use std::sync::{Arc, Mutex};
     use std::time::{Duration, Instant};
@@ -957,6 +1149,7 @@ mod tests {
         InjectionOrigin, InjectionReport, InjectionRunError, InjectionRunOutput,
         InjectorWorkerHandle,
     };
+    use crate::llm::{LlmAnswerer, LlmDelta, LlmDeltaStream, LlmProgress};
     use crate::overlay_process::{
         OverlayProcessManager, OverlayProcessMetrics, OverlayProcessSink,
     };
@@ -973,9 +1166,92 @@ mod tests {
 
     use super::{
         handle_server_message, parent_focus_from_observation, ClientFocusRouter,
-        ClientInjectionDispatcher, ClientSessionRuntime, InjectionDispatchOutcome,
-        LlmAnswerInjection, LlmCompletionContext, LlmDeltaOverlay, SessionIntent,
+        ClientInjectionDispatcher, ClientLlmQueryRuntime, ClientSessionRuntime,
+        InjectionDispatchOutcome, LlmAnswerInjection, LlmCompletionContext, LlmDeltaOverlay,
+        LlmProgressOutcome, LlmQueryRequest, LlmStateOverlay, SessionIntent,
     };
+
+    type TestBoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+    type RecordedLlmRequests = Arc<Mutex<Vec<(Uuid, String)>>>;
+
+    struct TestLlmAnswerer {
+        requests: RecordedLlmRequests,
+        deltas: Vec<String>,
+        result: std::result::Result<String, String>,
+    }
+
+    impl TestLlmAnswerer {
+        fn successful<I, S>(
+            deltas: I,
+            answer: impl Into<String>,
+        ) -> (Arc<Self>, RecordedLlmRequests)
+        where
+            I: IntoIterator<Item = S>,
+            S: Into<String>,
+        {
+            Self::new(deltas, Ok(answer.into()))
+        }
+
+        fn failing(error: impl Into<String>) -> (Arc<Self>, RecordedLlmRequests) {
+            Self::new(std::iter::empty::<String>(), Err(error.into()))
+        }
+
+        fn new<I, S>(
+            deltas: I,
+            result: std::result::Result<String, String>,
+        ) -> (Arc<Self>, RecordedLlmRequests)
+        where
+            I: IntoIterator<Item = S>,
+            S: Into<String>,
+        {
+            let requests = Arc::new(Mutex::new(Vec::new()));
+            (
+                Arc::new(Self {
+                    requests: Arc::clone(&requests),
+                    deltas: deltas.into_iter().map(Into::into).collect(),
+                    result,
+                }),
+                requests,
+            )
+        }
+    }
+
+    impl LlmAnswerer for TestLlmAnswerer {
+        fn label(&self) -> String {
+            "test-llm".to_string()
+        }
+
+        fn stream_answer<'a>(&'a self, _prompt: &'a str) -> LlmDeltaStream<'a> {
+            Box::pin(futures::stream::empty::<anyhow::Result<LlmDelta>>())
+        }
+
+        fn health<'a>(&'a self) -> TestBoxFuture<'a, bool> {
+            Box::pin(async { true })
+        }
+
+        fn answer<'a>(
+            &'a self,
+            session_id: Uuid,
+            transcript: String,
+            progress_tx: mpsc::UnboundedSender<LlmProgress>,
+        ) -> TestBoxFuture<'a, anyhow::Result<String>> {
+            Box::pin(async move {
+                self.requests
+                    .lock()
+                    .expect("recorded LLM request lock should be available")
+                    .push((session_id, transcript));
+                for delta in &self.deltas {
+                    let _ = progress_tx.send(LlmProgress::Delta {
+                        session_id,
+                        delta: delta.clone(),
+                    });
+                }
+                self.result
+                    .clone()
+                    .map_err(|error| anyhow!("synthetic LLM failure: {error}"))
+            })
+        }
+    }
 
     struct SlowRunner {
         calls: Arc<AtomicU64>,
@@ -1181,8 +1457,11 @@ mod tests {
         );
     }
 
-    #[test]
-    fn client_session_runtime_resets_reconnect_caches() {
+    #[tokio::test(flavor = "current_thread")]
+    async fn client_llm_query_runtime_resets_reconnect_caches() {
+        let (answerer, _requests) =
+            TestLlmAnswerer::successful(std::iter::empty::<String>(), "late answer");
+        let mut llm_runtime = ClientLlmQueryRuntime::new(answerer);
         let mut runtime = ClientSessionRuntime::new();
         let session_id = runtime
             .begin_listening(SessionIntent::LlmQuery)
@@ -1190,38 +1469,73 @@ mod tests {
         runtime.stop_listening().expect("llm session should stop");
         runtime.record_stop_message_sent(session_id, TokioInstant::now());
         assert_eq!(
-            runtime.defer_session_end_if_needed(&ServerMessage::SessionEnded {
-                session_id,
-                reason: Some("connection_drop".to_string()),
-            }),
+            llm_runtime.defer_session_end_if_needed(
+                &ServerMessage::SessionEnded {
+                    session_id,
+                    reason: Some("connection_drop".to_string()),
+                },
+                &runtime,
+            ),
             Some(session_id)
         );
-        assert_eq!(runtime.start_llm_answer(session_id), 1);
         assert_eq!(
-            runtime.record_llm_delta(session_id, "partial".to_string()),
-            Some(LlmDeltaOverlay {
-                seq: 2,
-                text: "partial".to_string(),
-            })
+            llm_runtime.start_answer(
+                LlmQueryRequest::new(session_id, "prompt".to_string(), 1, 2),
+                &mut runtime,
+            ),
+            LlmStateOverlay {
+                session_id,
+                seq: 1,
+                state: "Generating answer...".to_string(),
+            }
         );
-        assert!(runtime.is_llm_busy());
-        assert_eq!(runtime.note_llm_busy_overlay_rejection(), (Uuid::nil(), 1));
+        assert!(llm_runtime.is_busy());
+        assert_eq!(
+            llm_runtime.note_busy_overlay_rejection(),
+            LlmStateOverlay {
+                session_id: Uuid::nil(),
+                seq: 1,
+                state: "LLM busy; wait for current answer".to_string(),
+            }
+        );
 
         runtime.reset_for_connection_drop();
+        llm_runtime.reset_for_connection_drop();
 
         assert_eq!(runtime.state_label(), "idle");
         assert_eq!(runtime.active_session_id(), None);
         assert_eq!(runtime.active_intent(), None);
-        assert!(!runtime.is_llm_busy());
-        assert_eq!(
-            runtime.record_llm_delta(session_id, "late".to_string()),
-            None
-        );
-        assert!(runtime.finish_llm_answer(session_id).is_none());
+        assert!(!llm_runtime.is_busy());
+        assert!(matches!(
+            llm_runtime.handle_progress(
+                LlmProgress::Delta {
+                    session_id,
+                    delta: "late".to_string(),
+                },
+                &mut runtime,
+            ),
+            LlmProgressOutcome::Ignored
+        ));
+        assert!(matches!(
+            llm_runtime.handle_progress(
+                LlmProgress::Finished {
+                    session_id,
+                    transcript: "prompt".to_string(),
+                    daemon_latency_ms: 1,
+                    daemon_audio_ms: 2,
+                    result: Ok("late answer".to_string()),
+                },
+                &mut runtime,
+            ),
+            LlmProgressOutcome::Ignored
+        ));
     }
 
-    #[test]
-    fn client_session_runtime_defers_session_end_until_llm_finish() {
+    #[tokio::test(flavor = "current_thread")]
+    async fn client_llm_query_runtime_defers_session_end_until_llm_finish() {
+        let (answerer, requests) =
+            TestLlmAnswerer::successful(["answer", " delta"], "answer delta");
+        let mut llm_runtime = ClientLlmQueryRuntime::new(answerer);
         let mut runtime = ClientSessionRuntime::new();
         let session_id = runtime
             .begin_listening(SessionIntent::LlmQuery)
@@ -1229,32 +1543,164 @@ mod tests {
         runtime.stop_listening().expect("llm session should stop");
         runtime.record_stop_message_sent(session_id, TokioInstant::now());
         assert_eq!(
-            runtime.defer_session_end_if_needed(&ServerMessage::SessionEnded {
-                session_id,
-                reason: Some("normal".to_string()),
-            }),
+            llm_runtime.defer_session_end_if_needed(
+                &ServerMessage::SessionEnded {
+                    session_id,
+                    reason: Some("normal".to_string()),
+                },
+                &runtime,
+            ),
             Some(session_id)
         );
-        assert_eq!(runtime.start_llm_answer(session_id), 1);
         assert_eq!(
-            runtime.record_llm_delta(session_id, "answer".to_string()),
-            Some(LlmDeltaOverlay {
-                seq: 2,
-                text: "answer".to_string(),
-            })
+            llm_runtime.start_answer(
+                LlmQueryRequest::new(session_id, "private prompt".to_string(), 55, 1500),
+                &mut runtime,
+            ),
+            LlmStateOverlay {
+                session_id,
+                seq: 1,
+                state: "Generating answer...".to_string(),
+            }
         );
 
-        let completion = runtime
-            .finish_llm_answer(session_id)
-            .expect("active llm completion should produce injection context");
+        let mut deltas = Vec::new();
+        let finished = timeout(Duration::from_secs(1), async {
+            loop {
+                let progress = llm_runtime
+                    .recv_progress()
+                    .await
+                    .expect("LLM progress channel should stay open");
+                match llm_runtime.handle_progress(progress, &mut runtime) {
+                    LlmProgressOutcome::Delta(delta) => deltas.push(delta),
+                    LlmProgressOutcome::Finished(answer) => break answer,
+                    LlmProgressOutcome::Ignored => {}
+                }
+            }
+        })
+        .await
+        .expect("LLM answer should finish");
 
-        assert_eq!(completion.session_end_reason.as_deref(), Some("normal"));
-        assert!(completion.session_end_was_deferred);
-        assert_eq!(completion.state_label, "idle");
-        assert!(completion.hotkey_up_elapsed_ms_at_enqueue.is_some());
-        assert!(completion.stop_message_elapsed_ms_at_enqueue.is_some());
-        assert!(!runtime.is_llm_busy());
-        assert!(runtime.finish_llm_answer(session_id).is_none());
+        assert_eq!(
+            *requests
+                .lock()
+                .expect("recorded LLM request lock should be available"),
+            vec![(session_id, "private prompt".to_string())]
+        );
+        assert_eq!(
+            deltas,
+            vec![
+                LlmDeltaOverlay {
+                    session_id,
+                    seq: 2,
+                    text: "answer".to_string(),
+                },
+                LlmDeltaOverlay {
+                    session_id,
+                    seq: 3,
+                    text: "answer delta".to_string(),
+                },
+            ]
+        );
+        assert_eq!(finished.session_id, session_id);
+        assert_eq!(finished.session_end_reason.as_deref(), Some("normal"));
+        assert_eq!(finished.injection.session_id, session_id);
+        assert_eq!(finished.injection.text, "answer delta");
+        assert_eq!(finished.injection.daemon_latency_ms, 55);
+        assert_eq!(finished.injection.daemon_audio_ms, 1500);
+        assert_eq!(
+            finished.injection.completion.session_end_reason.as_deref(),
+            Some("normal")
+        );
+        assert!(finished.injection.completion.session_end_was_deferred);
+        assert_eq!(finished.injection.completion.state_label, "idle");
+        assert!(finished
+            .injection
+            .completion
+            .hotkey_up_elapsed_ms_at_enqueue
+            .is_some());
+        assert!(finished
+            .injection
+            .completion
+            .stop_message_elapsed_ms_at_enqueue
+            .is_some());
+        assert!(!llm_runtime.is_busy());
+        assert!(matches!(
+            llm_runtime.handle_progress(
+                LlmProgress::Finished {
+                    session_id,
+                    transcript: "late prompt".to_string(),
+                    daemon_latency_ms: 1,
+                    daemon_audio_ms: 2,
+                    result: Ok("late".to_string()),
+                },
+                &mut runtime,
+            ),
+            LlmProgressOutcome::Ignored
+        ));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn client_llm_query_runtime_falls_back_to_transcript_on_failure_or_empty_answer() {
+        let (failing_answerer, _requests) = TestLlmAnswerer::failing("offline");
+        let mut runtime = ClientSessionRuntime::new();
+        let session_id = runtime
+            .begin_listening(SessionIntent::LlmQuery)
+            .expect("llm session should start");
+        runtime.stop_listening().expect("llm session should stop");
+        runtime.record_stop_message_sent(session_id, TokioInstant::now());
+        let mut failing_runtime = ClientLlmQueryRuntime::new(failing_answerer);
+        failing_runtime.start_answer(
+            LlmQueryRequest::new(session_id, "raw transcript".to_string(), 10, 20),
+            &mut runtime,
+        );
+
+        let failed = timeout(Duration::from_secs(1), async {
+            loop {
+                let progress = failing_runtime
+                    .recv_progress()
+                    .await
+                    .expect("LLM progress channel should stay open");
+                if let LlmProgressOutcome::Finished(answer) =
+                    failing_runtime.handle_progress(progress, &mut runtime)
+                {
+                    break answer;
+                }
+            }
+        })
+        .await
+        .expect("failed LLM answer should finish");
+        assert_eq!(failed.injection.text, "raw transcript");
+
+        let (empty_answerer, _requests) =
+            TestLlmAnswerer::successful(std::iter::empty::<String>(), "<think>hidden</think>");
+        let mut empty_runtime = ClientLlmQueryRuntime::new(empty_answerer);
+        let mut runtime = ClientSessionRuntime::new();
+        let session_id = runtime
+            .begin_listening(SessionIntent::LlmQuery)
+            .expect("llm session should start");
+        runtime.stop_listening().expect("llm session should stop");
+        runtime.record_stop_message_sent(session_id, TokioInstant::now());
+        empty_runtime.start_answer(
+            LlmQueryRequest::new(session_id, "fallback transcript".to_string(), 11, 21),
+            &mut runtime,
+        );
+        let empty = timeout(Duration::from_secs(1), async {
+            loop {
+                let progress = empty_runtime
+                    .recv_progress()
+                    .await
+                    .expect("LLM progress channel should stay open");
+                if let LlmProgressOutcome::Finished(answer) =
+                    empty_runtime.handle_progress(progress, &mut runtime)
+                {
+                    break answer;
+                }
+            }
+        })
+        .await
+        .expect("empty sanitized LLM answer should finish");
+        assert_eq!(empty.injection.text, "fallback transcript");
     }
 
     #[tokio::test(flavor = "current_thread")]


### PR DESCRIPTION
## Summary

- Adds `ClientLlmQueryRuntime` in the Client Session module to own local LLM query lifecycle state, progress channel/task spawning, answer delta assembly, final-answer fallback/sanitization, deferred Session-ended state, busy rejection sequencing, and connection-drop cleanup.
- Keeps `app.rs` as the hotkey/Daemon/Overlay/Injection coordinator while replacing direct LLM channel, task, and progress matching with focused LLM query outcomes.
- Adds focused Client module tests for query start, answer deltas, final answer completion, failure fallback, empty sanitized-answer fallback, busy rejection, and reconnect cleanup.

Closes #131.

## Verification (#131)

- targeted: `cargo test --manifest-path parakeet-ptt/Cargo.toml client_llm_query_runtime -- --nocapture` -> PASSED (3 tests)
- targeted: `cargo test --manifest-path parakeet-ptt/Cargo.toml app_llm -- --nocapture` -> PASSED (2 tests)
- targeted: `cargo test --manifest-path parakeet-ptt/Cargo.toml final_result_ -- --nocapture` -> PASSED (5 tests)
- targeted: `cargo test --manifest-path parakeet-ptt/Cargo.toml client_injection_dispatcher -- --nocapture` -> PASSED (3 tests)
- regression: N/A - refactor; added focused lifecycle, delta, fallback, busy, and reconnect coverage
- full suite: `cargo test --manifest-path parakeet-ptt/Cargo.toml -q` -> PASSED (87 + 156 + 12 tests)
- lint: `cargo fmt --manifest-path parakeet-ptt/Cargo.toml --check` -> PASSED
- lint: `cargo clippy --manifest-path parakeet-ptt/Cargo.toml --all-targets --all-features -- -D warnings` -> PASSED
- types: `cargo check --manifest-path parakeet-ptt/Cargo.toml --all-targets` -> PASSED
- dead-code: N/A - repo has no Rust dead-code gate for this slice
- build: N/A - Rust client refactor compiled through cargo check/clippy/test
- pre-commit: `prek run --files parakeet-ptt/src/app.rs parakeet-ptt/src/client_session.rs` -> PASSED
- pre-commit: `prek run --stage pre-push --files parakeet-ptt/src/app.rs parakeet-ptt/src/client_session.rs` -> PASSED
- pre-commit: `prek run --all-files` -> PASSED
- pre-commit: `prek run --stage pre-push --all-files` -> PASSED
- static/security: N/A - no security/static-analysis surface changed beyond lint/type/test gates above
- migrations: N/A
- CLI/script smoke: N/A - no helper or CLI flag changes
- UI render: N/A - no UI rendering surface changed
- destructive/negative: N/A - no destructive operations surface changed
- deletion test: `rg -n "llm_tx|llm_rx|LlmProgress::|answerer\\.answer\\(|sanitize_model_answer\\(&answer\\)|start_llm_answer|record_llm_delta|finish_llm_answer|is_llm_busy|note_llm_busy_overlay_rejection|defer_session_end_if_needed\\(&message\\)|LlmAnswerInjection" parakeet-ptt/src/app.rs` -> PASSED (no matches)
- review: `coderabbit_review_watch.py local -- --base main` -> Codex fallback completed cleanly because local CodeRabbit CLI errored; artifact `.git/coderabbit-review/20260522T135904Z/status.json`, report `.git/coderabbit-review/20260522T135904Z/codex-review.md`
- review: `coderabbit_review_watch.py gate --pr 149 --no-local-review --decisions .git/coderabbit-review/20260522T140643Z/decision-ledger.json --require-classified` -> clean; head `40272cf38c4dcf0d4f4379ad33a2607db12d0279`, summary `.git/coderabbit-review/20260522T141041Z/gate-summary.json`, ledger `.git/coderabbit-review/20260522T141041Z/decision-ledger.json`, remote `completed_clean`, codex-fallback yes for same-head local review
- PR feedback sweep: no review threads, no PR review comments, no blocking reviews, no actionable issue comments
- tests added/expanded: `parakeet-ptt/src/client_session.rs`; existing app LLM tests preserved in `parakeet-ptt/src/app.rs`
- preexisting failures left: none observed in this workspace