### PR TITLE
refactor(helper): centralize start profile metadata

### DIFF
--- a/parakeet-stt-daemon/tests/test_stt_helper_runtime_profiles.py
+++ b/parakeet-stt-daemon/tests/test_stt_helper_runtime_profiles.py
@@ -182,6 +182,26 @@ def _run_helper_help(topic: str) -> str:
     return completed.stdout
 
 
+def _expected_profile_help_label(profile: dict[str, str]) -> str:
+    aliases = [profile["start_cli_arg"]]
+    aliases.extend(
+        alias for alias in profile["mode_aliases"].split(",") if alias != profile["start_cli_arg"]
+    )
+    label = ",".join(aliases)
+    if profile["profile_id"] == "stream-seal":
+        return f"(default) {label}"
+    return label
+
+
+def _assert_profile_help_lines(help_text: str, profiles: list[dict[str, str]]) -> None:
+    help_lines = [line.strip() for line in help_text.splitlines()]
+    for profile in profiles:
+        matches = [line for line in help_lines if line.endswith(profile["help_description"])]
+        assert len(matches) == 1
+        rendered_label = matches[0][: -len(profile["help_description"])].rstrip()
+        assert rendered_label == _expected_profile_help_label(profile)
+
+
 def _run_get_stt_start_args_with_malformed_export() -> subprocess.CompletedProcess[str]:
     env = {
         key: value
@@ -420,10 +440,7 @@ def test_start_profile_metadata_drives_mode_aliases_and_generated_args() -> None
 def test_start_help_modes_are_generated_from_profile_metadata() -> None:
     help_text = _run_helper_help("start")
 
-    for profile in _run_start_profile_rows():
-        for alias in profile["mode_aliases"].split(","):
-            assert alias in help_text
-        assert profile["help_description"] in help_text
+    _assert_profile_help_lines(help_text, _run_start_profile_rows())
 
 
 def test_llm_help_modes_are_generated_from_profile_metadata() -> None:
@@ -434,10 +451,7 @@ def test_llm_help_modes_are_generated_from_profile_metadata() -> None:
     assert f"stt llm [{profile_choices}]" in help_text
     assert f"stt llm start [{profile_choices}]" in help_text
     assert f"stt llm restart [{profile_choices}]" in help_text
-    for profile in profiles:
-        for alias in profile["mode_aliases"].split(","):
-            assert alias in help_text
-        assert profile["help_description"] in help_text
+    _assert_profile_help_lines(help_text, profiles)
 
 
 def test_profile_overlay_env_overrides_metadata_defaults() -> None:

--- a/parakeet-stt-daemon/tests/test_stt_helper_runtime_profiles.py
+++ b/parakeet-stt-daemon/tests/test_stt_helper_runtime_profiles.py
@@ -182,6 +182,50 @@ def _run_helper_help(topic: str) -> str:
     return completed.stdout
 
 
+def _run_helper_variable_scope_probe() -> dict[str, str]:
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("PARAKEET_") and not key.startswith("_STT_")
+    }
+    env["PARAKEET_ROOT"] = str(REPO_ROOT)
+    env["_STT_SKIP_LOCAL_OVERRIDES"] = "1"
+
+    command = [
+        "bash",
+        "-lc",
+        (
+            f"source {shlex.quote(str(HELPER_PATH))} && "
+            "row=outer-row && "
+            "command_aliases=outer-command-aliases && "
+            "start_cli_arg=outer-start-cli-arg && "
+            "export command_aliases && "
+            "stt help >/dev/null && "
+            "printf 'row=%s\\n' \"$row\" && "
+            "printf 'command_aliases=%s\\n' \"$command_aliases\" && "
+            "printf 'start_cli_arg=%s\\n' \"$start_cli_arg\" && "
+            "if export -p | "
+            "grep -F 'declare -x command_aliases=\"outer-command-aliases\"' >/dev/null; "
+            "then printf 'command_aliases_exported=true\\n'; "
+            "else printf 'command_aliases_exported=false\\n'; fi"
+        ),
+    ]
+    completed = subprocess.run(
+        command,
+        check=True,
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+
+    values: dict[str, str] = {}
+    for line in completed.stdout.splitlines():
+        key, value = line.split("=", 1)
+        values[key] = value
+    return values
+
+
 def _expected_profile_help_label(profile: dict[str, str]) -> str:
     aliases = [profile["start_cli_arg"]]
     aliases.extend(
@@ -435,6 +479,17 @@ def test_start_profile_metadata_drives_mode_aliases_and_generated_args() -> None
 
         args = _run_get_stt_start_args(profile["start_cli_arg"])
         assert args[0] == profile["start_cli_arg"]
+
+
+def test_start_profile_alias_scan_does_not_leak_shell_variables() -> None:
+    values = _run_helper_variable_scope_probe()
+
+    assert values == {
+        "row": "outer-row",
+        "command_aliases": "outer-command-aliases",
+        "start_cli_arg": "outer-start-cli-arg",
+        "command_aliases_exported": "true",
+    }
 
 
 def test_start_help_modes_are_generated_from_profile_metadata() -> None:

--- a/parakeet-stt-daemon/tests/test_stt_helper_runtime_profiles.py
+++ b/parakeet-stt-daemon/tests/test_stt_helper_runtime_profiles.py
@@ -509,6 +509,48 @@ def test_llm_help_modes_are_generated_from_profile_metadata() -> None:
     _assert_profile_help_lines(help_text, profiles)
 
 
+def test_llm_direct_profile_forwards_remaining_start_args_once(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    for command_name in ("curl", "llama-server", "tmux"):
+        _write_fake_command(fake_bin, command_name, "#!/usr/bin/env bash\nexit 0\n")
+    for command_name in ("lsof", "ss"):
+        _write_fake_command(fake_bin, command_name, "#!/usr/bin/env bash\nexit 1\n")
+
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("PARAKEET_") and not key.startswith("_STT_")
+    }
+    env.update(
+        {
+            "PARAKEET_ROOT": str(REPO_ROOT),
+            "PARAKEET_LLM_SERVER_EXTRA_ARGS": "--test-no-model",
+            "PATH": f"{fake_bin}:{env['PATH']}",
+            "_STT_SKIP_LOCAL_OVERRIDES": "1",
+        }
+    )
+
+    llm_pid_file = Path("/tmp/parakeet-llama-server.pid")
+    llm_port_file = Path("/tmp/parakeet-llama-server.port")
+    with _preserve_paths(llm_pid_file, llm_port_file):
+        completed = subprocess.run(
+            [
+                "bash",
+                "-lc",
+                f"source {shlex.quote(str(HELPER_PATH))} && stt llm cpu --stt-test-sentinel",
+            ],
+            check=False,
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+        )
+
+    assert "Unknown option for 'stt start': --stt-test-sentinel" in completed.stdout
+    assert "Unknown option for 'stt start': cpu" not in completed.stdout
+
+
 def test_profile_overlay_env_overrides_metadata_defaults() -> None:
     config = _run_runtime_config(
         "offline",

--- a/parakeet-stt-daemon/tests/test_stt_helper_runtime_profiles.py
+++ b/parakeet-stt-daemon/tests/test_stt_helper_runtime_profiles.py
@@ -26,6 +26,18 @@ from parakeet_stt_daemon.messages import (
 REPO_ROOT = Path(__file__).resolve().parents[2]
 HELPER_PATH = REPO_ROOT / "scripts" / "stt-helper.sh"
 FIXTURE_DIR = REPO_ROOT / "docs" / "protocol" / "fixtures"
+START_PROFILE_ROW_FIELDS = (
+    "profile_id",
+    "mode_aliases",
+    "command_aliases",
+    "start_cli_arg",
+    "daemon_streaming_enabled",
+    "daemon_device_override",
+    "overlay_enabled_default",
+    "overlay_adaptive_width_default",
+    "help_label",
+    "help_description",
+)
 
 
 @contextmanager
@@ -114,6 +126,61 @@ def _run_get_stt_start_args(
         capture_output=True,
     )
     return [item.decode() for item in completed.stdout.split(b"\0") if item]
+
+
+def _run_start_profile_rows() -> list[dict[str, str]]:
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("PARAKEET_") and not key.startswith("_STT_")
+    }
+    env["PARAKEET_ROOT"] = str(REPO_ROOT)
+    env["_STT_SKIP_LOCAL_OVERRIDES"] = "1"
+
+    command = [
+        "bash",
+        "-lc",
+        f"source {shlex.quote(str(HELPER_PATH))} && stt __start-profile-rows",
+    ]
+    completed = subprocess.run(
+        command,
+        check=True,
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+    rows: list[dict[str, str]] = []
+    for line in completed.stdout.splitlines():
+        values = line.split("|")
+        assert len(values) == len(START_PROFILE_ROW_FIELDS)
+        rows.append(dict(zip(START_PROFILE_ROW_FIELDS, values, strict=True)))
+    return rows
+
+
+def _run_start_help() -> str:
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("PARAKEET_") and not key.startswith("_STT_")
+    }
+    env["PARAKEET_ROOT"] = str(REPO_ROOT)
+    env["_STT_SKIP_LOCAL_OVERRIDES"] = "1"
+
+    command = [
+        "bash",
+        "-lc",
+        f"source {shlex.quote(str(HELPER_PATH))} && stt help start",
+    ]
+    completed = subprocess.run(
+        command,
+        check=True,
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+    return completed.stdout
 
 
 def _run_get_stt_start_args_with_malformed_export() -> subprocess.CompletedProcess[str]:
@@ -322,6 +389,55 @@ def test_offline_profile_resolves_cuda_without_streaming() -> None:
     assert config["daemon_device"] == "cuda"
     assert config["daemon_streaming_enabled"] == "false"
     assert config["daemon_overlay_events_enabled"] == "false"
+
+
+def test_start_profile_metadata_drives_runtime_defaults() -> None:
+    profiles = _run_start_profile_rows()
+
+    assert [profile["profile_id"] for profile in profiles] == ["stream-seal", "offline", "cpu"]
+    for profile in profiles:
+        args = () if profile["profile_id"] == "stream-seal" else (profile["start_cli_arg"],)
+        config = _run_runtime_config(*args)
+        expected_device = profile["daemon_device_override"] or "cuda"
+
+        assert config["launch_profile"] == profile["profile_id"]
+        assert config["daemon_device"] == expected_device
+        assert config["daemon_streaming_enabled"] == profile["daemon_streaming_enabled"]
+        assert config["overlay_enabled"] == profile["overlay_enabled_default"]
+        assert config["overlay_adaptive_width"] == profile["overlay_adaptive_width_default"]
+        assert config["daemon_overlay_events_enabled"] == profile["overlay_enabled_default"]
+
+
+def test_start_profile_metadata_drives_mode_aliases_and_generated_args() -> None:
+    for profile in _run_start_profile_rows():
+        for alias in profile["mode_aliases"].split(","):
+            config = _run_runtime_config(alias)
+            assert config["launch_profile"] == profile["profile_id"]
+
+        args = _run_get_stt_start_args(profile["start_cli_arg"])
+        assert args[0] == profile["start_cli_arg"]
+
+
+def test_start_help_modes_are_generated_from_profile_metadata() -> None:
+    help_text = _run_start_help()
+
+    for profile in _run_start_profile_rows():
+        assert profile["help_label"] in help_text
+        assert profile["help_description"] in help_text
+
+
+def test_profile_overlay_env_overrides_metadata_defaults() -> None:
+    config = _run_runtime_config(
+        "offline",
+        extra_env={
+            "PARAKEET_OVERLAY_ENABLED": "true",
+            "PARAKEET_OVERLAY_ADAPTIVE_WIDTH": "true",
+        },
+    )
+
+    assert config["overlay_enabled"] == "true"
+    assert config["overlay_adaptive_width"] == "true"
+    assert config["daemon_overlay_events_enabled"] == "true"
 
 
 def test_helper_endpoint_defaults_match_daemon_settings() -> None:

--- a/parakeet-stt-daemon/tests/test_stt_helper_runtime_profiles.py
+++ b/parakeet-stt-daemon/tests/test_stt_helper_runtime_profiles.py
@@ -35,7 +35,6 @@ START_PROFILE_ROW_FIELDS = (
     "daemon_device_override",
     "overlay_enabled_default",
     "overlay_adaptive_width_default",
-    "help_label",
     "help_description",
 )
 
@@ -158,7 +157,7 @@ def _run_start_profile_rows() -> list[dict[str, str]]:
     return rows
 
 
-def _run_start_help() -> str:
+def _run_helper_help(topic: str) -> str:
     env = {
         key: value
         for key, value in os.environ.items()
@@ -170,7 +169,7 @@ def _run_start_help() -> str:
     command = [
         "bash",
         "-lc",
-        f"source {shlex.quote(str(HELPER_PATH))} && stt help start",
+        f"source {shlex.quote(str(HELPER_PATH))} && stt help {shlex.quote(topic)}",
     ]
     completed = subprocess.run(
         command,
@@ -419,10 +418,25 @@ def test_start_profile_metadata_drives_mode_aliases_and_generated_args() -> None
 
 
 def test_start_help_modes_are_generated_from_profile_metadata() -> None:
-    help_text = _run_start_help()
+    help_text = _run_helper_help("start")
 
     for profile in _run_start_profile_rows():
-        assert profile["help_label"] in help_text
+        for alias in profile["mode_aliases"].split(","):
+            assert alias in help_text
+        assert profile["help_description"] in help_text
+
+
+def test_llm_help_modes_are_generated_from_profile_metadata() -> None:
+    profiles = _run_start_profile_rows()
+    help_text = _run_helper_help("llm")
+    profile_choices = "|".join(profile["start_cli_arg"] for profile in profiles)
+
+    assert f"stt llm [{profile_choices}]" in help_text
+    assert f"stt llm start [{profile_choices}]" in help_text
+    assert f"stt llm restart [{profile_choices}]" in help_text
+    for profile in profiles:
+        for alias in profile["mode_aliases"].split(","):
+            assert alias in help_text
         assert profile["help_description"] in help_text
 
 

--- a/scripts/stt-helper.sh
+++ b/scripts/stt-helper.sh
@@ -191,9 +191,9 @@ stt() {
     )
     local start_profile_default="stream-seal"
     local -a start_profile_rows=(
-        "stream-seal|stream,streaming,on|stream,on|streaming|true||true|false|(default) streaming,stream,on|Launch daemon with stream+seal + overlay defaults."
-        "offline|offline,off|off|offline|false||false|false|offline,off|Launch daemon with streaming disabled."
-        "cpu|cpu|cpu|cpu|false|cpu|false|false|cpu|Launch daemon in offline mode on CPU (no GPU)."
+        "stream-seal|stream,streaming,on|stream,on|streaming|true||true|false|Launch daemon with stream+seal + overlay defaults."
+        "offline|offline,off|off|offline|false||false|false|Launch daemon with streaming disabled."
+        "cpu|cpu|cpu|cpu|false|cpu|false|false|Launch daemon in offline mode on CPU (no GPU)."
     )
     : "$default_injection_mode" "$default_paste_backend_failure_policy" "$default_uinput_dwell_ms"
     : "$default_paste_seat" "$default_paste_write_primary" "$default_completion_sound"
@@ -247,10 +247,10 @@ stt() {
 
     _apply_launch_profile_defaults() {
         local profile="$1"
-        local daemon_device_override overlay_enabled_default overlay_adaptive_width_default help_label help_description
+        local daemon_device_override overlay_enabled_default overlay_adaptive_width_default help_description
         local row
         row="$(_start_profile_row_for_id "$profile")" || return 1
-        IFS='|' read -r _ _ _ _ _ daemon_device_override overlay_enabled_default overlay_adaptive_width_default help_label help_description <<<"$row"
+        IFS='|' read -r _ _ _ _ _ daemon_device_override overlay_enabled_default overlay_adaptive_width_default help_description <<<"$row"
         if [ -n "$daemon_device_override" ]; then
             default_daemon_device="$daemon_device_override"
         fi
@@ -277,10 +277,38 @@ stt() {
         printf "%s" "$daemon_streaming_enabled"
     }
 
-    _print_start_profile_modes() {
-        local row help_label help_description
+    _start_profile_help_label() {
+        local profile_id="$1"
+        local mode_aliases="$2"
+        local start_cli_arg="$3"
+        local label="$start_cli_arg"
+        local alias
+        local -a aliases
+        IFS=',' read -r -a aliases <<<"$mode_aliases"
+        for alias in "${aliases[@]}"; do
+            [ "$alias" = "$start_cli_arg" ] && continue
+            label="$label,$alias"
+        done
+        if [ "$profile_id" = "$start_profile_default" ]; then
+            label="(default) $label"
+        fi
+        printf "%s" "$label"
+    }
+
+    _start_profile_cli_choices() {
+        local row start_cli_arg sep=""
         for row in "${start_profile_rows[@]}"; do
-            IFS='|' read -r _ _ _ _ _ _ _ _ help_label help_description <<<"$row"
+            IFS='|' read -r _ _ _ start_cli_arg _ <<<"$row"
+            printf "%s%s" "$sep" "$start_cli_arg"
+            sep="|"
+        done
+    }
+
+    _print_start_profile_modes() {
+        local row profile_id mode_aliases start_cli_arg help_label help_description
+        for row in "${start_profile_rows[@]}"; do
+            IFS='|' read -r profile_id mode_aliases _ start_cli_arg _ _ _ _ help_description <<<"$row"
+            help_label="$(_start_profile_help_label "$profile_id" "$mode_aliases" "$start_cli_arg")"
             printf "  %-30s %s\n" "$help_label" "$help_description"
         done
     }
@@ -1190,9 +1218,11 @@ EOF
     }
     _print_help_start() {
         _apply_launch_profile_defaults "$start_profile_default"
+        local profile_choices
+        profile_choices="$(_start_profile_cli_choices)"
         cat <<EOF
 Usage:
-  stt start [streaming|offline|cpu] [options]
+  stt start [$profile_choices] [options]
 
 Modes:
 EOF
@@ -1222,12 +1252,14 @@ EOF
     }
 
     _print_help_llm() {
+        local profile_choices
+        profile_choices="$(_start_profile_cli_choices)"
         cat <<EOF
 Usage:
-  stt llm [streaming|offline] [stt-start-options...]
-  stt llm start [streaming|offline] [stt-start-options...]
+  stt llm [$profile_choices] [stt-start-options...]
+  stt llm start [$profile_choices] [stt-start-options...]
   stt llm stop
-  stt llm restart [streaming|offline] [stt-start-options...]
+  stt llm restart [$profile_choices] [stt-start-options...]
   stt llm status
   stt llm logs
   stt llm show
@@ -1238,6 +1270,11 @@ Behavior:
   stt llm status        Show managed llama status, then normal STT status.
   stt llm logs          Tail /tmp/parakeet-llama-server.log.
   stt llm show          Attach to the llama tmux session.
+
+Profiles:
+EOF
+        _print_start_profile_modes
+        cat <<EOF
 
 Managed llama configuration (use shell env or $LOCAL_ENV_FILE):
   PARAKEET_LLM_SERVER_BIN=$default_llm_server_bin

--- a/scripts/stt-helper.sh
+++ b/scripts/stt-helper.sh
@@ -205,8 +205,9 @@ stt() {
 
     local cmd="${1:-start}"
     shift || true
+    local row _profile_id _mode_aliases command_aliases start_cli_arg _profile_remainder
     for row in "${start_profile_rows[@]}"; do
-        IFS='|' read -r _ _ command_aliases start_cli_arg _ <<<"$row"
+        IFS='|' read -r _profile_id _mode_aliases command_aliases start_cli_arg _profile_remainder <<<"$row"
         case ",$command_aliases," in
             *",$cmd,"*)
                 cmd="start"

--- a/scripts/stt-helper.sh
+++ b/scripts/stt-helper.sh
@@ -189,6 +189,12 @@ stt() {
         "llm-system-prompt|llm_system_prompt|default_llm_system_prompt|PARAKEET_LLM_SYSTEM_PROMPT|Stable controls|<text>|<assistant prompt>|nonempty|"
         "llm-overlay-stream|llm_overlay_stream|default_llm_overlay_stream|PARAKEET_LLM_OVERLAY_STREAM|Stable controls|<v>|true|always|true"
     )
+    local start_profile_default="stream-seal"
+    local -a start_profile_rows=(
+        "stream-seal|stream,streaming,on|stream,on|streaming|true||true|false|(default) streaming,stream,on|Launch daemon with stream+seal + overlay defaults."
+        "offline|offline,off|off|offline|false||false|false|offline,off|Launch daemon with streaming disabled."
+        "cpu|cpu|cpu|cpu|false|cpu|false|false|cpu|Launch daemon in offline mode on CPU (no GPU)."
+    )
     : "$default_injection_mode" "$default_paste_backend_failure_policy" "$default_uinput_dwell_ms"
     : "$default_paste_seat" "$default_paste_write_primary" "$default_completion_sound"
     : "$default_completion_sound_path" "$default_completion_sound_volume"
@@ -199,56 +205,91 @@ stt() {
 
     local cmd="${1:-start}"
     shift || true
-    if [ "$cmd" = "stream" ]; then
-        cmd="start"
-        set -- streaming "$@"
-    elif [ "$cmd" = "off" ]; then
-        cmd="start"
-        set -- offline "$@"
-    elif [ "$cmd" = "on" ]; then
-        cmd="start"
-        set -- streaming "$@"
-    elif [ "$cmd" = "cpu" ]; then
-        cmd="start"
-        set -- cpu "$@"
-    fi
+    for row in "${start_profile_rows[@]}"; do
+        IFS='|' read -r _ _ command_aliases start_cli_arg _ <<<"$row"
+        case ",$command_aliases," in
+            *",$cmd,"*)
+                cmd="start"
+                set -- "$start_cli_arg" "$@"
+                break
+                ;;
+        esac
+    done
+
+    _start_profile_row_for_id() {
+        local target="$1"
+        local row profile_id
+        for row in "${start_profile_rows[@]}"; do
+            IFS='|' read -r profile_id _ <<<"$row"
+            if [ "$profile_id" = "$target" ]; then
+                printf "%s\n" "$row"
+                return 0
+            fi
+        done
+        return 1
+    }
+
+    _start_profile_row_for_token() {
+        local token="$1"
+        local row mode_aliases
+        [ -n "$token" ] || return 1
+        for row in "${start_profile_rows[@]}"; do
+            IFS='|' read -r _ mode_aliases _ <<<"$row"
+            case ",$mode_aliases," in
+                *",$token,"*)
+                    printf "%s\n" "$row"
+                    return 0
+                    ;;
+            esac
+        done
+        return 1
+    }
 
     _apply_launch_profile_defaults() {
         local profile="$1"
-        if [ "$profile" = "stream-seal" ]; then
-            # Keep "stt" ergonomic for daily use: online stream+seal with overlay,
-            # but non-adaptive width so rendering remains predictable.
-            if [ -z "${PARAKEET_OVERLAY_ENABLED+x}" ]; then
-                default_overlay_enabled="true"
-            fi
-            if [ -z "${PARAKEET_OVERLAY_ADAPTIVE_WIDTH+x}" ]; then
-                default_overlay_adaptive_width="false"
-            fi
-            : "$default_overlay_enabled" "$default_overlay_adaptive_width"
-            return 0
+        local daemon_device_override overlay_enabled_default overlay_adaptive_width_default help_label help_description
+        local row
+        row="$(_start_profile_row_for_id "$profile")" || return 1
+        IFS='|' read -r _ _ _ _ _ daemon_device_override overlay_enabled_default overlay_adaptive_width_default help_label help_description <<<"$row"
+        if [ -n "$daemon_device_override" ]; then
+            default_daemon_device="$daemon_device_override"
         fi
-
-        if [ "$profile" = "offline" ]; then
-            # "stt off" favors fastest accurate offline dictation with no overlay.
-            if [ -z "${PARAKEET_OVERLAY_ENABLED+x}" ]; then
-                default_overlay_enabled="false"
-            fi
-            if [ -z "${PARAKEET_OVERLAY_ADAPTIVE_WIDTH+x}" ]; then
-                default_overlay_adaptive_width="false"
-            fi
+        if [ -n "$overlay_enabled_default" ] && [ -z "${PARAKEET_OVERLAY_ENABLED+x}" ]; then
+            default_overlay_enabled="$overlay_enabled_default"
         fi
-
-        if [ "$profile" = "cpu" ]; then
-            # "stt cpu" runs offline on CPU; no streaming, no overlay.
-            default_daemon_device="cpu"
-            if [ -z "${PARAKEET_OVERLAY_ENABLED+x}" ]; then
-                default_overlay_enabled="false"
-            fi
-            if [ -z "${PARAKEET_OVERLAY_ADAPTIVE_WIDTH+x}" ]; then
-                default_overlay_adaptive_width="false"
-            fi
+        if [ -n "$overlay_adaptive_width_default" ] && [ -z "${PARAKEET_OVERLAY_ADAPTIVE_WIDTH+x}" ]; then
+            default_overlay_adaptive_width="$overlay_adaptive_width_default"
         fi
         : "$default_overlay_enabled" "$default_overlay_adaptive_width"
+    }
+
+    _start_profile_cli_arg() {
+        local row start_cli_arg
+        row="$(_start_profile_row_for_id "$1")" || return 1
+        IFS='|' read -r _ _ _ start_cli_arg _ <<<"$row"
+        printf "%s" "$start_cli_arg"
+    }
+
+    _start_profile_daemon_streaming_enabled() {
+        local row daemon_streaming_enabled
+        row="$(_start_profile_row_for_id "$1")" || return 1
+        IFS='|' read -r _ _ _ _ daemon_streaming_enabled _ <<<"$row"
+        printf "%s" "$daemon_streaming_enabled"
+    }
+
+    _print_start_profile_modes() {
+        local row help_label help_description
+        for row in "${start_profile_rows[@]}"; do
+            IFS='|' read -r _ _ _ _ _ _ _ _ help_label help_description <<<"$row"
+            printf "  %-30s %s\n" "$help_label" "$help_description"
+        done
+    }
+
+    _print_start_profile_rows() {
+        local row
+        for row in "${start_profile_rows[@]}"; do
+            printf "%s\n" "$row"
+        done
     }
 
     _start_option_exists() {
@@ -329,19 +370,10 @@ stt() {
     _build_start_cli_args() {
         local -n start_cli_args_ref="$1"
         local launch_profile="$2"
-        local row opt_name var_name include_policy
+        local row opt_name var_name include_policy start_cli_arg
         start_cli_args_ref=()
-        case "$launch_profile" in
-            offline)
-                start_cli_args_ref+=(offline)
-                ;;
-            cpu)
-                start_cli_args_ref+=(cpu)
-                ;;
-            *)
-                start_cli_args_ref+=(streaming)
-                ;;
-        esac
+        start_cli_arg="$(_start_profile_cli_arg "$launch_profile")" || return 1
+        start_cli_args_ref+=("$start_cli_arg")
         for row in "${start_option_rows[@]}"; do
             IFS='|' read -r opt_name var_name _ _ _ _ _ include_policy _ <<<"$row"
             if [ "$include_policy" = "nonempty" ] && [ -z "${!var_name}" ]; then
@@ -456,44 +488,29 @@ stt() {
     _resolve_start_launch_profile() {
         local -n launch_profile_ref="$1"
         local candidate="${2:-}"
-        launch_profile_ref="stream-seal"
-        case "$candidate" in
-            stream|streaming|on)
-                return 0
-                ;;
-            offline|off)
-                launch_profile_ref="offline"
-                return 0
-                ;;
-            cpu)
-                launch_profile_ref="cpu"
-                : "$launch_profile_ref"
-                return 0
-                ;;
-            *)
-                return 1
-                ;;
-        esac
+        local row profile_id
+        launch_profile_ref="$start_profile_default"
+        row="$(_start_profile_row_for_token "$candidate")" || return 1
+        IFS='|' read -r profile_id _ <<<"$row"
+        launch_profile_ref="$profile_id"
+        : "$launch_profile_ref"
+        return 0
     }
 
     _resolve_start_runtime_config() {
         local launch_profile="$1"
         shift
 
-        _apply_launch_profile_defaults "$launch_profile"
+        _apply_launch_profile_defaults "$launch_profile" || return 1
         _load_start_vars_from_defaults
 
         daemon_device="$default_daemon_device"
-        daemon_streaming_enabled="$default_daemon_streaming_enabled"
+        daemon_streaming_enabled="$(_start_profile_daemon_streaming_enabled "$launch_profile")" || return 1
         daemon_chunk_secs="$default_daemon_chunk_secs"
         daemon_right_context_secs="$default_daemon_right_context_secs"
         daemon_left_context_secs="$default_daemon_left_context_secs"
         daemon_batch_size="$default_daemon_batch_size"
         daemon_overlay_events_enabled="false"
-
-        if [ "$launch_profile" = "stream-seal" ]; then
-            daemon_streaming_enabled="true"
-        fi
 
         local parse_status=0
         _parse_start_options "$@" || parse_status=$?
@@ -1172,16 +1189,15 @@ Commands:
 EOF
     }
     _print_help_start() {
-        _apply_launch_profile_defaults "stream-seal"
+        _apply_launch_profile_defaults "$start_profile_default"
         cat <<EOF
 Usage:
   stt start [streaming|offline|cpu] [options]
 
 Modes:
-  (default) streaming    Launch daemon with stream+seal + overlay defaults.
-  streaming|stream       Launch daemon with stream+seal enabled.
-  offline|off            Launch daemon with streaming disabled.
-  cpu                    Launch daemon in offline mode on CPU (no GPU).
+EOF
+        _print_start_profile_modes
+        cat <<EOF
 
 Injection mode:
   --paste                              Alias for --injection-mode paste
@@ -1266,6 +1282,32 @@ EOF
 CLIENTCMD
     }
 
+    _start_managed_llm_then_stt() {
+        local llm_base_url
+        echo ">>> Starting managed llama + Parakeet STT..."
+        echo "   - LLM binary: $default_llm_server_bin"
+        echo "   - LLM model path: ${default_llm_server_model_path:-<unset>}"
+        echo "   - LLM model alias: $default_llm_server_model_alias"
+        echo "   - LLM API base URL: $(_llm_api_base_url)"
+        echo "   - LLM context/gpu/parallel: ${default_llm_server_ctx_size}/${default_llm_server_gpu_layers}/${default_llm_server_parallel}"
+        echo "   - LLM metrics: $default_llm_server_metrics"
+        if ! _ensure_llm_server; then
+            return 1
+        fi
+        if ! llm_base_url="$(_llm_api_base_url)"; then
+            echo "   - Failed to resolve managed LLM API base URL."
+            return 1
+        fi
+        if [ -z "$llm_base_url" ]; then
+            echo "   - Managed LLM API base URL is empty."
+            return 1
+        fi
+        export PARAKEET_LLM_BASE_URL="$llm_base_url"
+        export PARAKEET_LLM_MODEL="$default_llm_server_model_alias"
+        local _STT_SKIP_LOCAL_OVERRIDES=1
+        stt start "$@"
+    }
+
     case "$cmd" in
         help|--help|-h)
             case "${1:-}" in
@@ -1288,6 +1330,9 @@ CLIENTCMD
             ;;
         __start-option-names)
             _print_start_option_names
+            ;;
+        __start-profile-rows)
+            _print_start_profile_rows
             ;;
         __start-args)
             local injection_mode paste_backend_failure_policy
@@ -1387,6 +1432,8 @@ daemon_chunk_secs=$daemon_chunk_secs
 daemon_right_context_secs=$daemon_right_context_secs
 daemon_left_context_secs=$daemon_left_context_secs
 daemon_batch_size=$daemon_batch_size
+overlay_enabled=$overlay_enabled
+overlay_adaptive_width=$overlay_adaptive_width
 daemon_host=$HOST
 daemon_port=$PORT
 daemon_websocket_endpoint=$(_daemon_ws_endpoint)
@@ -1653,52 +1700,10 @@ EOF
                     ;;
                 start|"")
                     [ "$llm_action" = "start" ] && shift
-                    local llm_base_url
-                    echo ">>> Starting managed llama + Parakeet STT..."
-                    echo "   - LLM binary: $default_llm_server_bin"
-                    echo "   - LLM model path: ${default_llm_server_model_path:-<unset>}"
-                    echo "   - LLM model alias: $default_llm_server_model_alias"
-                    echo "   - LLM API base URL: $(_llm_api_base_url)"
-                    echo "   - LLM context/gpu/parallel: ${default_llm_server_ctx_size}/${default_llm_server_gpu_layers}/${default_llm_server_parallel}"
-                    echo "   - LLM metrics: $default_llm_server_metrics"
-                    if ! _ensure_llm_server; then
-                        return 1
-                    fi
-                    if ! llm_base_url="$(_llm_api_base_url)"; then
-                        echo "   - Failed to resolve managed LLM API base URL."
-                        return 1
-                    fi
-                    if [ -z "$llm_base_url" ]; then
-                        echo "   - Managed LLM API base URL is empty."
-                        return 1
-                    fi
-                    export PARAKEET_LLM_BASE_URL="$llm_base_url"
-                    export PARAKEET_LLM_MODEL="$default_llm_server_model_alias"
-                    local _STT_SKIP_LOCAL_OVERRIDES=1
-                    stt start "$@"
+                    _start_managed_llm_then_stt "$@"
                     ;;
-                stream|streaming|offline|off|on|cpu|--*)
-                    local llm_base_url
-                    echo ">>> Starting managed llama + Parakeet STT..."
-                    echo "   - LLM binary: $default_llm_server_bin"
-                    echo "   - LLM model path: ${default_llm_server_model_path:-<unset>}"
-                    echo "   - LLM model alias: $default_llm_server_model_alias"
-                    echo "   - LLM API base URL: $(_llm_api_base_url)"
-                    if ! _ensure_llm_server; then
-                        return 1
-                    fi
-                    if ! llm_base_url="$(_llm_api_base_url)"; then
-                        echo "   - Failed to resolve managed LLM API base URL."
-                        return 1
-                    fi
-                    if [ -z "$llm_base_url" ]; then
-                        echo "   - Managed LLM API base URL is empty."
-                        return 1
-                    fi
-                    export PARAKEET_LLM_BASE_URL="$llm_base_url"
-                    export PARAKEET_LLM_MODEL="$default_llm_server_model_alias"
-                    local _STT_SKIP_LOCAL_OVERRIDES=1
-                    stt start "$llm_action" "$@"
+                --*)
+                    _start_managed_llm_then_stt "$llm_action" "$@"
                     ;;
                 restart)
                     shift
@@ -1746,6 +1751,10 @@ EOF
                     fi
                     ;;
                 *)
+                    if _start_profile_row_for_token "$llm_action" >/dev/null; then
+                        _start_managed_llm_then_stt "$llm_action" "$@"
+                        return $?
+                    fi
                     echo "Unknown llm subcommand: $llm_action"
                     echo
                     _print_help_llm
@@ -1755,8 +1764,9 @@ EOF
             ;;
         restart)
             local restart_mode=""
-            if [ "${1:-}" = "stream" ] || [ "${1:-}" = "streaming" ] || [ "${1:-}" = "offline" ] || [ "${1:-}" = "cpu" ]; then
-                restart_mode="$1"
+            local restart_launch_profile
+            if _resolve_start_launch_profile restart_launch_profile "${1:-}"; then
+                restart_mode="$(_start_profile_cli_arg "$restart_launch_profile")"
                 shift
             fi
             stt stop

--- a/scripts/stt-helper.sh
+++ b/scripts/stt-helper.sh
@@ -1790,6 +1790,7 @@ EOF
                     ;;
                 *)
                     if _start_profile_row_for_token "$llm_action" >/dev/null; then
+                        shift
                         _start_managed_llm_then_stt "$llm_action" "$@"
                         return $?
                     fi


### PR DESCRIPTION
## Summary

- Adds `start_profile_rows` as the Helper profile metadata interface for `stream-seal`, `offline`, and `cpu` launch profiles.
- Derives start command aliases, mode parsing, generated `stt start` args, profile overlay/device defaults, daemon streaming env, `stt start`/`stt llm` help mode text, restart dispatch, and managed-LLM profile dispatch from that metadata.
- Expands helper profile tests so runtime config, mode aliases, generated args, help text, token-aware rendered profile labels, sourced-shell variable locality, direct LLM profile forwarding, and env override precedence all reflect the same metadata rows.

Closes #132.

## Verification (#132)

- targeted: `uv run pytest -q tests/test_stt_helper_runtime_profiles.py` -> PASSED (37 passed)
- regression: profile metadata tests cover runtime defaults, mode aliases, generated start args, start/LLM help mode text, token-aware rendered profile labels, sourced-shell variable locality, direct LLM profile forwarding, and overlay env override precedence -> PASSED
- full suite: `uv run pytest -q` -> PASSED (220 passed)
- lint: `bash -n scripts/stt-helper.sh` -> PASSED
- lint: `shellcheck scripts/stt-helper.sh` -> PASSED
- lint: `uv run ruff format --check tests/test_stt_helper_runtime_profiles.py` -> PASSED
- lint: `uv run ruff check tests/test_stt_helper_runtime_profiles.py` -> PASSED
- types: `ty check --project parakeet-stt-daemon --error-on-warning` -> PASSED
- dead-code: N/A - shell/Python helper profile refactor; repo has no dead-code gate for this slice
- build: N/A - no package build output changed; helper/runtime behavior covered by shell and test gates
- pre-commit: `prek run --files scripts/stt-helper.sh parakeet-stt-daemon/tests/test_stt_helper_runtime_profiles.py` -> PASSED
- pre-commit: `prek run --files parakeet-stt-daemon/tests/test_stt_helper_runtime_profiles.py` -> PASSED
- pre-commit: `prek run --stage pre-push --files scripts/stt-helper.sh parakeet-stt-daemon/tests/test_stt_helper_runtime_profiles.py` -> PASSED
- pre-commit: `prek run --stage pre-push --files parakeet-stt-daemon/tests/test_stt_helper_runtime_profiles.py` -> PASSED
- pre-commit: `prek run --all-files` -> PASSED
- pre-commit: `prek run --stage pre-push --all-files` -> PASSED
- CLI/script smoke: `source scripts/stt-helper.sh && stt help start` -> PASSED
- CLI/script smoke: `source scripts/stt-helper.sh && stt help llm` -> PASSED
- CLI/script smoke: `source scripts/stt-helper.sh && stt __start-profile-rows` -> PASSED
- CLI/script smoke: `source scripts/stt-helper.sh && stt __start-runtime-config`; `source scripts/stt-helper.sh && stt __start-runtime-config offline`; `source scripts/stt-helper.sh && stt __start-runtime-config cpu`; exported overlay env override + `stt __start-runtime-config offline`; `get_stt_start_args start_args off` -> PASSED
- static/security: N/A - no dependency, secret, auth, or destructive operation surface changed
- migrations: N/A
- UI render: N/A
- destructive/negative: N/A - no destructive operation surface changed
- deletion test: `rg -n "if \[ \"\$profile\" =|if \[ \"\$launch_profile\" =|case \"\$launch_profile\"|stream\|streaming\|offline\|off\|on\|cpu\|--\*" scripts/stt-helper.sh` -> PASSED (no matches)
- review: `coderabbit_review_watch.py local -- --base main` -> Codex fallback completed cleanly because local CodeRabbit CLI errored; artifact `.git/coderabbit-review/20260522T142124Z/status.json`, report `.git/coderabbit-review/20260522T142124Z/codex-review.md`
- review remediation: CodeRabbit medium finding for undocumented `stt llm` aliases fixed in `35778c5`
- review remediation: CodeRabbit medium finding for substring-based help alias assertions fixed in `5b1344c`
- review remediation: local fallback finding for sourced-shell alias-scan variable leakage fixed in `31bb9c3`
- review remediation: local fallback P2 finding for duplicated direct LLM profile forwarding fixed in `6618cf3`
- review final gate: `coderabbit_review_watch.py gate --pr 150 --no-local-review --decisions .git/coderabbit-review/20260522T151222Z/decision-ledger.json --require-classified` -> PASSED, exit 0; summary `.git/coderabbit-review/20260522T151839Z/gate-summary.json`, ledger `.git/coderabbit-review/20260522T151839Z/decision-ledger.json`, remote clean, same-head local fallback clean at `.git/coderabbit-review/20260522T151222Z/local-review/codex-review.md`
- tests added/expanded: `parakeet-stt-daemon/tests/test_stt_helper_runtime_profiles.py`
- preexisting failures left: none observed for the changed behavior

## Notes

- GitHub reported an existing Dependabot vulnerability on the default branch during push; this PR does not touch dependencies.
- While validating the LLM forwarding fix, I observed that an existing `stt start` unknown-option path prints an error but returns success due to a preexisting `if ! _resolve_start_runtime_config` status-capture pattern on `main`; this PR does not rely on that status and leaves it unchanged.
