### PR TITLE
refactor: type daemon runtime truth source

### DIFF
--- a/parakeet-stt-daemon/src/parakeet_stt_daemon/runtime_truth_snapshot.py
+++ b/parakeet-stt-daemon/src/parakeet_stt_daemon/runtime_truth_snapshot.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
-import math
 from dataclasses import dataclass
-from typing import Any, Literal
+from typing import Literal, Protocol
 
 from .messages import StatusMessage
 from .overlay_interim import InterimTranscriptRuntimeFacts, InterimTranscriptSource
-from .session import SealPathRuntimeFacts, SessionState, StreamPathRuntimeFacts
+from .session import SessionState
 from .tail_trim import TailTrimMode
 
 StreamHelperScope = Literal["live_session_only"]
@@ -43,8 +42,14 @@ class SealPathFacts:
 @dataclass(frozen=True, slots=True)
 class TailTrimFacts:
     tail_trim_mode: TailTrimMode
+    vad_enabled: bool
     vad_active: bool
     vad_fallback_reason: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class OverlayTransportFacts:
+    enabled: bool
 
 
 @dataclass(frozen=True, slots=True)
@@ -66,6 +71,22 @@ class RuntimeTruthMetrics:
     last_audio_ms: int | None = None
     last_infer_ms: int | None = None
     last_send_ms: int | None = None
+
+
+class RuntimeTruthSource(Protocol):
+    """Typed source for Daemon runtime truth facts."""
+
+    def runtime_truth_device_info(self) -> DeviceInfo: ...
+
+    def runtime_truth_stream_path_facts(self) -> StreamPathFacts: ...
+
+    def runtime_truth_seal_path_facts(self) -> SealPathFacts: ...
+
+    def runtime_truth_tail_trim_facts(self) -> TailTrimFacts: ...
+
+    def runtime_truth_interim_transcript_facts(self) -> InterimTranscriptRuntimeFacts: ...
+
+    def runtime_truth_overlay_transport_facts(self) -> OverlayTransportFacts: ...
 
 
 @dataclass(frozen=True, slots=True)
@@ -198,25 +219,14 @@ class RuntimeTruth:
 
 
 def snapshot(
-    orchestrator: Any,
-    *,
-    stream_path: StreamPathFacts | None = None,
-    seal_path: SealPathFacts | None = None,
-    last_trim_outcome: object | None = None,
-    device_info: DeviceInfo | None = None,
-    overlay_events_enabled: bool | None = None,
+    source: RuntimeTruthSource,
 ) -> RuntimeTruth:
-    settings = orchestrator.settings
-    stream_path = stream_path or _stream_path_facts(orchestrator)
-    seal_path = seal_path or _seal_path_facts(orchestrator)
-    tail_trim = _tail_trim_facts(orchestrator, last_trim_outcome)
-    device_info = device_info or _device_info(orchestrator)
-    overlay_enabled = (
-        bool(getattr(settings, "overlay_events_enabled", False))
-        if overlay_events_enabled is None
-        else overlay_events_enabled
-    )
-    interim = _interim_transcript_facts(orchestrator, enabled=overlay_enabled)
+    device_info = source.runtime_truth_device_info()
+    stream_path = source.runtime_truth_stream_path_facts()
+    seal_path = source.runtime_truth_seal_path_facts()
+    tail_trim = source.runtime_truth_tail_trim_facts()
+    interim = source.runtime_truth_interim_transcript_facts()
+    overlay_transport = source.runtime_truth_overlay_transport_facts()
     return RuntimeTruth(
         device=device_info.requested_device,
         effective_device=device_info.effective_device,
@@ -230,7 +240,7 @@ def snapshot(
         finalization_mode=seal_path.finalization_mode,
         final_audio_source=seal_path.final_audio_source,
         tail_trim_mode=tail_trim.tail_trim_mode,
-        vad_enabled=bool(getattr(orchestrator, "_vad_enabled", False)),
+        vad_enabled=tail_trim.vad_enabled,
         vad_active=tail_trim.vad_active,
         vad_fallback_reason=tail_trim.vad_fallback_reason,
         interim_transcript_enabled=interim.enabled,
@@ -243,141 +253,13 @@ def snapshot(
         interim_transcript_live_failed=interim.live_failed,
         interim_transcript_stop_replay_failed=interim.stop_replay_failed,
         interim_transcript_source_fallback_reason=interim.source_fallback_reason,
-        overlay_events_enabled=overlay_enabled,
+        overlay_events_enabled=overlay_transport.enabled,
         chunk_secs=stream_path.chunk_secs,
     )
 
 
 def format_log_record(record: dict[str, object]) -> str:
     return ", ".join(f"{key}={_format_log_value(value)}" for key, value in record.items())
-
-
-def _empty_interim_transcript_facts(*, enabled: bool) -> InterimTranscriptRuntimeFacts:
-    return InterimTranscriptRuntimeFacts(
-        enabled=enabled,
-        last_source=None,
-        live_chunks_processed=0,
-        live_updates_emitted=0,
-        live_failed=False,
-        stop_replay_chunks_processed=0,
-        stop_replay_updates_emitted=0,
-        stop_replay_failed=False,
-        source_fallback_reason=None,
-    )
-
-
-def _interim_transcript_facts(
-    orchestrator: Any,
-    *,
-    enabled: bool,
-) -> InterimTranscriptRuntimeFacts:
-    getter = getattr(orchestrator, "interim_transcript_runtime_facts_for_runtime", None)
-    if not callable(getter):
-        return _empty_interim_transcript_facts(enabled=enabled)
-    try:
-        facts = getter()
-    except Exception:  # noqa: BLE001
-        return _empty_interim_transcript_facts(enabled=enabled)
-    if isinstance(facts, InterimTranscriptRuntimeFacts):
-        return facts
-    return _empty_interim_transcript_facts(enabled=enabled)
-
-
-def _device_info(orchestrator: Any) -> DeviceInfo:
-    settings = orchestrator.settings
-    requested = _string_or_none(
-        getattr(orchestrator, "_requested_device", getattr(settings, "device", None))
-    )
-    effective = _string_or_none(getattr(orchestrator, "_effective_device", requested))
-    return DeviceInfo(requested_device=requested, effective_device=effective)
-
-
-def _stream_path_facts(orchestrator: Any) -> StreamPathFacts:
-    settings = orchestrator.settings
-    streaming_enabled = bool(getattr(settings, "streaming_enabled", False))
-    chunk_secs = _chunk_secs_or_none(settings)
-    getter = getattr(orchestrator, "stream_path_runtime_facts_for_runtime", None)
-    if callable(getter):
-        try:
-            runtime_facts = getter()
-        except Exception:  # noqa: BLE001
-            runtime_facts = None
-        if isinstance(runtime_facts, StreamPathRuntimeFacts):
-            return StreamPathFacts(
-                streaming_enabled=runtime_facts.streaming_enabled,
-                helper_active=runtime_facts.helper_active,
-                helper_scope=runtime_facts.helper_scope,
-                helper_class_name=runtime_facts.helper_class_name,
-                fallback_reason=runtime_facts.fallback_reason,
-                chunk_secs=runtime_facts.chunk_secs,
-                path_executed=runtime_facts.path_executed,
-                chunks_processed=runtime_facts.chunks_processed,
-            )
-    streaming_transcriber = getattr(orchestrator, "streaming_transcriber", None)
-    if not streaming_enabled:
-        return StreamPathFacts(
-            streaming_enabled=False,
-            helper_active=False,
-            helper_scope="live_session_only",
-            helper_class_name=None,
-            fallback_reason=None,
-            chunk_secs=None,
-            path_executed=False,
-            chunks_processed=0,
-        )
-    if streaming_transcriber is None:
-        return StreamPathFacts(
-            streaming_enabled=True,
-            helper_active=False,
-            helper_scope="live_session_only",
-            helper_class_name=None,
-            fallback_reason="streaming_transcriber_unavailable",
-            chunk_secs=chunk_secs,
-            path_executed=False,
-            chunks_processed=0,
-        )
-    fallback_reason = getattr(streaming_transcriber, "fallback_reason", None)
-    return StreamPathFacts(
-        streaming_enabled=True,
-        helper_active=bool(getattr(streaming_transcriber, "helper_active", False)),
-        helper_scope="live_session_only",
-        helper_class_name=_string_or_none(
-            getattr(streaming_transcriber, "_helper_class_name", None)
-        ),
-        fallback_reason=fallback_reason,
-        chunk_secs=chunk_secs,
-        path_executed=False,
-        chunks_processed=0,
-    )
-
-
-def _seal_path_facts(orchestrator: Any) -> SealPathFacts:
-    getter = getattr(orchestrator, "seal_path_runtime_facts_for_runtime", None)
-    if callable(getter):
-        try:
-            runtime_facts = getter()
-        except Exception:  # noqa: BLE001
-            runtime_facts = None
-        if isinstance(runtime_facts, SealPathRuntimeFacts):
-            return SealPathFacts(
-                finalization_mode=runtime_facts.finalization_mode,
-                final_audio_source=runtime_facts.final_audio_source,
-            )
-    return SealPathFacts()
-
-
-def _tail_trim_facts(orchestrator: Any, last_trim_outcome: object | None) -> TailTrimFacts:
-    outcome = last_trim_outcome
-    if outcome is None:
-        tail_trimmer = getattr(orchestrator, "tail_trimmer", None)
-        outcome = getattr(tail_trimmer, "last_outcome", None)
-    if outcome is None and hasattr(orchestrator, "_tail_trimmer_for_runtime"):
-        outcome = orchestrator._tail_trimmer_for_runtime().last_outcome
-    return TailTrimFacts(
-        tail_trim_mode=getattr(outcome, "tail_trim_mode", "rms"),
-        vad_active=bool(getattr(outcome, "vad_active", False)),
-        vad_fallback_reason=getattr(outcome, "vad_fallback_reason", None),
-    )
 
 
 def _format_log_value(value: object) -> str:
@@ -388,36 +270,17 @@ def _format_log_value(value: object) -> str:
     return str(value)
 
 
-def _string_or_none(value: object) -> str | None:
-    if value is None:
-        return None
-    return str(value)
-
-
-def _chunk_secs_or_none(settings: object) -> float | None:
-    value = getattr(settings, "chunk_secs", None)
-    if value is None:
-        return None
-    if isinstance(value, bool):
-        return None
-    try:
-        parsed = float(value)
-    except (TypeError, ValueError):
-        return None
-    if not math.isfinite(parsed):
-        return None
-    return parsed
-
-
 class RuntimeTruthSnapshot:
     snapshot = staticmethod(snapshot)
 
 
 __all__ = [
     "DeviceInfo",
+    "OverlayTransportFacts",
     "RuntimeTruth",
     "RuntimeTruthMetrics",
     "RuntimeTruthSnapshot",
+    "RuntimeTruthSource",
     "RuntimeTruthState",
     "SealPathFacts",
     "StreamPathFacts",

--- a/parakeet-stt-daemon/src/parakeet_stt_daemon/session_orchestrator.py
+++ b/parakeet-stt-daemon/src/parakeet_stt_daemon/session_orchestrator.py
@@ -46,9 +46,14 @@ from .model import (
     load_parakeet_model,
 )
 from .runtime_truth_snapshot import (
+    DeviceInfo,
+    OverlayTransportFacts,
     RuntimeTruth,
     RuntimeTruthMetrics,
     RuntimeTruthState,
+    SealPathFacts,
+    StreamPathFacts,
+    TailTrimFacts,
     format_log_record,
 )
 from .runtime_truth_snapshot import (
@@ -99,6 +104,30 @@ class AbortSessionIntent:
     owner_token: int
     event_sink: EventSink
     reason: Literal["timeout", "user", "error"]
+
+
+@dataclass(frozen=True, slots=True)
+class DaemonRuntimeTruthSource:
+    orchestrator: SessionOrchestrator
+    overlay_events_enabled: bool
+
+    def runtime_truth_device_info(self) -> DeviceInfo:
+        return self.orchestrator.runtime_truth_device_info_for_runtime()
+
+    def runtime_truth_stream_path_facts(self) -> StreamPathFacts:
+        return self.orchestrator.runtime_truth_stream_path_facts_for_runtime()
+
+    def runtime_truth_seal_path_facts(self) -> SealPathFacts:
+        return self.orchestrator.runtime_truth_seal_path_facts_for_runtime()
+
+    def runtime_truth_tail_trim_facts(self) -> TailTrimFacts:
+        return self.orchestrator.runtime_truth_tail_trim_facts_for_runtime()
+
+    def runtime_truth_interim_transcript_facts(self) -> InterimTranscriptRuntimeFacts:
+        return self.orchestrator.interim_transcript_runtime_facts_for_runtime()
+
+    def runtime_truth_overlay_transport_facts(self) -> OverlayTransportFacts:
+        return OverlayTransportFacts(enabled=self.overlay_events_enabled)
 
 
 class SessionOrchestrator:
@@ -797,11 +826,47 @@ class SessionOrchestrator:
         interim_runtime.clear_session(session_id)
 
     def runtime_truth(self, *, overlay_events_enabled: bool) -> RuntimeTruth:
-        seal_path_runtime = self._seal_path_runtime_for_runtime()
         return runtime_truth_snapshot(
-            self,
-            last_trim_outcome=seal_path_runtime.last_tail_trim_outcome,
-            overlay_events_enabled=overlay_events_enabled,
+            DaemonRuntimeTruthSource(
+                orchestrator=self,
+                overlay_events_enabled=overlay_events_enabled,
+            )
+        )
+
+    def runtime_truth_device_info_for_runtime(self) -> DeviceInfo:
+        return DeviceInfo(
+            requested_device=self._requested_device,
+            effective_device=self._effective_device,
+        )
+
+    def runtime_truth_stream_path_facts_for_runtime(self) -> StreamPathFacts:
+        facts = self.stream_path_runtime_facts_for_runtime()
+        return StreamPathFacts(
+            streaming_enabled=facts.streaming_enabled,
+            helper_active=facts.helper_active,
+            helper_scope=facts.helper_scope,
+            helper_class_name=facts.helper_class_name,
+            fallback_reason=facts.fallback_reason,
+            chunk_secs=facts.chunk_secs,
+            path_executed=facts.path_executed,
+            chunks_processed=facts.chunks_processed,
+        )
+
+    def runtime_truth_seal_path_facts_for_runtime(self) -> SealPathFacts:
+        facts = self.seal_path_runtime_facts_for_runtime()
+        return SealPathFacts(
+            finalization_mode=facts.finalization_mode,
+            final_audio_source=facts.final_audio_source,
+        )
+
+    def runtime_truth_tail_trim_facts_for_runtime(self) -> TailTrimFacts:
+        tail_trimmer = self._tail_trimmer_for_runtime()
+        outcome = tail_trimmer.last_outcome
+        return TailTrimFacts(
+            tail_trim_mode=outcome.tail_trim_mode,
+            vad_enabled=tail_trimmer.vad_enabled,
+            vad_active=outcome.vad_active,
+            vad_fallback_reason=outcome.vad_fallback_reason,
         )
 
     def stream_path_runtime_facts_for_runtime(self) -> StreamPathRuntimeFacts:

--- a/parakeet-stt-daemon/tests/test_streaming_truth.py
+++ b/parakeet-stt-daemon/tests/test_streaming_truth.py
@@ -11,17 +11,23 @@ import numpy as np
 
 from parakeet_stt_daemon.config import ServerSettings
 from parakeet_stt_daemon.messages import StatusMessage
-from parakeet_stt_daemon.runtime_truth_snapshot import RuntimeTruth, snapshot
+from parakeet_stt_daemon.runtime_truth_snapshot import (
+    DeviceInfo,
+    OverlayTransportFacts,
+    RuntimeTruth,
+    SealPathFacts,
+    StreamPathFacts,
+    TailTrimFacts,
+    snapshot,
+)
 from parakeet_stt_daemon.session import (
     InterimTranscriptRuntime,
     InterimTranscriptRuntimeFacts,
     SealPathFinalizationResult,
     SealPathRuntime,
-    SealPathRuntimeFacts,
     Session,
     SessionManager,
     StreamPathRuntime,
-    StreamPathRuntimeFacts,
 )
 from parakeet_stt_daemon.session_orchestrator import SessionOrchestrator
 from parakeet_stt_daemon.tail_trim import SealPathTailTrimmer
@@ -73,27 +79,71 @@ class FakeVadAdapter:
         return samples.astype(np.float32, copy=False)
 
 
-class RuntimeTruthPrivateFieldTrap(SimpleNamespace):
+class RuntimeTruthSourceTrap:
+    def __init__(
+        self,
+        *,
+        device_info: DeviceInfo | None = None,
+        stream_path: StreamPathFacts | None = None,
+        seal_path: SealPathFacts | None = None,
+        tail_trim: TailTrimFacts | None = None,
+        interim: InterimTranscriptRuntimeFacts | None = None,
+        overlay_transport: OverlayTransportFacts | None = None,
+    ) -> None:
+        self._device_info = device_info or DeviceInfo(
+            requested_device="cpu",
+            effective_device="cpu",
+        )
+        self._stream_path = stream_path or StreamPathFacts(
+            streaming_enabled=False,
+            helper_active=False,
+            helper_scope="live_session_only",
+            helper_class_name=None,
+            fallback_reason=None,
+            chunk_secs=None,
+            path_executed=False,
+            chunks_processed=0,
+        )
+        self._seal_path = seal_path or SealPathFacts()
+        self._tail_trim = tail_trim or TailTrimFacts(
+            tail_trim_mode="rms",
+            vad_enabled=False,
+            vad_active=False,
+            vad_fallback_reason=None,
+        )
+        self._interim = interim or InterimTranscriptRuntimeFacts(
+            enabled=False,
+            last_source=None,
+            live_chunks_processed=0,
+            live_updates_emitted=0,
+            live_failed=False,
+            stop_replay_chunks_processed=0,
+            stop_replay_updates_emitted=0,
+            stop_replay_failed=False,
+            source_fallback_reason=None,
+        )
+        self._overlay_transport = overlay_transport or OverlayTransportFacts(enabled=False)
+
     def __getattr__(self, name: str) -> Any:
-        private_stream_prefixes = ("_current_" + "stream", "_last_" + "stream")
-        if name.startswith(private_stream_prefixes):
-            raise AssertionError(f"runtime truth probed old Stream path field {name}")
-        private_interim_fields = (
-            "_interim_transcript_by_session",
-            "_last_interim_transcript_runtime_facts",
-        )
-        if name in private_interim_fields:
-            raise AssertionError(f"runtime truth probed old interim transcript field {name}")
-        private_seal_fields = (
-            "_last_audio_ms",
-            "_last_audio_stop_ms",
-            "_last_finalize_ms",
-            "_last_infer_ms",
-            "_last_send_ms",
-        )
-        if name in private_seal_fields:
-            raise AssertionError(f"runtime truth probed old Seal path field {name}")
-        raise AttributeError(name)
+        raise AssertionError(f"runtime truth probed non-interface field {name}")
+
+    def runtime_truth_device_info(self) -> DeviceInfo:
+        return self._device_info
+
+    def runtime_truth_stream_path_facts(self) -> StreamPathFacts:
+        return self._stream_path
+
+    def runtime_truth_seal_path_facts(self) -> SealPathFacts:
+        return self._seal_path
+
+    def runtime_truth_tail_trim_facts(self) -> TailTrimFacts:
+        return self._tail_trim
+
+    def runtime_truth_interim_transcript_facts(self) -> InterimTranscriptRuntimeFacts:
+        return self._interim
+
+    def runtime_truth_overlay_transport_facts(self) -> OverlayTransportFacts:
+        return self._overlay_transport
 
 
 def _build_server(
@@ -158,10 +208,8 @@ def _status(orchestrator: SessionOrchestrator) -> StatusMessage:
 
 
 def _truth(orchestrator: SessionOrchestrator) -> RuntimeTruth:
-    return snapshot(
-        orchestrator,
-        last_trim_outcome=orchestrator.tail_trimmer.last_outcome,
-        overlay_events_enabled=orchestrator.settings.overlay_events_enabled,
+    return orchestrator.runtime_truth(
+        overlay_events_enabled=orchestrator.settings.overlay_events_enabled
     )
 
 
@@ -253,22 +301,20 @@ def test_runtime_truth_log_record_contains_helper_expected_fields() -> None:
 
 
 def test_runtime_truth_preserves_missing_optional_device_and_chunk_values() -> None:
-    orchestrator = cast(
-        SessionOrchestrator,
-        SimpleNamespace(
-            settings=SimpleNamespace(
-                streaming_enabled=True, chunk_secs=None, overlay_events_enabled=False
-            ),
-            streaming_transcriber=None,
-        ),
-    )
     truth = snapshot(
-        orchestrator,
-        last_trim_outcome=SimpleNamespace(
-            tail_trim_mode="rms",
-            vad_active=False,
-            vad_fallback_reason=None,
-        ),
+        RuntimeTruthSourceTrap(
+            device_info=DeviceInfo(requested_device=None, effective_device=None),
+            stream_path=StreamPathFacts(
+                streaming_enabled=True,
+                helper_active=False,
+                helper_scope="live_session_only",
+                helper_class_name=None,
+                fallback_reason="streaming_transcriber_unavailable",
+                chunk_secs=None,
+                path_executed=False,
+                chunks_processed=0,
+            ),
+        )
     )
 
     assert truth.device is None
@@ -278,36 +324,19 @@ def test_runtime_truth_preserves_missing_optional_device_and_chunk_values() -> N
 
 
 def test_runtime_truth_reads_stream_path_interface_instead_of_orchestrator_fields() -> None:
-    runtime_facts = StreamPathRuntimeFacts(
-        streaming_enabled=True,
-        helper_active=True,
-        helper_scope="live_session_only",
-        helper_class_name="InterfaceHelper",
-        fallback_reason="interface:fallback",
-        chunk_secs=1.25,
-        path_executed=True,
-        chunks_processed=3,
-    )
-    orchestrator = cast(
-        SessionOrchestrator,
-        RuntimeTruthPrivateFieldTrap(
-            settings=SimpleNamespace(
-                streaming_enabled=True,
-                chunk_secs=9.99,
-                overlay_events_enabled=False,
-            ),
-            streaming_transcriber=None,
-            stream_path_runtime_facts_for_runtime=lambda: runtime_facts,
-        ),
-    )
-
     truth = snapshot(
-        orchestrator,
-        last_trim_outcome=SimpleNamespace(
-            tail_trim_mode="rms",
-            vad_active=False,
-            vad_fallback_reason=None,
-        ),
+        RuntimeTruthSourceTrap(
+            stream_path=StreamPathFacts(
+                streaming_enabled=True,
+                helper_active=True,
+                helper_scope="live_session_only",
+                helper_class_name="InterfaceHelper",
+                fallback_reason="interface:fallback",
+                chunk_secs=1.25,
+                path_executed=True,
+                chunks_processed=3,
+            ),
+        )
     )
 
     assert truth.stream_helper_active is True
@@ -330,27 +359,7 @@ def test_runtime_truth_reads_interim_interface_instead_of_orchestrator_fields() 
         stop_replay_failed=True,
         source_fallback_reason="stop_replay_transcribe_error:RuntimeError",
     )
-    orchestrator = cast(
-        SessionOrchestrator,
-        RuntimeTruthPrivateFieldTrap(
-            settings=SimpleNamespace(
-                streaming_enabled=False,
-                chunk_secs=None,
-                overlay_events_enabled=True,
-            ),
-            streaming_transcriber=None,
-            interim_transcript_runtime_facts_for_runtime=lambda: interim_facts,
-        ),
-    )
-
-    truth = snapshot(
-        orchestrator,
-        last_trim_outcome=SimpleNamespace(
-            tail_trim_mode="rms",
-            vad_active=False,
-            vad_fallback_reason=None,
-        ),
-    )
+    truth = snapshot(RuntimeTruthSourceTrap(interim=interim_facts))
 
     assert truth.interim_transcript_enabled is True
     assert truth.interim_transcript_last_source == "stop_replay"
@@ -368,34 +377,23 @@ def test_runtime_truth_reads_interim_interface_instead_of_orchestrator_fields() 
 
 
 def test_runtime_truth_reads_seal_path_interface() -> None:
-    runtime_facts = SealPathRuntimeFacts(
-        finalization_mode="offline_seal",
-        final_audio_source="canonical_session_audio",
-    )
-    orchestrator = cast(
-        SessionOrchestrator,
-        RuntimeTruthPrivateFieldTrap(
-            settings=SimpleNamespace(
-                streaming_enabled=False,
-                chunk_secs=None,
-                overlay_events_enabled=False,
-            ),
-            streaming_transcriber=None,
-            seal_path_runtime_facts_for_runtime=lambda: runtime_facts,
-        ),
-    )
-
     truth = snapshot(
-        orchestrator,
-        last_trim_outcome=SimpleNamespace(
-            tail_trim_mode="rms",
-            vad_active=False,
-            vad_fallback_reason=None,
-        ),
+        RuntimeTruthSourceTrap(
+            seal_path=SealPathFacts(
+                finalization_mode="offline_seal",
+                final_audio_source="canonical_session_audio",
+            )
+        )
     )
 
     assert truth.finalization_mode == "offline_seal"
     assert truth.final_audio_source == "canonical_session_audio"
+
+
+def test_runtime_truth_reads_overlay_transport_interface() -> None:
+    truth = snapshot(RuntimeTruthSourceTrap(overlay_transport=OverlayTransportFacts(enabled=True)))
+
+    assert truth.overlay_events_enabled is True
 
 
 def test_interim_runtime_syncs_cached_session_config() -> None:
@@ -413,30 +411,14 @@ def test_interim_runtime_syncs_cached_session_config() -> None:
     assert runtime.session_runtime_facts(session_id).enabled is True
 
 
-def test_runtime_truth_ignores_invalid_chunk_secs_values() -> None:
+def test_stream_runtime_ignores_invalid_chunk_secs_values() -> None:
     for chunk_secs in ("not-a-number", "nan", "inf", float("nan"), float("inf"), True):
-        orchestrator = cast(
-            SessionOrchestrator,
-            SimpleNamespace(
-                settings=SimpleNamespace(
-                    streaming_enabled=True,
-                    chunk_secs=chunk_secs,
-                    overlay_events_enabled=False,
-                ),
-                streaming_transcriber=None,
-            ),
+        runtime = StreamPathRuntime.from_settings(
+            SimpleNamespace(streaming_enabled=True, chunk_secs=chunk_secs),
+            streaming_transcriber=None,
         )
 
-        truth = snapshot(
-            orchestrator,
-            last_trim_outcome=SimpleNamespace(
-                tail_trim_mode="rms",
-                vad_active=False,
-                vad_fallback_reason=None,
-            ),
-        )
-
-        assert truth.chunk_secs is None
+        assert runtime.facts(active_session=False).chunk_secs is None
 
 
 def test_status_vad_enabled_pending_load_is_explicit() -> None:


### PR DESCRIPTION
Fixes #154.

## Summary
- Replace reflection-based Runtime Truth snapshot collection with an explicit `RuntimeTruthSource` protocol.
- Have `SessionOrchestrator` provide typed device, Stream path, Seal path, tail/VAD, interim transcript, and overlay transport facts.
- Preserve existing `/status` `StatusMessage` fields and runtime truth log projection behavior.

## Verification (#154)
- targeted: `cd parakeet-stt-daemon && uv run pytest tests/test_streaming_truth.py -q` -> PASSED (29 passed)
- regression: N/A (typed-interface refactor; focused interface tests added)
- full suite: `cd parakeet-stt-daemon && uv run pytest -q` -> PASSED (232 passed); `prek run --stage pre-push --all-files` -> PASSED
- lint: `cd parakeet-stt-daemon && uv run ruff format --check .`; `uv run ruff check .` -> PASSED
- types: `cd parakeet-stt-daemon && ty check --project . --error-on-warning` -> PASSED
- dead-code: `cd parakeet-stt-daemon && uv run deptry .` -> FAILED preexisting unrelated `DEP002` on `onnxruntime` in unchanged `pyproject.toml`
- build: `cd parakeet-stt-daemon && uv build` -> PASSED
- pre-commit: `prek run --files parakeet-stt-daemon/src/parakeet_stt_daemon/runtime_truth_snapshot.py parakeet-stt-daemon/src/parakeet_stt_daemon/session_orchestrator.py parakeet-stt-daemon/tests/test_streaming_truth.py`; `prek run --all-files`; `prek run --stage pre-push --all-files` -> PASSED
- static/security: N/A (no security linter configured for touched Python surface)
- migrations: N/A
- CLI/script smoke: N/A
- UI render: N/A
- destructive/negative: N/A
- review: `coderabbit_review_watch.py local -- --base main` -> exit 10, CodeRabbit unavailable; Codex fallback clean (status: `.git/coderabbit-review/20260523T120809Z/status.json`, report: `.git/coderabbit-review/20260523T120809Z/codex-review.md`)
- PR gate: `coderabbit_review_watch.py gate --pr 163` -> exit 10, remote clean, local Codex fallback (summary: `.git/coderabbit-review/20260523T121319Z/gate-summary.json`, ledger: `.git/coderabbit-review/20260523T121319Z/decision-ledger.json`, remote: `completed_clean`, codex-fallback: yes)
- final classified gate: `coderabbit_review_watch.py gate --pr 163 --decisions .git/coderabbit-review/20260523T121319Z/decision-ledger.json --require-classified --no-local-review` -> PASSED (summary: `.git/coderabbit-review/20260523T121832Z/gate-summary.json`, ledger: `.git/coderabbit-review/20260523T121832Z/decision-ledger.json`)
- tests added/expanded: `parakeet-stt-daemon/tests/test_streaming_truth.py`
- preexisting failures left: `uv run deptry .` reports `pyproject.toml` `DEP002` `'onnxruntime' defined as a dependency but not used in the codebase`.

## Reviewer Findings
- CodeRabbit actionable findings: none.
- CodeRabbit pre-merge docstring coverage warning: IGNORE. Reason: the repo does not enforce docstring coverage in `prek`, Ruff, ty, or pytest; changed functions follow the existing local style, and adding broad docstrings would be unrelated churn for #154.

## Residual Risk
- The local CodeRabbit CLI returned `coderabbit_error`; the watcher used Codex fallback for local/base review. Remote CodeRabbit review completed clean for PR head `58da9b2802d182eb1c68131d6d1e78024d6ccd03`.
- `deptry` has a preexisting unrelated `onnxruntime` false-positive/dependency-drift finding in unchanged daemon dependencies.
