### PR TITLE
refactor(client): route ptt decisions through session coordinator

### DIFF
--- a/parakeet-ptt/src/app.rs
+++ b/parakeet-ptt/src/app.rs
@@ -20,7 +20,8 @@ use crate::audio_feedback::AudioFeedback;
 use crate::client::WsClient;
 use crate::client_session::{
     classify_error_code, handle_server_message, ClientFocusRouter, ClientInjectionDispatcher,
-    ClientLlmQueryRuntime, ClientSessionRuntime, LlmProgressOutcome, LlmQueryRequest,
+    ClientLlmQueryRuntime, ClientSessionAction, ClientSessionIgnoredHotkeyReason,
+    ClientSessionRuntime, ClientSessionStartBlocker, LlmProgressOutcome, LlmQueryRequest,
     SessionIntent,
 };
 use crate::config::ClientConfig;
@@ -466,59 +467,107 @@ pub async fn run(config: ClientConfig, ports: ClientPorts) -> Result<()> {
                                     HotkeyEvent::Down { intent } => {
                                         let intent = session_intent_from_hotkey(intent);
                                         hotkey_intent_diagnostics.note_hotkey_down(intent);
-                                        if llm_query_runtime.is_busy() {
-                                            warn!("ignoring hotkey down while LLM response is in progress");
-                                            let busy = llm_query_runtime.note_busy_overlay_rejection();
-                                            overlay_router.route_llm_answer_state_with_output_hint(
-                                                busy.session_id,
-                                                busy.seq,
-                                                busy.state,
-                                                || focus_router.next_overlay_output_hint(),
-                                            );
-                                            overlay_router.route_session_ended(
-                                                None,
-                                                busy.session_id,
-                                                Some("busy".to_string()),
-                                            );
-                                            focus_router.reset_overlay_target();
-                                            hotkey_intent_diagnostics.note_llm_busy_reject();
-                                            hotkey_intent_diagnostics.maybe_log_summary("hotkey_down_busy");
-                                            continue;
-                                        }
-                                        if let Some(session_id) = session_runtime.begin_listening(intent) {
-                                            let message = start_message(session_id, Some("auto".to_string()));
-                                            send_message(daemon.as_mut(), &message).await?;
-                                            info!(session = %session_id, ?intent, "start_session sent (hotkey down)");
-                                        } else {
-                                            hotkey_intent_diagnostics.note_hotkey_down_ignored();
-                                            debug!(
-                                                state = session_runtime.state_label(),
-                                                active_session = ?session_runtime.active_session_id(),
-                                                active_intent = ?session_runtime.active_intent(),
-                                                llm_busy = llm_query_runtime.is_busy(),
-                                                "ignoring hotkey down because client is not idle"
-                                            );
+                                        let start_blocker = llm_query_runtime
+                                            .is_busy()
+                                            .then_some(ClientSessionStartBlocker::LlmBusy);
+                                        match session_runtime
+                                            .handle_hotkey_down(intent, start_blocker)
+                                        {
+                                            ClientSessionAction::StartSession {
+                                                session_id,
+                                                intent,
+                                            } => {
+                                                let message =
+                                                    start_message(session_id, Some("auto".to_string()));
+                                                send_message(daemon.as_mut(), &message).await?;
+                                                info!(
+                                                    session = %session_id,
+                                                    ?intent,
+                                                    "start_session sent (hotkey down)"
+                                                );
+                                            }
+                                            ClientSessionAction::IgnoreHotkeyDown {
+                                                reason: ClientSessionIgnoredHotkeyReason::LlmBusy,
+                                                ..
+                                            } => {
+                                                warn!(
+                                                    "ignoring hotkey down while LLM response is in progress"
+                                                );
+                                                let busy =
+                                                    llm_query_runtime.note_busy_overlay_rejection();
+                                                overlay_router
+                                                    .route_llm_answer_state_with_output_hint(
+                                                        busy.session_id,
+                                                        busy.seq,
+                                                        busy.state,
+                                                        || focus_router.next_overlay_output_hint(),
+                                                    );
+                                                overlay_router.route_session_ended(
+                                                    None,
+                                                    busy.session_id,
+                                                    Some("busy".to_string()),
+                                                );
+                                                focus_router.reset_overlay_target();
+                                                hotkey_intent_diagnostics.note_llm_busy_reject();
+                                                hotkey_intent_diagnostics
+                                                    .maybe_log_summary("hotkey_down_busy");
+                                                continue;
+                                            }
+                                            ClientSessionAction::IgnoreHotkeyDown {
+                                                reason,
+                                                snapshot,
+                                            } => {
+                                                hotkey_intent_diagnostics.note_hotkey_down_ignored();
+                                                debug!(
+                                                    state = snapshot.state,
+                                                    active_session = ?snapshot.active_session_id,
+                                                    active_intent = ?snapshot.active_intent,
+                                                    llm_busy = llm_query_runtime.is_busy(),
+                                                    reason = reason.as_str(),
+                                                    "ignoring hotkey down because client is not idle"
+                                                );
+                                            }
+                                            other => {
+                                                unreachable!("hotkey down produced non-down action: {other:?}");
+                                            }
                                         }
                                         hotkey_intent_diagnostics.maybe_log_summary("hotkey_down");
                                     }
                                     HotkeyEvent::Up => {
                                         hotkey_intent_diagnostics.note_hotkey_up();
-                                        if let Some(session_id) = session_runtime.stop_listening() {
-                                            let message = stop_message(session_id);
-                                            send_message(daemon.as_mut(), &message).await?;
-                                            let stop_sent_at = TokioInstant::now();
-                                            focus_router.record_stop_target(session_id, stop_sent_at);
-                                            session_runtime.record_stop_message_sent(session_id, stop_sent_at);
-                                            info!(session = %session_id, "stop_session sent (hotkey up)");
-                                        } else {
-                                            hotkey_intent_diagnostics.note_hotkey_up_ignored();
-                                            debug!(
-                                                state = session_runtime.state_label(),
-                                                active_session = ?session_runtime.active_session_id(),
-                                                active_intent = ?session_runtime.active_intent(),
-                                                llm_busy = llm_query_runtime.is_busy(),
-                                                "ignoring hotkey up because no listening session is active"
-                                            );
+                                        match session_runtime.handle_hotkey_up() {
+                                            ClientSessionAction::StopSession { session_id } => {
+                                                let message = stop_message(session_id);
+                                                send_message(daemon.as_mut(), &message).await?;
+                                                let stop_sent_at = TokioInstant::now();
+                                                focus_router
+                                                    .record_stop_target(session_id, stop_sent_at);
+                                                session_runtime.record_stop_message_sent(
+                                                    session_id,
+                                                    stop_sent_at,
+                                                );
+                                                info!(
+                                                    session = %session_id,
+                                                    "stop_session sent (hotkey up)"
+                                                );
+                                            }
+                                            ClientSessionAction::IgnoreHotkeyUp {
+                                                reason,
+                                                snapshot,
+                                            } => {
+                                                hotkey_intent_diagnostics.note_hotkey_up_ignored();
+                                                debug!(
+                                                    state = snapshot.state,
+                                                    active_session = ?snapshot.active_session_id,
+                                                    active_intent = ?snapshot.active_intent,
+                                                    llm_busy = llm_query_runtime.is_busy(),
+                                                    reason = reason.as_str(),
+                                                    "ignoring hotkey up because no listening session is active"
+                                                );
+                                            }
+                                            other => {
+                                                unreachable!("hotkey up produced non-up action: {other:?}");
+                                            }
                                         }
                                         hotkey_intent_diagnostics.maybe_log_summary("hotkey_up");
                                     }
@@ -642,7 +691,11 @@ pub async fn run(config: ClientConfig, ports: ClientPorts) -> Result<()> {
                     warn!("session loop ended with error: {err}");
                 }
                 hotkey_intent_diagnostics.log_summary("daemon_connection_drop");
-                session_runtime.reset_for_connection_drop();
+                let reset_action = session_runtime.handle_connection_drop();
+                debug!(
+                    ?reset_action,
+                    "client session coordinator reset after daemon connection drop"
+                );
                 llm_query_runtime.reset_for_connection_drop();
                 focus_router.reset_for_connection_drop();
                 warn!("Reconnecting to daemon after drop");
@@ -1159,6 +1212,35 @@ mod tests {
             }
             other => panic!("expected start_session, got {other:?}"),
         }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn app_hotkey_release_sends_stop_session_message() {
+        let (config, ports, mut runtime) =
+            ClientRuntimeHarness::new(test_app_config()).into_parts();
+
+        let app_task = tokio::spawn(run(config, ports));
+        runtime.send_hotkey_down(HotkeyIntent::Dictate);
+        let start = runtime.next_sent_message(Duration::from_millis(250)).await;
+        let active_session_id = match start {
+            ClientMessage::StartSession { session_id, .. } => session_id,
+            other => panic!("expected start_session, got {other:?}"),
+        };
+
+        runtime.send_hotkey_up();
+        let stop = runtime.next_sent_message(Duration::from_millis(250)).await;
+        app_task.abort();
+
+        match stop {
+            ClientMessage::StopSession { session_id, .. } => {
+                assert_eq!(session_id, active_session_id);
+            }
+            other => panic!("expected stop_session, got {other:?}"),
+        }
+        assert!(
+            runtime.recorded_injections().is_empty(),
+            "stop-session hotkey path should not enqueue Injection"
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/parakeet-ptt/src/client_session.rs
+++ b/parakeet-ptt/src/client_session.rs
@@ -68,6 +68,47 @@ pub(crate) struct ClientSessionRuntime {
     last_stop_message: Option<(Uuid, TokioInstant)>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ClientSessionStartBlocker {
+    LlmBusy,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ClientSessionIgnoredHotkeyReason {
+    LlmBusy,
+    NotIdle,
+    NotListening,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ClientSessionSnapshot {
+    pub(crate) state: &'static str,
+    pub(crate) active_session_id: Option<Uuid>,
+    pub(crate) active_intent: Option<SessionIntent>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ClientSessionAction {
+    StartSession {
+        session_id: Uuid,
+        intent: SessionIntent,
+    },
+    StopSession {
+        session_id: Uuid,
+    },
+    IgnoreHotkeyDown {
+        reason: ClientSessionIgnoredHotkeyReason,
+        snapshot: ClientSessionSnapshot,
+    },
+    IgnoreHotkeyUp {
+        reason: ClientSessionIgnoredHotkeyReason,
+        snapshot: ClientSessionSnapshot,
+    },
+    ResetForConnectionDrop {
+        before: ClientSessionSnapshot,
+    },
+}
+
 #[derive(Debug, Default)]
 struct LlmSessionRuntime {
     busy: bool,
@@ -277,6 +318,24 @@ impl LlmQueryRequest {
             transcript,
             daemon_latency_ms,
             daemon_audio_ms,
+        }
+    }
+}
+
+impl ClientSessionIgnoredHotkeyReason {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::LlmBusy => "llm_busy",
+            Self::NotIdle => "not_idle",
+            Self::NotListening => "not_listening",
+        }
+    }
+}
+
+impl From<ClientSessionStartBlocker> for ClientSessionIgnoredHotkeyReason {
+    fn from(blocker: ClientSessionStartBlocker) -> Self {
+        match blocker {
+            ClientSessionStartBlocker::LlmBusy => Self::LlmBusy,
         }
     }
 }
@@ -901,6 +960,43 @@ impl ClientSessionRuntime {
         }
     }
 
+    pub(crate) fn handle_hotkey_down(
+        &mut self,
+        intent: SessionIntent,
+        start_blocker: Option<ClientSessionStartBlocker>,
+    ) -> ClientSessionAction {
+        if let Some(start_blocker) = start_blocker {
+            return ClientSessionAction::IgnoreHotkeyDown {
+                reason: start_blocker.into(),
+                snapshot: self.snapshot(),
+            };
+        }
+
+        match self.begin_listening(intent) {
+            Some(session_id) => ClientSessionAction::StartSession { session_id, intent },
+            None => ClientSessionAction::IgnoreHotkeyDown {
+                reason: ClientSessionIgnoredHotkeyReason::NotIdle,
+                snapshot: self.snapshot(),
+            },
+        }
+    }
+
+    pub(crate) fn handle_hotkey_up(&mut self) -> ClientSessionAction {
+        match self.stop_listening() {
+            Some(session_id) => ClientSessionAction::StopSession { session_id },
+            None => ClientSessionAction::IgnoreHotkeyUp {
+                reason: ClientSessionIgnoredHotkeyReason::NotListening,
+                snapshot: self.snapshot(),
+            },
+        }
+    }
+
+    pub(crate) fn handle_connection_drop(&mut self) -> ClientSessionAction {
+        let before = self.snapshot();
+        self.reset_for_connection_drop();
+        ClientSessionAction::ResetForConnectionDrop { before }
+    }
+
     pub(crate) fn begin_listening(&mut self, intent: SessionIntent) -> Option<Uuid> {
         let session_id = self.state.begin_listening()?;
         self.active_intent = Some(intent);
@@ -937,6 +1033,14 @@ impl ClientSessionRuntime {
 
     pub(crate) fn state_label(&self) -> &'static str {
         state_label(&self.state)
+    }
+
+    fn snapshot(&self) -> ClientSessionSnapshot {
+        ClientSessionSnapshot {
+            state: self.state_label(),
+            active_session_id: self.active_session_id(),
+            active_intent: self.active_intent(),
+        }
     }
 
     pub(crate) fn final_result_belongs_to_active_session(&self, session_id: Uuid) -> bool {
@@ -1166,9 +1270,11 @@ mod tests {
 
     use super::{
         handle_server_message, parent_focus_from_observation, ClientFocusRouter,
-        ClientInjectionDispatcher, ClientLlmQueryRuntime, ClientSessionRuntime,
-        InjectionDispatchOutcome, LlmAnswerInjection, LlmCompletionContext, LlmDeltaOverlay,
-        LlmProgressOutcome, LlmQueryRequest, LlmStateOverlay, SessionIntent,
+        ClientInjectionDispatcher, ClientLlmQueryRuntime, ClientSessionAction,
+        ClientSessionIgnoredHotkeyReason, ClientSessionRuntime, ClientSessionSnapshot,
+        ClientSessionStartBlocker, InjectionDispatchOutcome, LlmAnswerInjection,
+        LlmCompletionContext, LlmDeltaOverlay, LlmProgressOutcome, LlmQueryRequest,
+        LlmStateOverlay, SessionIntent,
     };
 
     type TestBoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
@@ -1350,6 +1456,127 @@ mod tests {
             .expect("state should stop listening");
         runtime.record_stop_message_sent(session_id, stopped_at);
         (runtime, session_id)
+    }
+
+    #[test]
+    fn client_session_coordinator_starts_idle_session_once() {
+        let mut runtime = ClientSessionRuntime::new();
+
+        let session_id = match runtime.handle_hotkey_down(SessionIntent::Dictate, None) {
+            ClientSessionAction::StartSession { session_id, intent } => {
+                assert_eq!(intent, SessionIntent::Dictate);
+                session_id
+            }
+            other => panic!("expected start_session action, got {other:?}"),
+        };
+
+        assert_eq!(runtime.state_label(), "listening");
+        assert_eq!(runtime.active_session_id(), Some(session_id));
+        assert_eq!(runtime.active_intent(), Some(SessionIntent::Dictate));
+        assert_eq!(
+            runtime.handle_hotkey_down(SessionIntent::Dictate, None),
+            ClientSessionAction::IgnoreHotkeyDown {
+                reason: ClientSessionIgnoredHotkeyReason::NotIdle,
+                snapshot: ClientSessionSnapshot {
+                    state: "listening",
+                    active_session_id: Some(session_id),
+                    active_intent: Some(SessionIntent::Dictate),
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn client_session_coordinator_stops_active_session_once() {
+        let mut runtime = ClientSessionRuntime::new();
+        let session_id = match runtime.handle_hotkey_down(SessionIntent::Dictate, None) {
+            ClientSessionAction::StartSession { session_id, .. } => session_id,
+            other => panic!("expected start_session action, got {other:?}"),
+        };
+
+        assert_eq!(
+            runtime.handle_hotkey_up(),
+            ClientSessionAction::StopSession { session_id }
+        );
+        assert_eq!(runtime.state_label(), "waiting_result");
+        assert_eq!(runtime.active_session_id(), Some(session_id));
+        assert_eq!(
+            runtime.handle_hotkey_up(),
+            ClientSessionAction::IgnoreHotkeyUp {
+                reason: ClientSessionIgnoredHotkeyReason::NotListening,
+                snapshot: ClientSessionSnapshot {
+                    state: "waiting_result",
+                    active_session_id: Some(session_id),
+                    active_intent: Some(SessionIntent::Dictate),
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn client_session_coordinator_ignores_out_of_order_hotkey_up() {
+        let mut runtime = ClientSessionRuntime::new();
+
+        assert_eq!(
+            runtime.handle_hotkey_up(),
+            ClientSessionAction::IgnoreHotkeyUp {
+                reason: ClientSessionIgnoredHotkeyReason::NotListening,
+                snapshot: ClientSessionSnapshot {
+                    state: "idle",
+                    active_session_id: None,
+                    active_intent: None,
+                },
+            }
+        );
+        assert_eq!(runtime.state_label(), "idle");
+        assert_eq!(runtime.active_session_id(), None);
+        assert_eq!(runtime.active_intent(), None);
+    }
+
+    #[test]
+    fn client_session_coordinator_rejects_hotkey_down_when_start_blocked() {
+        let mut runtime = ClientSessionRuntime::new();
+
+        assert_eq!(
+            runtime.handle_hotkey_down(
+                SessionIntent::LlmQuery,
+                Some(ClientSessionStartBlocker::LlmBusy),
+            ),
+            ClientSessionAction::IgnoreHotkeyDown {
+                reason: ClientSessionIgnoredHotkeyReason::LlmBusy,
+                snapshot: ClientSessionSnapshot {
+                    state: "idle",
+                    active_session_id: None,
+                    active_intent: None,
+                },
+            }
+        );
+        assert_eq!(runtime.state_label(), "idle");
+        assert_eq!(runtime.active_session_id(), None);
+        assert_eq!(runtime.active_intent(), None);
+    }
+
+    #[test]
+    fn client_session_coordinator_reset_action_clears_connection_state() {
+        let stop_message_at = TokioInstant::now();
+        let (mut runtime, session_id) = runtime_waiting_for_result_with_timing(stop_message_at);
+
+        assert_eq!(
+            runtime.handle_connection_drop(),
+            ClientSessionAction::ResetForConnectionDrop {
+                before: ClientSessionSnapshot {
+                    state: "waiting_result",
+                    active_session_id: Some(session_id),
+                    active_intent: Some(SessionIntent::Dictate),
+                },
+            }
+        );
+
+        assert_eq!(runtime.state_label(), "idle");
+        assert_eq!(runtime.active_session_id(), None);
+        assert_eq!(runtime.active_intent(), None);
+        assert_eq!(runtime.last_hotkey_up_at, None);
+        assert_eq!(runtime.last_stop_message, None);
     }
 
     fn test_focus_snapshot(output_name: Option<&str>) -> FocusSnapshot {


### PR DESCRIPTION
## Summary

Closes #155.

- Add explicit `ClientSessionAction` outputs for hotkey down, hotkey up, and connection-drop reset in `ClientSessionRuntime`.
- Keep `app.rs` as the adapter that executes coordinator actions against the Daemon WebSocket.
- Add coordinator tests for idle start, duplicate/stale/out-of-order hotkey input, blocked starts, and connection-drop reset, plus an app runtime stop-session smoke.

## Verification (#155)

- targeted: `cargo test --manifest-path parakeet-ptt/Cargo.toml client_session_coordinator -- --nocapture` -> PASSED
- targeted: `cargo test --manifest-path parakeet-ptt/Cargo.toml app_hotkey_ -- --nocapture` -> PASSED
- regression: coordinator tests for duplicate down, stale/duplicate up, out-of-order up, blocked down, and connection drop -> PASSED; parent fail demo N/A because this is a refactor extraction, not a bug-fix report
- full suite: `cargo test --manifest-path parakeet-ptt/Cargo.toml -q` -> PASSED
- full suite: `prek run --stage pre-push --all-files` -> PASSED
- full suite: `just phase6-contract` -> PASSED
- lint: `cargo fmt --manifest-path parakeet-ptt/Cargo.toml -- --check` -> PASSED
- lint: `cargo clippy --manifest-path parakeet-ptt/Cargo.toml --all-targets --all-features -- -D warnings` -> PASSED
- types: `cargo check --manifest-path parakeet-ptt/Cargo.toml --all-targets --all-features` -> PASSED
- build: `cargo build --manifest-path parakeet-ptt/Cargo.toml --bins` -> PASSED
- pre-commit: `prek run --files parakeet-ptt/src/app.rs parakeet-ptt/src/client_session.rs` -> PASSED
- pre-commit: `prek run --all-files` -> PASSED
- static/security: `git diff --check` -> PASSED; dedicated security scan N/A
- migrations: N/A
- CLI/script smoke: N/A, no CLI or shell-helper behavior changed
- UI render: N/A, no UI rendering changed
- destructive/negative: N/A, no destructive operations changed
- tests added/expanded: `parakeet-ptt/src/client_session.rs`; `parakeet-ptt/src/app.rs`
- preexisting failures left: none

## Review (#155)

- CodeRabbit same-head gate: `coderabbit_review_watch.py gate --pr 165` -> exit 10 because local CodeRabbit CLI returned `coderabbit_error`; watcher completed Codex fallback, remote CodeRabbit review was `completed_clean`, no actionable findings. Summary: `.git/coderabbit-review/20260523T210107Z/gate-summary.json`; ledger: `.git/coderabbit-review/20260523T210107Z/decision-ledger.json`; head: `58635f2dfe5f689290d1d32e302cb710241e7eae`.
- Final classified gate: `coderabbit_review_watch.py gate --pr 165 --decisions .git/coderabbit-review/20260523T210107Z/decision-ledger.json --require-classified --no-local-review` -> exit 0 clean. Summary: `.git/coderabbit-review/20260523T210628Z/gate-summary.json`; ledger: `.git/coderabbit-review/20260523T210628Z/decision-ledger.json`.
- PR feedback fetch: `gh pr view`, `gh api repos/SystemicVoid/parakeet-stt/pulls/165/comments`, and GraphQL `reviewThreads` found no review comments, reviews, or review threads. CodeRabbit top-level comment says no actionable comments; its generated docstring-coverage warning was not a gate finding and is treated as non-actionable/project-wide.

## Deferrals

None.
