### PR TITLE
fix: make runtime truth fact gaps explicit

### DIFF
--- a/parakeet-stt-daemon/pyproject.toml
+++ b/parakeet-stt-daemon/pyproject.toml
@@ -64,6 +64,8 @@ known-first-party = ["check_model_lib", "parakeet_stt_daemon"]
 
 [tool.deptry]
 known_first_party = ["check_model_lib", "parakeet_stt_daemon"]
+# Required indirectly by silero_vad.load_silero_vad(onnx=True).
+per_rule_ignores = { DEP002 = ["onnxruntime"] }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/parakeet-stt-daemon/src/parakeet_stt_daemon/runtime_truth_snapshot.py
+++ b/parakeet-stt-daemon/src/parakeet_stt_daemon/runtime_truth_snapshot.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Literal, Protocol
+from typing import Literal, Protocol, TypeVar
 
 from .messages import StatusMessage
 from .overlay_interim import InterimTranscriptRuntimeFacts, InterimTranscriptSource
@@ -13,6 +14,7 @@ from .tail_trim import TailTrimMode
 StreamHelperScope = Literal["live_session_only"]
 FinalizationMode = Literal["offline_seal"]
 FinalAudioSource = Literal["canonical_session_audio"]
+T = TypeVar("T")
 
 
 @dataclass(frozen=True, slots=True)
@@ -23,33 +25,52 @@ class DeviceInfo:
 
 @dataclass(frozen=True, slots=True)
 class StreamPathFacts:
-    streaming_enabled: bool
-    helper_active: bool
-    helper_scope: StreamHelperScope
+    streaming_enabled: bool | None
+    helper_active: bool | None
+    helper_scope: StreamHelperScope | None
     helper_class_name: str | None
     fallback_reason: str | None
     chunk_secs: float | None
-    path_executed: bool
-    chunks_processed: int
+    path_executed: bool | None
+    chunks_processed: int | None
 
 
 @dataclass(frozen=True, slots=True)
 class SealPathFacts:
-    finalization_mode: FinalizationMode = "offline_seal"
-    final_audio_source: FinalAudioSource = "canonical_session_audio"
+    finalization_mode: FinalizationMode | None = "offline_seal"
+    final_audio_source: FinalAudioSource | None = "canonical_session_audio"
 
 
 @dataclass(frozen=True, slots=True)
 class TailTrimFacts:
-    tail_trim_mode: TailTrimMode
-    vad_enabled: bool
-    vad_active: bool
+    tail_trim_mode: TailTrimMode | None
+    vad_enabled: bool | None
+    vad_active: bool | None
     vad_fallback_reason: str | None
 
 
 @dataclass(frozen=True, slots=True)
 class OverlayTransportFacts:
-    enabled: bool
+    enabled: bool | None
+
+
+@dataclass(frozen=True, slots=True)
+class InterimTranscriptFacts:
+    enabled: bool | None
+    last_source: InterimTranscriptSource | None
+    live_chunks_processed: int | None
+    live_updates_emitted: int | None
+    live_failed: bool | None
+    stop_replay_chunks_processed: int | None
+    stop_replay_updates_emitted: int | None
+    stop_replay_failed: bool | None
+    source_fallback_reason: str | None
+
+    @property
+    def updates_emitted(self) -> int | None:
+        if self.live_updates_emitted is None or self.stop_replay_updates_emitted is None:
+            return None
+        return self.live_updates_emitted + self.stop_replay_updates_emitted
 
 
 @dataclass(frozen=True, slots=True)
@@ -84,7 +105,9 @@ class RuntimeTruthSource(Protocol):
 
     def runtime_truth_tail_trim_facts(self) -> TailTrimFacts: ...
 
-    def runtime_truth_interim_transcript_facts(self) -> InterimTranscriptRuntimeFacts: ...
+    def runtime_truth_interim_transcript_facts(
+        self,
+    ) -> InterimTranscriptRuntimeFacts | InterimTranscriptFacts: ...
 
     def runtime_truth_overlay_transport_facts(self) -> OverlayTransportFacts: ...
 
@@ -93,38 +116,54 @@ class RuntimeTruthSource(Protocol):
 class RuntimeTruth:
     device: str | None
     effective_device: str | None
-    streaming_enabled: bool
-    stream_helper_active: bool
-    stream_helper_scope: StreamHelperScope
+    streaming_enabled: bool | None
+    stream_helper_active: bool | None
+    stream_helper_scope: StreamHelperScope | None
     stream_helper_class_name: str | None
     stream_fallback_reason: str | None
-    stream_path_executed: bool
-    stream_chunks_processed: int
-    finalization_mode: FinalizationMode
-    final_audio_source: FinalAudioSource
-    tail_trim_mode: TailTrimMode
-    vad_enabled: bool
-    vad_active: bool
+    stream_path_executed: bool | None
+    stream_chunks_processed: int | None
+    finalization_mode: FinalizationMode | None
+    final_audio_source: FinalAudioSource | None
+    tail_trim_mode: TailTrimMode | None
+    vad_enabled: bool | None
+    vad_active: bool | None
     vad_fallback_reason: str | None
-    interim_transcript_enabled: bool
+    interim_transcript_enabled: bool | None
     interim_transcript_last_source: InterimTranscriptSource | None
-    interim_transcript_live_chunks_processed: int
-    interim_transcript_stop_replay_chunks_processed: int
-    interim_transcript_updates_emitted: int
-    interim_transcript_live_updates_emitted: int
-    interim_transcript_stop_replay_updates_emitted: int
-    interim_transcript_live_failed: bool
-    interim_transcript_stop_replay_failed: bool
+    interim_transcript_live_chunks_processed: int | None
+    interim_transcript_stop_replay_chunks_processed: int | None
+    interim_transcript_updates_emitted: int | None
+    interim_transcript_live_updates_emitted: int | None
+    interim_transcript_stop_replay_updates_emitted: int | None
+    interim_transcript_live_failed: bool | None
+    interim_transcript_stop_replay_failed: bool | None
     interim_transcript_source_fallback_reason: str | None
-    overlay_events_enabled: bool
+    overlay_events_enabled: bool | None
     chunk_secs: float | None
 
     @property
     def degraded(self) -> bool:
-        stream_degraded = self.streaming_enabled and (
-            not self.stream_helper_active or self.stream_fallback_reason is not None
+        device_degraded = self.device is None and self.effective_device is None
+        stream_degraded = self.stream_fallback_reason is not None or (
+            self.streaming_enabled is True and self.stream_helper_active is not True
         )
-        return stream_degraded or (self.vad_enabled and not self.vad_active)
+        vad_degraded = self.vad_fallback_reason is not None or (
+            self.vad_enabled is True and self.vad_active is not True
+        )
+        interim_degraded = self.interim_transcript_source_fallback_reason is not None
+        unavailable_degraded = (
+            self.finalization_mode is None
+            or self.final_audio_source is None
+            or self.overlay_events_enabled is None
+        )
+        return (
+            device_degraded
+            or stream_degraded
+            or vad_degraded
+            or interim_degraded
+            or unavailable_degraded
+        )
 
     def to_status(self, state: RuntimeTruthState, metrics: RuntimeTruthMetrics) -> StatusMessage:
         return StatusMessage(
@@ -221,12 +260,36 @@ class RuntimeTruth:
 def snapshot(
     source: RuntimeTruthSource,
 ) -> RuntimeTruth:
-    device_info = source.runtime_truth_device_info()
-    stream_path = source.runtime_truth_stream_path_facts()
-    seal_path = source.runtime_truth_seal_path_facts()
-    tail_trim = source.runtime_truth_tail_trim_facts()
-    interim = source.runtime_truth_interim_transcript_facts()
-    overlay_transport = source.runtime_truth_overlay_transport_facts()
+    device_info = _read_fact(
+        "device",
+        lambda: source.runtime_truth_device_info(),
+        _unavailable_device_info,
+    )
+    stream_path = _read_fact(
+        "stream_path",
+        lambda: source.runtime_truth_stream_path_facts(),
+        _unavailable_stream_path_facts,
+    )
+    seal_path = _read_fact(
+        "seal_path",
+        lambda: source.runtime_truth_seal_path_facts(),
+        _unavailable_seal_path_facts,
+    )
+    tail_trim = _read_fact(
+        "tail_trim_vad",
+        lambda: source.runtime_truth_tail_trim_facts(),
+        _unavailable_tail_trim_facts,
+    )
+    interim = _read_fact(
+        "interim_transcript",
+        lambda: source.runtime_truth_interim_transcript_facts(),
+        _unavailable_interim_transcript_facts,
+    )
+    overlay_transport = _read_fact(
+        "overlay_transport",
+        lambda: source.runtime_truth_overlay_transport_facts(),
+        _unavailable_overlay_transport_facts,
+    )
     return RuntimeTruth(
         device=device_info.requested_device,
         effective_device=device_info.effective_device,
@@ -247,7 +310,7 @@ def snapshot(
         interim_transcript_last_source=interim.last_source,
         interim_transcript_live_chunks_processed=interim.live_chunks_processed,
         interim_transcript_stop_replay_chunks_processed=interim.stop_replay_chunks_processed,
-        interim_transcript_updates_emitted=interim.updates_emitted,
+        interim_transcript_updates_emitted=_interim_updates_emitted(interim),
         interim_transcript_live_updates_emitted=interim.live_updates_emitted,
         interim_transcript_stop_replay_updates_emitted=interim.stop_replay_updates_emitted,
         interim_transcript_live_failed=interim.live_failed,
@@ -256,6 +319,71 @@ def snapshot(
         overlay_events_enabled=overlay_transport.enabled,
         chunk_secs=stream_path.chunk_secs,
     )
+
+
+def _read_fact(
+    group: str,
+    read: Callable[[], T],
+    fallback: Callable[[str], T],
+) -> T:
+    try:
+        return read()
+    except Exception as exc:  # noqa: BLE001 - runtime truth must stay status-safe
+        return fallback(f"runtime_truth_unavailable:{group}:{exc.__class__.__name__}")
+
+
+def _unavailable_device_info(_reason: str) -> DeviceInfo:
+    return DeviceInfo(requested_device=None, effective_device=None)
+
+
+def _unavailable_stream_path_facts(reason: str) -> StreamPathFacts:
+    return StreamPathFacts(
+        streaming_enabled=None,
+        helper_active=None,
+        helper_scope=None,
+        helper_class_name=None,
+        fallback_reason=reason,
+        chunk_secs=None,
+        path_executed=None,
+        chunks_processed=None,
+    )
+
+
+def _unavailable_seal_path_facts(_reason: str) -> SealPathFacts:
+    return SealPathFacts(finalization_mode=None, final_audio_source=None)
+
+
+def _unavailable_tail_trim_facts(reason: str) -> TailTrimFacts:
+    return TailTrimFacts(
+        tail_trim_mode=None,
+        vad_enabled=None,
+        vad_active=None,
+        vad_fallback_reason=reason,
+    )
+
+
+def _unavailable_interim_transcript_facts(reason: str) -> InterimTranscriptFacts:
+    return InterimTranscriptFacts(
+        enabled=None,
+        last_source=None,
+        live_chunks_processed=None,
+        live_updates_emitted=None,
+        live_failed=None,
+        stop_replay_chunks_processed=None,
+        stop_replay_updates_emitted=None,
+        stop_replay_failed=None,
+        source_fallback_reason=reason,
+    )
+
+
+def _unavailable_overlay_transport_facts(_reason: str) -> OverlayTransportFacts:
+    return OverlayTransportFacts(enabled=None)
+
+
+def _interim_updates_emitted(
+    interim: InterimTranscriptRuntimeFacts | InterimTranscriptFacts,
+) -> int | None:
+    return interim.updates_emitted
 
 
 def format_log_record(record: dict[str, object]) -> str:
@@ -276,6 +404,7 @@ class RuntimeTruthSnapshot:
 
 __all__ = [
     "DeviceInfo",
+    "InterimTranscriptFacts",
     "OverlayTransportFacts",
     "RuntimeTruth",
     "RuntimeTruthMetrics",

--- a/parakeet-stt-daemon/src/parakeet_stt_daemon/session_orchestrator.py
+++ b/parakeet-stt-daemon/src/parakeet_stt_daemon/session_orchestrator.py
@@ -47,6 +47,7 @@ from .model import (
 )
 from .runtime_truth_snapshot import (
     DeviceInfo,
+    InterimTranscriptFacts,
     OverlayTransportFacts,
     RuntimeTruth,
     RuntimeTruthMetrics,
@@ -109,7 +110,7 @@ class AbortSessionIntent:
 @dataclass(frozen=True, slots=True)
 class DaemonRuntimeTruthSource:
     orchestrator: SessionOrchestrator
-    overlay_events_enabled: bool
+    overlay_events_enabled: bool | None
 
     def runtime_truth_device_info(self) -> DeviceInfo:
         return self.orchestrator.runtime_truth_device_info_for_runtime()
@@ -123,11 +124,14 @@ class DaemonRuntimeTruthSource:
     def runtime_truth_tail_trim_facts(self) -> TailTrimFacts:
         return self.orchestrator.runtime_truth_tail_trim_facts_for_runtime()
 
-    def runtime_truth_interim_transcript_facts(self) -> InterimTranscriptRuntimeFacts:
+    def runtime_truth_interim_transcript_facts(
+        self,
+    ) -> InterimTranscriptRuntimeFacts | InterimTranscriptFacts:
         return self.orchestrator.interim_transcript_runtime_facts_for_runtime()
 
     def runtime_truth_overlay_transport_facts(self) -> OverlayTransportFacts:
-        return OverlayTransportFacts(enabled=self.overlay_events_enabled)
+        enabled = self.overlay_events_enabled
+        return OverlayTransportFacts(enabled=enabled if isinstance(enabled, bool) else None)
 
 
 class SessionOrchestrator:
@@ -732,11 +736,29 @@ class SessionOrchestrator:
     ) -> InterimTranscriptRuntimeFacts:
         return self._interim_transcript_runtime_for_runtime().session_runtime_facts(session_id)
 
-    def interim_transcript_runtime_facts_for_runtime(self) -> InterimTranscriptRuntimeFacts:
+    def interim_transcript_runtime_facts_for_runtime(
+        self,
+    ) -> InterimTranscriptRuntimeFacts | InterimTranscriptFacts:
         active = self.sessions.active
-        return self._interim_transcript_runtime_for_runtime().facts(
-            active_session_id=active.session_id if active is not None else None
+        runtime = getattr(self, "interim_transcript_runtime", None)
+        if not isinstance(runtime, InterimTranscriptRuntime):
+            return InterimTranscriptFacts(
+                enabled=_runtime_bool(getattr(self.settings, "overlay_events_enabled", None)),
+                last_source=None,
+                live_chunks_processed=None,
+                live_updates_emitted=None,
+                live_failed=None,
+                stop_replay_chunks_processed=None,
+                stop_replay_updates_emitted=None,
+                stop_replay_failed=None,
+                source_fallback_reason="runtime_truth_unavailable:interim_transcript_runtime",
+            )
+        audio = getattr(self, "audio", None)
+        runtime.sync_from_runtime(
+            settings=self.settings,
+            sample_rate=int(getattr(audio, "sample_rate", 16_000)),
         )
+        return runtime.facts(active_session_id=active.session_id if active is not None else None)
 
     async def _emit_interim_state(
         self,
@@ -825,7 +847,7 @@ class SessionOrchestrator:
         await self.sessions.clear(session_id, owner_token=owner_token)
         interim_runtime.clear_session(session_id)
 
-    def runtime_truth(self, *, overlay_events_enabled: bool) -> RuntimeTruth:
+    def runtime_truth(self, *, overlay_events_enabled: bool | None) -> RuntimeTruth:
         return runtime_truth_snapshot(
             DaemonRuntimeTruthSource(
                 orchestrator=self,
@@ -834,13 +856,31 @@ class SessionOrchestrator:
         )
 
     def runtime_truth_device_info_for_runtime(self) -> DeviceInfo:
+        requested_device = getattr(self, "_requested_device", None)
+        effective_device = getattr(self, "_effective_device", None)
         return DeviceInfo(
-            requested_device=self._requested_device,
-            effective_device=self._effective_device,
+            requested_device=str(requested_device) if requested_device is not None else None,
+            effective_device=str(effective_device) if effective_device is not None else None,
         )
 
     def runtime_truth_stream_path_facts_for_runtime(self) -> StreamPathFacts:
-        facts = self.stream_path_runtime_facts_for_runtime()
+        runtime = getattr(self, "stream_path_runtime", None)
+        if not isinstance(runtime, StreamPathRuntime):
+            return StreamPathFacts(
+                streaming_enabled=_runtime_bool(getattr(self.settings, "streaming_enabled", None)),
+                helper_active=False,
+                helper_scope="live_session_only",
+                helper_class_name=None,
+                fallback_reason="runtime_truth_unavailable:stream_path_runtime",
+                chunk_secs=None,
+                path_executed=False,
+                chunks_processed=0,
+            )
+        runtime.sync_from_runtime(
+            settings=self.settings,
+            streaming_transcriber=getattr(self, "streaming_transcriber", None),
+        )
+        facts = runtime.facts(active_session=self.sessions.active is not None)
         return StreamPathFacts(
             streaming_enabled=facts.streaming_enabled,
             helper_active=facts.helper_active,
@@ -853,14 +893,24 @@ class SessionOrchestrator:
         )
 
     def runtime_truth_seal_path_facts_for_runtime(self) -> SealPathFacts:
-        facts = self.seal_path_runtime_facts_for_runtime()
+        runtime = getattr(self, "seal_path_runtime", None)
+        if not isinstance(runtime, SealPathRuntime):
+            return SealPathFacts(finalization_mode=None, final_audio_source=None)
+        facts = runtime.facts()
         return SealPathFacts(
             finalization_mode=facts.finalization_mode,
             final_audio_source=facts.final_audio_source,
         )
 
     def runtime_truth_tail_trim_facts_for_runtime(self) -> TailTrimFacts:
-        tail_trimmer = self._tail_trimmer_for_runtime()
+        tail_trimmer = getattr(self, "tail_trimmer", None)
+        if not isinstance(tail_trimmer, SealPathTailTrimmer):
+            return TailTrimFacts(
+                tail_trim_mode=None,
+                vad_enabled=_runtime_bool(getattr(self, "_vad_enabled", None)),
+                vad_active=False,
+                vad_fallback_reason="runtime_truth_unavailable:tail_trimmer",
+            )
         outcome = tail_trimmer.last_outcome
         return TailTrimFacts(
             tail_trim_mode=outcome.tail_trim_mode,
@@ -1044,6 +1094,10 @@ class SessionOrchestrator:
                 release_device_cache=runtime.release_device_cache,
             )
         return runtime
+
+
+def _runtime_bool(value: object) -> bool | None:
+    return value if isinstance(value, bool) else None
 
 
 __all__ = [

--- a/parakeet-stt-daemon/tests/test_session_cleanup.py
+++ b/parakeet-stt-daemon/tests/test_session_cleanup.py
@@ -22,8 +22,16 @@ from parakeet_stt_daemon.messages import (
     StopSession,
 )
 from parakeet_stt_daemon.server import DaemonServer
-from parakeet_stt_daemon.session import SealPathFinalizationResult, Session, SessionManager
+from parakeet_stt_daemon.session import (
+    InterimTranscriptRuntime,
+    SealPathFinalizationResult,
+    SealPathRuntime,
+    Session,
+    SessionManager,
+    StreamPathRuntime,
+)
 from parakeet_stt_daemon.session_orchestrator import SessionOrchestrator
+from parakeet_stt_daemon.tail_trim import SealPathTailTrimmer
 
 
 class FakeAudio:
@@ -167,12 +175,27 @@ def _build_server() -> DaemonServer:
     orchestrator._active_stream = object()
     orchestrator._stream_drain_task = None
     orchestrator._stream_drain_running = False
+    orchestrator.stream_path_runtime = StreamPathRuntime.from_settings(
+        orchestrator.settings,
+        orchestrator.streaming_transcriber,
+    )
     orchestrator._session_guard_task = None
     orchestrator._session_guard_running = False
     orchestrator._session_sample_limit = 1_440_000
     orchestrator._session_age_limit_ms = 90_000
     orchestrator._requested_device = "cpu"
     orchestrator._effective_device = "cpu"
+    orchestrator._vad_enabled = False
+    orchestrator.tail_trimmer = SealPathTailTrimmer(vad_enabled=False, silence_floor_db=-40.0)
+    orchestrator.seal_path_runtime = SealPathRuntime(
+        sample_rate=FakeAudio.sample_rate,
+        tail_trimmer=orchestrator.tail_trimmer,
+        release_device_cache=lambda _device: None,
+    )
+    orchestrator.interim_transcript_runtime = InterimTranscriptRuntime.from_settings(
+        orchestrator.settings,
+        sample_rate=FakeAudio.sample_rate,
+    )
 
     async def fake_collect_interim_text_updates(
         _session_id: UUID, _ready_chunks: list[object]

--- a/parakeet-stt-daemon/tests/test_streaming_truth.py
+++ b/parakeet-stt-daemon/tests/test_streaming_truth.py
@@ -15,6 +15,8 @@ from parakeet_stt_daemon.runtime_truth_snapshot import (
     DeviceInfo,
     OverlayTransportFacts,
     RuntimeTruth,
+    RuntimeTruthMetrics,
+    RuntimeTruthState,
     SealPathFacts,
     StreamPathFacts,
     TailTrimFacts,
@@ -27,6 +29,7 @@ from parakeet_stt_daemon.session import (
     SealPathRuntime,
     Session,
     SessionManager,
+    SessionState,
     StreamPathRuntime,
 )
 from parakeet_stt_daemon.session_orchestrator import SessionOrchestrator
@@ -146,6 +149,31 @@ class RuntimeTruthSourceTrap:
         return self._overlay_transport
 
 
+class RuntimeTruthUnavailableSource:
+    def runtime_truth_device_info(self) -> DeviceInfo:
+        raise RuntimeError("device unavailable")
+
+    def runtime_truth_stream_path_facts(self) -> StreamPathFacts:
+        raise RuntimeError("stream path unavailable")
+
+    def runtime_truth_seal_path_facts(self) -> SealPathFacts:
+        raise RuntimeError("seal path unavailable")
+
+    def runtime_truth_tail_trim_facts(self) -> TailTrimFacts:
+        raise RuntimeError("tail trim unavailable")
+
+    def runtime_truth_interim_transcript_facts(self) -> InterimTranscriptRuntimeFacts:
+        raise RuntimeError("interim transcript unavailable")
+
+    def runtime_truth_overlay_transport_facts(self) -> OverlayTransportFacts:
+        raise RuntimeError("overlay transport unavailable")
+
+
+class RuntimeTruthDeviceUnavailableSource(RuntimeTruthSourceTrap):
+    def runtime_truth_device_info(self) -> DeviceInfo:
+        raise RuntimeError("device unavailable")
+
+
 def _build_server(
     *,
     streaming_enabled: bool = True,
@@ -171,6 +199,10 @@ def _build_server(
     orchestrator._active_stream = None
     orchestrator._stream_drain_task = None
     orchestrator._stream_drain_running = False
+    orchestrator.stream_path_runtime = StreamPathRuntime.from_settings(
+        orchestrator.settings,
+        streaming_transcriber,
+    )
     orchestrator._requested_device = "cpu"
     orchestrator._effective_device = "cpu"
     orchestrator._vad_enabled = vad_enabled
@@ -184,6 +216,10 @@ def _build_server(
         sample_rate=FakeAudio.sample_rate,
         tail_trimmer=orchestrator.tail_trimmer,
         release_device_cache=lambda _device: None,
+    )
+    orchestrator.interim_transcript_runtime = InterimTranscriptRuntime.from_settings(
+        orchestrator.settings,
+        sample_rate=FakeAudio.sample_rate,
     )
     return cast(SessionOrchestrator, orchestrator)
 
@@ -394,6 +430,117 @@ def test_runtime_truth_reads_overlay_transport_interface() -> None:
     truth = snapshot(RuntimeTruthSourceTrap(overlay_transport=OverlayTransportFacts(enabled=True)))
 
     assert truth.overlay_events_enabled is True
+
+
+def test_runtime_truth_marks_unavailable_fact_sources_explicitly() -> None:
+    truth = snapshot(RuntimeTruthUnavailableSource())
+    status = truth.to_status(
+        RuntimeTruthState(
+            state=SessionState.IDLE,
+            sessions_active=0,
+            active_session_age_ms=None,
+        ),
+        RuntimeTruthMetrics(),
+    )
+    log_record = truth.to_log_record()
+
+    StatusMessage.model_validate(status.model_dump(mode="json"))
+    assert truth.degraded is True
+    assert status.device is None
+    assert status.effective_device is None
+    assert status.streaming_enabled is None
+    assert status.stream_helper_active is None
+    assert status.stream_fallback_reason == "runtime_truth_unavailable:stream_path:RuntimeError"
+    assert status.stream_path_executed is None
+    assert status.stream_chunks_processed is None
+    assert status.finalization_mode is None
+    assert status.final_audio_source is None
+    assert status.tail_trim_mode is None
+    assert status.vad_enabled is None
+    assert status.vad_active is None
+    assert status.vad_fallback_reason == "runtime_truth_unavailable:tail_trim_vad:RuntimeError"
+    assert status.interim_transcript_enabled is None
+    assert status.interim_transcript_updates_emitted is None
+    assert (
+        status.interim_transcript_source_fallback_reason
+        == "runtime_truth_unavailable:interim_transcript:RuntimeError"
+    )
+    assert status.overlay_events_enabled is None
+    assert (
+        log_record["stream_fallback_reason"] == "runtime_truth_unavailable:stream_path:RuntimeError"
+    )
+    assert (
+        log_record["interim_transcript_source_fallback_reason"]
+        == "runtime_truth_unavailable:interim_transcript:RuntimeError"
+    )
+    assert log_record["overlay_events_enabled"] is None
+
+
+def test_runtime_truth_marks_device_only_unavailable_as_degraded() -> None:
+    truth = snapshot(RuntimeTruthDeviceUnavailableSource())
+    status = truth.to_status(
+        RuntimeTruthState(
+            state=SessionState.IDLE,
+            sessions_active=0,
+            active_session_age_ms=None,
+        ),
+        RuntimeTruthMetrics(),
+    )
+
+    StatusMessage.model_validate(status.model_dump(mode="json"))
+    assert status.device is None
+    assert status.effective_device is None
+    assert status.stream_fallback_reason is None
+    assert status.finalization_mode == "offline_seal"
+    assert status.overlay_events_enabled is False
+    assert truth.degraded is True
+
+
+def test_orchestrator_runtime_truth_marks_missing_runtime_owners_explicitly() -> None:
+    server = _build_server(
+        streaming_enabled=True,
+        overlay_events_enabled=True,
+        vad_enabled=True,
+    )
+    for attr in (
+        "_effective_device",
+        "_requested_device",
+        "interim_transcript_runtime",
+        "seal_path_runtime",
+        "stream_path_runtime",
+        "tail_trimmer",
+    ):
+        delattr(server, attr)
+
+    truth = server.runtime_truth(overlay_events_enabled=cast(Any, None))
+    status = truth.to_status(server.runtime_status_state(), RuntimeTruthMetrics())
+    log_record = truth.to_log_record()
+
+    StatusMessage.model_validate(status.model_dump(mode="json"))
+    assert truth.degraded is True
+    assert status.device is None
+    assert status.effective_device is None
+    assert status.streaming_enabled is True
+    assert status.stream_helper_active is False
+    assert status.stream_fallback_reason == "runtime_truth_unavailable:stream_path_runtime"
+    assert status.stream_path_executed is False
+    assert status.stream_chunks_processed == 0
+    assert status.finalization_mode is None
+    assert status.final_audio_source is None
+    assert status.tail_trim_mode is None
+    assert status.vad_enabled is True
+    assert status.vad_active is False
+    assert status.vad_fallback_reason == "runtime_truth_unavailable:tail_trimmer"
+    assert status.interim_transcript_enabled is True
+    assert status.interim_transcript_live_chunks_processed is None
+    assert (
+        status.interim_transcript_source_fallback_reason
+        == "runtime_truth_unavailable:interim_transcript_runtime"
+    )
+    assert status.overlay_events_enabled is None
+    assert log_record["finalization_mode"] is None
+    assert log_record["stream_fallback_reason"] == ("runtime_truth_unavailable:stream_path_runtime")
+    assert log_record["vad_fallback_reason"] == "runtime_truth_unavailable:tail_trimmer"
 
 
 def test_interim_runtime_syncs_cached_session_config() -> None:


### PR DESCRIPTION
Fixes #157.

## Summary
- Make runtime truth snapshot collection status-safe per fact group: missing or failing sources now produce explicit `null`/fallback values instead of failing or appearing healthy.
- Make `RuntimeTruth.degraded` include unavailable device, Seal path, Overlay transport, Stream, VAD, and interim fallback states.
- Keep `SessionOrchestrator` runtime-truth methods from recreating missing runtime owners solely for status, while preserving sync for existing owners.
- Add focused tests for source failures, missing runtime owners, and device-only unavailable truth.

## Commit Notes
- `9d7d9d9` is a preliminary housekeeping commit authorized before #157 work; it records the known runtime `onnxruntime` dependency for deptry so the dead-code gate is no longer blocked by the residual #154 false positive.
- `cd4e666` contains the #157 implementation.

## Verification (#157)
- targeted: `cd parakeet-stt-daemon && uv run pytest tests/test_streaming_truth.py -q` -> PASSED (32 passed)
- regression: `cd parakeet-stt-daemon && uv run pytest tests/test_streaming_truth.py -q` -> PASSED (device-only unavailable source degrades; missing runtime owners explicit)
- full suite: `cd parakeet-stt-daemon && uv run pytest -q` -> PASSED (235 passed)
- lint: `cd parakeet-stt-daemon && uv run ruff format --check . && uv run ruff check .` -> PASSED
- types: `cd parakeet-stt-daemon && ty check --project . --error-on-warning` -> PASSED
- dead-code: `cd parakeet-stt-daemon && uv run deptry .` -> PASSED
- build: `cd parakeet-stt-daemon && uv build` -> PASSED
- pre-commit: `prek run --files parakeet-stt-daemon/src/parakeet_stt_daemon/runtime_truth_snapshot.py parakeet-stt-daemon/src/parakeet_stt_daemon/session_orchestrator.py parakeet-stt-daemon/tests/test_streaming_truth.py parakeet-stt-daemon/tests/test_session_cleanup.py parakeet-stt-daemon/pyproject.toml`; `prek run --all-files` -> PASSED
- pre-push: `prek run --stage pre-push --all-files` -> PASSED; push hook also passed
- static/security: N/A (no security linter configured for touched Python surface)
- migrations: N/A
- CLI/script smoke: N/A
- UI render: N/A
- destructive/negative: N/A
- review: `coderabbit_review_watch.py local -- --base main` -> exit 10, CodeRabbit local errored, Codex fallback clean after fixing one P2 device-degraded finding (status: `.git/coderabbit-review/20260523T194354Z/status.json`, report: `.git/coderabbit-review/20260523T194354Z/codex-review.md`)
- PR gate: `coderabbit_review_watch.py gate --pr 164` -> exit 10, remote CodeRabbit clean, local Codex fallback (summary: `.git/coderabbit-review/20260523T195227Z/gate-summary.json`, ledger: `.git/coderabbit-review/20260523T195227Z/decision-ledger.json`)
- final classified gate: `coderabbit_review_watch.py gate --pr 164 --decisions .git/coderabbit-review/20260523T195227Z/decision-ledger.json --require-classified --no-local-review` -> PASSED (summary: `.git/coderabbit-review/20260523T195838Z/gate-summary.json`, ledger: `.git/coderabbit-review/20260523T195838Z/decision-ledger.json`)
- tests added/expanded: `parakeet-stt-daemon/tests/test_streaming_truth.py`; `parakeet-stt-daemon/tests/test_session_cleanup.py`
- preexisting failures left: none

## Reviewer Findings
- CodeRabbit actionable findings: none.
- CodeRabbit pre-merge docstring coverage warning: IGNORE. Reason: this repo does not enforce docstring coverage in `prek`, Ruff, ty, or pytest; the touched functions follow the existing local style, and adding broad docstrings would be unrelated churn for #157.

## Residual Risk
- Local CodeRabbit CLI returned `coderabbit_error`; watcher used Codex fallback for local/base review. Remote CodeRabbit PR review and final classified gate completed clean for PR head `cd4e666803990d95adeb2841a453b8d8aa809467`.
