### PR TITLE
Resolve #159 shared focus routing policy

### DIFF
--- a/parakeet-ptt/src/client_session.rs
+++ b/parakeet-ptt/src/client_session.rs
@@ -1363,7 +1363,10 @@ mod tests {
     };
     use crate::protocol::ServerMessage;
     use crate::routing::FocusObservation;
-    use crate::surface_focus::{FocusSnapshot, WaylandFocusObservation};
+    use crate::surface_focus::{
+        FocusSnapshot, WaylandFocusObservation, WAYLAND_FOCUS_REASON_CACHE_STALE,
+        WAYLAND_FOCUS_REASON_TRANSITION_NO_ACTIVATED,
+    };
     use anyhow::anyhow;
     use tokio::sync::mpsc;
     use tokio::time::{timeout, Instant as TokioInstant};
@@ -1830,7 +1833,7 @@ mod tests {
             FocusObservation::from_wayland(WaylandFocusObservation::LowConfidence {
                 snapshot: test_focus_snapshot(Some("DP-1")),
                 cache_age_ms: 1_600,
-                reason: "wayland_cache_stale",
+                reason: WAYLAND_FOCUS_REASON_CACHE_STALE,
             });
         assert_eq!(
             focus_router
@@ -1842,7 +1845,7 @@ mod tests {
             FocusObservation::from_wayland(WaylandFocusObservation::LowConfidence {
                 snapshot: test_focus_snapshot(Some("HDMI-A-1")),
                 cache_age_ms: 12,
-                reason: "wayland_transition_no_activated",
+                reason: WAYLAND_FOCUS_REASON_TRANSITION_NO_ACTIVATED,
             });
         assert_eq!(
             focus_router

--- a/parakeet-ptt/src/client_session.rs
+++ b/parakeet-ptt/src/client_session.rs
@@ -23,8 +23,12 @@ use crate::injector_runtime::{
 use crate::llm::{sanitize_model_answer, LlmAnswerer, LlmProgress};
 use crate::overlay_router::{OverlayRouter, OverlaySink};
 use crate::protocol::ServerMessage;
+use crate::routing::{
+    decide_overlay_output_target, FocusObservation, OVERLAY_OUTPUT_STALE_MS,
+    OVERLAY_OUTPUT_TRANSITION_GRACE_MS,
+};
 use crate::state::PttState;
-use crate::surface_focus::{WaylandFocusCache, WaylandFocusObservation};
+use crate::surface_focus::WaylandFocusCache;
 
 const PARENT_FOCUS_STALE_MS: u64 = 30_000;
 const PARENT_FOCUS_TRANSITION_GRACE_MS: u64 = 500;
@@ -257,7 +261,12 @@ impl ClientFocusRouter {
     }
 
     pub(crate) fn next_overlay_output_hint(&mut self) -> Option<String> {
-        let output_name = self.focus_cache.as_ref()?.current_output_name();
+        let output_name = self.focus_cache.as_ref().and_then(|cache| {
+            let observation = FocusObservation::from_wayland(
+                cache.observe(OVERLAY_OUTPUT_STALE_MS, OVERLAY_OUTPUT_TRANSITION_GRACE_MS),
+            );
+            decide_overlay_output_target(&observation)
+        });
         self.next_overlay_output_hint_from(output_name)
     }
 
@@ -273,10 +282,10 @@ impl ClientFocusRouter {
 
     fn capture_parent_focus(&self) -> Option<ParentFocusCapture> {
         let cache = self.focus_cache.as_ref()?;
-        Some(parent_focus_from_observation(cache.observe(
-            PARENT_FOCUS_STALE_MS,
-            PARENT_FOCUS_TRANSITION_GRACE_MS,
-        )))
+        let observation = FocusObservation::from_wayland(
+            cache.observe(PARENT_FOCUS_STALE_MS, PARENT_FOCUS_TRANSITION_GRACE_MS),
+        );
+        Some(parent_focus_from_observation(observation))
     }
 
     fn take_captured_parent_focus_for_enqueue(
@@ -308,6 +317,14 @@ impl ClientFocusRouter {
     #[cfg(test)]
     fn next_overlay_output_hint_for_tests(&mut self, output_name: Option<&str>) -> Option<String> {
         self.next_overlay_output_hint_from(output_name.map(str::to_string))
+    }
+
+    #[cfg(test)]
+    fn next_overlay_output_hint_from_observation_for_tests(
+        &mut self,
+        observation: FocusObservation,
+    ) -> Option<String> {
+        self.next_overlay_output_hint_from(decide_overlay_output_target(&observation))
     }
 }
 
@@ -978,39 +995,13 @@ fn log_dispatch_worker_gone(session_id: Uuid, origin: InjectionOrigin) {
     }
 }
 
-fn parent_focus_from_observation(observation: WaylandFocusObservation) -> ParentFocusCapture {
-    match observation {
-        WaylandFocusObservation::Fresh {
-            snapshot,
-            cache_age_ms,
-        } => ParentFocusCapture {
-            snapshot: Some(snapshot),
-            source_selected: "wayland_cache".to_string(),
-            wayland_cache_age_ms: Some(cache_age_ms),
-            wayland_fallback_reason: None,
-            captured_elapsed_ms: Some(0),
-        },
-        WaylandFocusObservation::LowConfidence {
-            snapshot,
-            cache_age_ms,
-            reason,
-        } => ParentFocusCapture {
-            snapshot: Some(snapshot),
-            source_selected: "wayland_cache_low_confidence".to_string(),
-            wayland_cache_age_ms: Some(cache_age_ms),
-            wayland_fallback_reason: Some(reason.to_string()),
-            captured_elapsed_ms: Some(0),
-        },
-        WaylandFocusObservation::Unavailable {
-            reason,
-            cache_age_ms,
-        } => ParentFocusCapture {
-            snapshot: None,
-            source_selected: "wayland_unavailable".to_string(),
-            wayland_cache_age_ms: cache_age_ms,
-            wayland_fallback_reason: Some(reason.to_string()),
-            captured_elapsed_ms: Some(0),
-        },
+fn parent_focus_from_observation(observation: FocusObservation) -> ParentFocusCapture {
+    ParentFocusCapture {
+        snapshot: observation.snapshot,
+        source_selected: observation.source_selected.to_string(),
+        wayland_cache_age_ms: observation.wayland_cache_age_ms,
+        wayland_fallback_reason: observation.wayland_fallback_reason.map(str::to_string),
+        captured_elapsed_ms: Some(0),
     }
 }
 
@@ -1371,6 +1362,7 @@ mod tests {
         RuntimeOverlaySink,
     };
     use crate::protocol::ServerMessage;
+    use crate::routing::FocusObservation;
     use crate::surface_focus::{FocusSnapshot, WaylandFocusObservation};
     use anyhow::anyhow;
     use tokio::sync::mpsc;
@@ -1757,11 +1749,13 @@ mod tests {
     #[test]
     fn client_focus_router_maps_parent_focus_for_injection() {
         let session_id = Uuid::new_v4();
-        let parent_focus = parent_focus_from_observation(WaylandFocusObservation::LowConfidence {
-            snapshot: test_focus_snapshot(Some("DP-1")),
-            cache_age_ms: 17,
-            reason: "within_transition_grace",
-        });
+        let parent_focus = parent_focus_from_observation(FocusObservation::from_wayland(
+            WaylandFocusObservation::LowConfidence {
+                snapshot: test_focus_snapshot(Some("DP-1")),
+                cache_age_ms: 17,
+                reason: "within_transition_grace",
+            },
+        ));
         let mut focus_router = ClientFocusRouter::default();
         focus_router.record_parent_focus_for_tests(
             session_id,
@@ -1817,6 +1811,52 @@ mod tests {
         assert_eq!(
             focus_router.next_overlay_output_hint_for_tests(Some("HDMI-A-1")),
             Some("HDMI-A-1".to_string())
+        );
+    }
+
+    #[test]
+    fn client_focus_router_uses_shared_observation_for_overlay_hints() {
+        let mut focus_router = ClientFocusRouter::default();
+        let fresh = FocusObservation::from_wayland(WaylandFocusObservation::Fresh {
+            snapshot: test_focus_snapshot(Some("DP-1")),
+            cache_age_ms: 5,
+        });
+        assert_eq!(
+            focus_router.next_overlay_output_hint_from_observation_for_tests(fresh),
+            Some("DP-1".to_string())
+        );
+
+        let duplicate_low_confidence =
+            FocusObservation::from_wayland(WaylandFocusObservation::LowConfidence {
+                snapshot: test_focus_snapshot(Some("DP-1")),
+                cache_age_ms: 1_600,
+                reason: "wayland_cache_stale",
+            });
+        assert_eq!(
+            focus_router
+                .next_overlay_output_hint_from_observation_for_tests(duplicate_low_confidence),
+            None
+        );
+
+        let low_confidence_new_output =
+            FocusObservation::from_wayland(WaylandFocusObservation::LowConfidence {
+                snapshot: test_focus_snapshot(Some("HDMI-A-1")),
+                cache_age_ms: 12,
+                reason: "wayland_transition_no_activated",
+            });
+        assert_eq!(
+            focus_router
+                .next_overlay_output_hint_from_observation_for_tests(low_confidence_new_output),
+            Some("HDMI-A-1".to_string())
+        );
+
+        let unavailable = FocusObservation::from_wayland(WaylandFocusObservation::Unavailable {
+            reason: "wayland_cache_uninitialized",
+            cache_age_ms: None,
+        });
+        assert_eq!(
+            focus_router.next_overlay_output_hint_from_observation_for_tests(unavailable),
+            None
         );
     }
 
@@ -2244,10 +2284,12 @@ mod tests {
         let dispatcher = ClientInjectionDispatcher::new(worker);
         let session_id = Uuid::new_v4();
         let mut focus_router = ClientFocusRouter::default();
-        let parent_focus = parent_focus_from_observation(WaylandFocusObservation::Fresh {
-            snapshot: test_focus_snapshot(Some("DP-1")),
-            cache_age_ms: 8,
-        });
+        let parent_focus = parent_focus_from_observation(FocusObservation::from_wayland(
+            WaylandFocusObservation::Fresh {
+                snapshot: test_focus_snapshot(Some("DP-1")),
+                cache_age_ms: 8,
+            },
+        ));
         focus_router.record_parent_focus_for_tests(
             session_id,
             parent_focus,
@@ -2341,10 +2383,12 @@ mod tests {
         let mut focus_router = ClientFocusRouter::default();
         focus_router.record_parent_focus_for_tests(
             session_id,
-            parent_focus_from_observation(WaylandFocusObservation::Fresh {
-                snapshot: test_focus_snapshot(Some("DP-1")),
-                cache_age_ms: 3,
-            }),
+            parent_focus_from_observation(FocusObservation::from_wayland(
+                WaylandFocusObservation::Fresh {
+                    snapshot: test_focus_snapshot(Some("DP-1")),
+                    cache_age_ms: 3,
+                },
+            )),
             TokioInstant::now() - Duration::from_millis(10),
         );
 

--- a/parakeet-ptt/src/injector.rs
+++ b/parakeet-ptt/src/injector.rs
@@ -15,8 +15,8 @@ use tracing::{debug, info, warn};
 use uuid::Uuid;
 
 use crate::config::{ClipboardOptions, PasteShortcut};
-use crate::routing::{decide_route_for_focus, FocusConfidence, FocusRouteInput, RouteDecision};
-use crate::surface_focus::{FocusSnapshot, WaylandFocusCache, WaylandFocusObservation};
+use crate::routing::{decide_route_for_focus, FocusObservation, RouteDecision};
+use crate::surface_focus::{FocusSnapshot, WaylandFocusCache};
 
 static INJECTION_TRACE_ID: AtomicU64 = AtomicU64::new(1);
 
@@ -635,15 +635,6 @@ pub struct ClipboardInjector {
     wayland_focus_cache: Option<WaylandFocusCache>,
     context: Option<InjectorContext>,
     forced_shortcut: Option<PasteShortcut>,
-}
-
-#[derive(Debug, Clone)]
-struct FocusResolutionOutcome {
-    snapshot: Option<FocusSnapshot>,
-    source_selected: &'static str,
-    confidence: FocusConfidence,
-    wayland_cache_age_ms: Option<u64>,
-    wayland_fallback_reason: Option<&'static str>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -1442,49 +1433,13 @@ impl ClipboardInjector {
         Self::stop_foreground_source(primary_source, trace_id, "primary");
     }
 
-    fn resolve_focus_metadata(&self, _trace_id: u64) -> FocusResolutionOutcome {
+    fn resolve_focus_metadata(&self, _trace_id: u64) -> FocusObservation {
         let Some(cache) = self.wayland_focus_cache.as_ref() else {
-            return FocusResolutionOutcome {
-                snapshot: None,
-                source_selected: "wayland_unavailable",
-                confidence: FocusConfidence::Unavailable,
-                wayland_cache_age_ms: None,
-                wayland_fallback_reason: Some("wayland_cache_not_initialized"),
-            };
+            return FocusObservation::unavailable("wayland_cache_not_initialized", None);
         };
-        match cache.observe(Self::WAYLAND_STALE_MS, Self::WAYLAND_TRANSITION_GRACE_MS) {
-            WaylandFocusObservation::Fresh {
-                snapshot,
-                cache_age_ms,
-            } => FocusResolutionOutcome {
-                snapshot: Some(snapshot),
-                source_selected: "wayland_cache",
-                confidence: FocusConfidence::Fresh,
-                wayland_cache_age_ms: Some(cache_age_ms),
-                wayland_fallback_reason: None,
-            },
-            WaylandFocusObservation::LowConfidence {
-                snapshot,
-                cache_age_ms,
-                reason,
-            } => FocusResolutionOutcome {
-                snapshot: Some(snapshot),
-                source_selected: "wayland_cache_low_confidence",
-                confidence: FocusConfidence::LowConfidence,
-                wayland_cache_age_ms: Some(cache_age_ms),
-                wayland_fallback_reason: Some(reason),
-            },
-            WaylandFocusObservation::Unavailable {
-                reason,
-                cache_age_ms,
-            } => FocusResolutionOutcome {
-                snapshot: None,
-                source_selected: "wayland_unavailable",
-                confidence: FocusConfidence::Unavailable,
-                wayland_cache_age_ms: cache_age_ms,
-                wayland_fallback_reason: Some(reason),
-            },
-        }
+        FocusObservation::from_wayland(
+            cache.observe(Self::WAYLAND_STALE_MS, Self::WAYLAND_TRANSITION_GRACE_MS),
+        )
     }
 }
 
@@ -1763,11 +1718,7 @@ impl TextInjector for ClipboardInjector {
                 route_decision = Some(route);
                 (shortcuts.primary, shortcuts.adaptive_fallback)
             } else {
-                let route = decide_route_for_focus(FocusRouteInput::new(
-                    child_focus.snapshot.as_ref(),
-                    child_focus.source_selected,
-                    child_focus.confidence,
-                ));
+                let route = decide_route_for_focus(child_focus.route_input());
                 let shortcuts = route.shortcut_plan;
 
                 if let Some(snapshot) = child_focus.snapshot.as_ref() {

--- a/parakeet-ptt/src/routing.rs
+++ b/parakeet-ptt/src/routing.rs
@@ -1,6 +1,9 @@
 use crate::config::PasteShortcut;
-use crate::surface_focus::FocusSnapshot;
+use crate::surface_focus::{FocusSnapshot, WaylandFocusObservation};
 use serde::{Deserialize, Serialize};
+
+pub const OVERLAY_OUTPUT_STALE_MS: u64 = 1_500;
+pub const OVERLAY_OUTPUT_TRANSITION_GRACE_MS: u64 = 250;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SurfaceClass {
@@ -56,6 +59,68 @@ impl<'a> FocusRouteInput<'a> {
             source,
             confidence,
         }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FocusObservation {
+    pub snapshot: Option<FocusSnapshot>,
+    pub source_selected: &'static str,
+    pub confidence: FocusConfidence,
+    pub wayland_cache_age_ms: Option<u64>,
+    pub wayland_fallback_reason: Option<&'static str>,
+}
+
+impl FocusObservation {
+    pub fn from_wayland(observation: WaylandFocusObservation) -> Self {
+        match observation {
+            WaylandFocusObservation::Fresh {
+                snapshot,
+                cache_age_ms,
+            } => Self {
+                snapshot: Some(snapshot),
+                source_selected: "wayland_cache",
+                confidence: FocusConfidence::Fresh,
+                wayland_cache_age_ms: Some(cache_age_ms),
+                wayland_fallback_reason: None,
+            },
+            WaylandFocusObservation::LowConfidence {
+                snapshot,
+                cache_age_ms,
+                reason,
+            } => Self {
+                snapshot: Some(snapshot),
+                source_selected: "wayland_cache_low_confidence",
+                confidence: FocusConfidence::LowConfidence,
+                wayland_cache_age_ms: Some(cache_age_ms),
+                wayland_fallback_reason: Some(reason),
+            },
+            WaylandFocusObservation::Unavailable {
+                reason,
+                cache_age_ms,
+            } => Self::unavailable(reason, cache_age_ms),
+        }
+    }
+
+    pub fn unavailable(
+        reason: &'static str,
+        wayland_cache_age_ms: Option<u64>,
+    ) -> FocusObservation {
+        Self {
+            snapshot: None,
+            source_selected: "wayland_unavailable",
+            confidence: FocusConfidence::Unavailable,
+            wayland_cache_age_ms,
+            wayland_fallback_reason: Some(reason),
+        }
+    }
+
+    pub fn route_input(&self) -> FocusRouteInput<'_> {
+        FocusRouteInput::new(
+            self.snapshot.as_ref(),
+            self.source_selected,
+            self.confidence,
+        )
     }
 }
 
@@ -180,6 +245,27 @@ pub fn decide_route_for_focus(input: FocusRouteInput<'_>) -> RouteDecision {
     }
 }
 
+pub fn decide_overlay_output_target(observation: &FocusObservation) -> Option<String> {
+    match observation.confidence {
+        FocusConfidence::Fresh => observation
+            .snapshot
+            .as_ref()
+            .and_then(|snapshot| snapshot.output_name.clone()),
+        FocusConfidence::LowConfidence
+            if matches!(
+                observation.wayland_fallback_reason,
+                Some("wayland_transition_no_activated" | "wayland_cache_stale")
+            ) =>
+        {
+            observation
+                .snapshot
+                .as_ref()
+                .and_then(|snapshot| snapshot.output_name.clone())
+        }
+        FocusConfidence::LowConfidence | FocusConfidence::Unavailable => None,
+    }
+}
+
 fn route_decision(
     input: FocusRouteInput<'_>,
     surface_class: SurfaceClass,
@@ -267,11 +353,11 @@ fn normalize_for_hint_match(raw: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        classify_surface_with_reason, decide_route_for_focus, FocusConfidence, FocusRouteInput,
-        SurfaceClass,
+        classify_surface_with_reason, decide_overlay_output_target, decide_route_for_focus,
+        FocusConfidence, FocusObservation, FocusRouteInput, SurfaceClass,
     };
     use crate::config::PasteShortcut;
-    use crate::surface_focus::FocusSnapshot;
+    use crate::surface_focus::{FocusSnapshot, WaylandFocusObservation};
 
     fn snapshot(
         app_name: &str,
@@ -471,5 +557,92 @@ mod tests {
         );
         assert_eq!(decision.output_name, None);
         assert_eq!(decision.reason, "adaptive unknown surface");
+    }
+
+    #[test]
+    fn shared_focus_observation_feeds_injection_route_and_overlay_target() {
+        let mut focus = snapshot(
+            "Ghostty",
+            "terminal",
+            "/com/mitchellh/ghostty/a11y/abc",
+            true,
+        );
+        focus.output_name = Some("DP-1".to_string());
+
+        let observation = FocusObservation::from_wayland(WaylandFocusObservation::Fresh {
+            snapshot: focus,
+            cache_age_ms: 8,
+        });
+        let route = decide_route_for_focus(observation.route_input());
+
+        assert_eq!(observation.source_selected, "wayland_cache");
+        assert_eq!(observation.confidence, FocusConfidence::Fresh);
+        assert_eq!(route.source, "wayland_cache");
+        assert_eq!(route.focus_confidence, FocusConfidence::Fresh);
+        assert_eq!(route.surface_class, SurfaceClass::Terminal);
+        assert_eq!(route.output_name.as_deref(), Some("DP-1"));
+        assert_eq!(
+            decide_overlay_output_target(&observation).as_deref(),
+            Some("DP-1")
+        );
+    }
+
+    #[test]
+    fn overlay_output_target_preserves_focus_confidence_rules() {
+        let mut fresh = snapshot("Code", "editor", "/org/example/code", true);
+        fresh.output_name = Some("DP-1".to_string());
+        let fresh_observation = FocusObservation::from_wayland(WaylandFocusObservation::Fresh {
+            snapshot: fresh,
+            cache_age_ms: 4,
+        });
+        assert_eq!(
+            decide_overlay_output_target(&fresh_observation).as_deref(),
+            Some("DP-1")
+        );
+
+        let mut stale = snapshot("Ghostty", "terminal", "/org/example/terminal", true);
+        stale.output_name = Some("HDMI-A-1".to_string());
+        let stale_observation =
+            FocusObservation::from_wayland(WaylandFocusObservation::LowConfidence {
+                snapshot: stale,
+                cache_age_ms: 1_600,
+                reason: "wayland_cache_stale",
+            });
+        assert_eq!(
+            decide_overlay_output_target(&stale_observation).as_deref(),
+            Some("HDMI-A-1")
+        );
+
+        let mut transition = snapshot("Code", "editor", "/org/example/code", false);
+        transition.output_name = Some("DP-2".to_string());
+        let transition_observation =
+            FocusObservation::from_wayland(WaylandFocusObservation::LowConfidence {
+                snapshot: transition,
+                cache_age_ms: 12,
+                reason: "wayland_transition_no_activated",
+            });
+        assert_eq!(
+            decide_overlay_output_target(&transition_observation).as_deref(),
+            Some("DP-2")
+        );
+
+        let mut low_confidence_other = snapshot("Code", "editor", "/org/example/code", true);
+        low_confidence_other.output_name = Some("DP-3".to_string());
+        let low_confidence_other_observation =
+            FocusObservation::from_wayland(WaylandFocusObservation::LowConfidence {
+                snapshot: low_confidence_other,
+                cache_age_ms: 12,
+                reason: "other_low_confidence_reason",
+            });
+        assert_eq!(
+            decide_overlay_output_target(&low_confidence_other_observation),
+            None
+        );
+
+        let unavailable = FocusObservation::from_wayland(WaylandFocusObservation::Unavailable {
+            reason: "wayland_cache_uninitialized",
+            cache_age_ms: None,
+        });
+        assert_eq!(decide_overlay_output_target(&unavailable), None);
     }
 }

--- a/parakeet-ptt/src/routing.rs
+++ b/parakeet-ptt/src/routing.rs
@@ -1,5 +1,8 @@
 use crate::config::PasteShortcut;
-use crate::surface_focus::{FocusSnapshot, WaylandFocusObservation};
+use crate::surface_focus::{
+    FocusSnapshot, WaylandFocusObservation, WAYLAND_FOCUS_REASON_CACHE_STALE,
+    WAYLAND_FOCUS_REASON_TRANSITION_NO_ACTIVATED,
+};
 use serde::{Deserialize, Serialize};
 
 pub const OVERLAY_OUTPUT_STALE_MS: u64 = 1_500;
@@ -254,7 +257,9 @@ pub fn decide_overlay_output_target(observation: &FocusObservation) -> Option<St
         FocusConfidence::LowConfidence
             if matches!(
                 observation.wayland_fallback_reason,
-                Some("wayland_transition_no_activated" | "wayland_cache_stale")
+                Some(
+                    WAYLAND_FOCUS_REASON_TRANSITION_NO_ACTIVATED | WAYLAND_FOCUS_REASON_CACHE_STALE
+                )
             ) =>
         {
             observation
@@ -357,7 +362,10 @@ mod tests {
         FocusConfidence, FocusObservation, FocusRouteInput, SurfaceClass,
     };
     use crate::config::PasteShortcut;
-    use crate::surface_focus::{FocusSnapshot, WaylandFocusObservation};
+    use crate::surface_focus::{
+        FocusSnapshot, WaylandFocusObservation, WAYLAND_FOCUS_REASON_CACHE_STALE,
+        WAYLAND_FOCUS_REASON_TRANSITION_NO_ACTIVATED,
+    };
 
     fn snapshot(
         app_name: &str,
@@ -606,7 +614,7 @@ mod tests {
             FocusObservation::from_wayland(WaylandFocusObservation::LowConfidence {
                 snapshot: stale,
                 cache_age_ms: 1_600,
-                reason: "wayland_cache_stale",
+                reason: WAYLAND_FOCUS_REASON_CACHE_STALE,
             });
         assert_eq!(
             decide_overlay_output_target(&stale_observation).as_deref(),
@@ -619,7 +627,7 @@ mod tests {
             FocusObservation::from_wayland(WaylandFocusObservation::LowConfidence {
                 snapshot: transition,
                 cache_age_ms: 12,
-                reason: "wayland_transition_no_activated",
+                reason: WAYLAND_FOCUS_REASON_TRANSITION_NO_ACTIVATED,
             });
         assert_eq!(
             decide_overlay_output_target(&transition_observation).as_deref(),

--- a/parakeet-ptt/src/surface_focus.rs
+++ b/parakeet-ptt/src/surface_focus.rs
@@ -167,16 +167,11 @@ impl WaylandFocusCache {
     }
 
     pub fn current_output_name(&self) -> Option<String> {
-        match self.observe(1_500, 250) {
-            WaylandFocusObservation::Fresh { snapshot, .. } => snapshot.output_name,
-            WaylandFocusObservation::LowConfidence {
-                snapshot,
-                reason: "wayland_transition_no_activated" | "wayland_cache_stale",
-                ..
-            } => snapshot.output_name,
-            WaylandFocusObservation::Unavailable { .. } => None,
-            WaylandFocusObservation::LowConfidence { .. } => None,
-        }
+        let observation = crate::routing::FocusObservation::from_wayland(self.observe(
+            crate::routing::OVERLAY_OUTPUT_STALE_MS,
+            crate::routing::OVERLAY_OUTPUT_TRANSITION_GRACE_MS,
+        ));
+        crate::routing::decide_overlay_output_target(&observation)
     }
 }
 

--- a/parakeet-ptt/src/surface_focus.rs
+++ b/parakeet-ptt/src/surface_focus.rs
@@ -60,6 +60,9 @@ pub enum WaylandFocusObservation {
     },
 }
 
+pub const WAYLAND_FOCUS_REASON_CACHE_STALE: &str = "wayland_cache_stale";
+pub const WAYLAND_FOCUS_REASON_TRANSITION_NO_ACTIVATED: &str = "wayland_transition_no_activated";
+
 #[derive(Debug, Clone)]
 pub struct WaylandFocusCache {
     shared: Arc<Mutex<WaylandFocusSharedState>>,
@@ -123,7 +126,7 @@ impl WaylandFocusCache {
                 return WaylandFocusObservation::LowConfidence {
                     snapshot: active.to_focus_snapshot(true),
                     cache_age_ms,
-                    reason: "wayland_cache_stale",
+                    reason: WAYLAND_FOCUS_REASON_CACHE_STALE,
                 };
             }
             return WaylandFocusObservation::Fresh {
@@ -134,7 +137,7 @@ impl WaylandFocusCache {
 
         if cache_age_ms > stale_ms.max(1) {
             return WaylandFocusObservation::Unavailable {
-                reason: "wayland_cache_stale",
+                reason: WAYLAND_FOCUS_REASON_CACHE_STALE,
                 cache_age_ms: Some(cache_age_ms),
             };
         }
@@ -155,7 +158,7 @@ impl WaylandFocusCache {
                 return WaylandFocusObservation::LowConfidence {
                     snapshot: last_activated.to_focus_snapshot(false),
                     cache_age_ms,
-                    reason: "wayland_transition_no_activated",
+                    reason: WAYLAND_FOCUS_REASON_TRANSITION_NO_ACTIVATED,
                 };
             }
         }
@@ -591,7 +594,8 @@ fn parse_cosmic_state_has_activated(state: &[u8]) -> bool {
 mod tests {
     use super::{
         parse_cosmic_state_has_activated, CachedToplevel, WaylandFocusCache,
-        WaylandFocusObservation, WaylandFocusSharedState,
+        WaylandFocusObservation, WaylandFocusSharedState, WAYLAND_FOCUS_REASON_CACHE_STALE,
+        WAYLAND_FOCUS_REASON_TRANSITION_NO_ACTIVATED,
     };
     use std::sync::{Arc, Mutex};
     use std::time::{Duration, Instant};
@@ -633,7 +637,7 @@ mod tests {
             } => {
                 assert!(snapshot.focused);
                 assert_eq!(snapshot.resolver, "wayland");
-                assert_eq!(reason, "wayland_cache_stale");
+                assert_eq!(reason, WAYLAND_FOCUS_REASON_CACHE_STALE);
             }
             _ => panic!("expected stale active cache to be low confidence"),
         }
@@ -666,7 +670,7 @@ mod tests {
             } => {
                 assert!(!snapshot.focused);
                 assert_eq!(snapshot.resolver, "wayland");
-                assert_eq!(reason, "wayland_transition_no_activated");
+                assert_eq!(reason, WAYLAND_FOCUS_REASON_TRANSITION_NO_ACTIVATED);
             }
             _ => panic!("expected low-confidence transition snapshot"),
         }


### PR DESCRIPTION
Closes #159

## Summary
- Add a shared `FocusObservation` shape and Overlay output-target policy in `routing.rs`.
- Feed Injection route decisions, Client parent focus capture, Client Overlay hints, and `WaylandFocusCache::current_output_name` through the shared observation/policy.
- Preserve current Overlay output behavior for fresh, accepted low-confidence stale/transition observations, and unavailable observations.
- Address CodeRabbit's fallback-reason nitpick by sharing Wayland fallback-reason constants between `surface_focus.rs`, routing policy, and tests.

## Verification
- `cargo test --manifest-path parakeet-ptt/Cargo.toml routing -- --nocapture`
- `cargo test --manifest-path parakeet-ptt/Cargo.toml client_focus_router -- --nocapture`
- `cargo test --manifest-path parakeet-ptt/Cargo.toml current_output_name_accepts_stale_active_snapshot -- --nocapture`
- `cargo test --manifest-path parakeet-ptt/Cargo.toml overlay -- --nocapture`
- `cargo check` from `parakeet-ptt/`
- `cargo fmt --check` from `parakeet-ptt/`
- `cargo test -q` from `parakeet-ptt/`
- `cargo clippy --all-targets --all-features -- -D warnings` from `parakeet-ptt/`
- `cargo build --bins` from `parakeet-ptt/`
- `git diff --check`
- `env -u VIRTUAL_ENV PATH=... prek run --files parakeet-ptt/src/client_session.rs parakeet-ptt/src/injector.rs parakeet-ptt/src/routing.rs parakeet-ptt/src/surface_focus.rs`
- `env -u VIRTUAL_ENV PATH=... prek run --stage pre-push --files parakeet-ptt/src/client_session.rs parakeet-ptt/src/injector.rs parakeet-ptt/src/routing.rs parakeet-ptt/src/surface_focus.rs`

## Review Evidence
- CodeRabbit PR gate on head `310a7a296dc4084885250522eb15b33e09bab993`: remote clean, no actionable PR feedback, empty decision ledger.
- Watcher exit was `10` only because local CodeRabbit errored and the helper used Codex fallback; remote CodeRabbit verdict was `completed_clean`.
- Gate artifacts: `.git/coderabbit-review/20260524T142452Z/gate-summary.json`, `.git/coderabbit-review/20260524T142452Z/decision-ledger.json`.
- Review-thread audit: no review threads. Prior CodeRabbit review-body nitpick was on commit `b4f7f5eac08ae54ddf345ba6c1fb4db10a95b269` and is fixed by `310a7a296dc4084885250522eb15b33e09bab993`; latest CodeRabbit top-level review says no actionable comments.

## Deferrals
- None.
