### PR TITLE
Extract pure Session audio buffer

### DIFF
--- a/parakeet-stt-daemon/src/parakeet_stt_daemon/audio.py
+++ b/parakeet-stt-daemon/src/parakeet_stt_daemon/audio.py
@@ -3,36 +3,13 @@
 from __future__ import annotations
 
 import threading
-from collections import deque
-from dataclasses import dataclass
 from typing import Any
 
 import numpy as np
 import sounddevice as sd
 from loguru import logger
 
-
-@dataclass(frozen=True, slots=True)
-class CaptureSessionResult:
-    """Stop-time audio facts captured for one Session."""
-
-    audio_samples: np.ndarray
-    ready_chunks: list[np.ndarray]
-    tail_buffer: np.ndarray
-    pre_roll_samples: int
-    post_start_samples: int
-
-    @property
-    def captured_samples(self) -> int:
-        return int(self.audio_samples.size)
-
-    @property
-    def ready_chunk_count(self) -> int:
-        return len(self.ready_chunks)
-
-    @property
-    def tail_samples(self) -> int:
-        return int(self.tail_buffer.size)
+from .audio_buffer import CaptureSessionResult, SessionAudioBuffer
 
 
 class AudioInput:
@@ -54,22 +31,12 @@ class AudioInput:
         self.dtype = dtype
         self.device = device
         self.blocksize = blocksize
-        self._pre_roll_capacity = int(pre_roll_seconds * sample_rate)
-
-        self._pre_roll: deque[np.ndarray] = deque()
-        self._pre_roll_frames = 0
-        self._session_chunks: list[np.ndarray] = []
-        self._session_active = False
-        self._max_session_samples = (
-            max(1, int(max_session_samples)) if max_session_samples is not None else None
+        self._buffer = SessionAudioBuffer(
+            sample_rate=sample_rate,
+            dtype=dtype,
+            pre_roll_seconds=pre_roll_seconds,
+            max_session_samples=max_session_samples,
         )
-        self._session_pre_roll_samples = 0
-        self._session_samples = 0
-        self._session_limit_exceeded = False
-        self._stream_chunk_size: int | None = None
-        self._stream_ready: list[np.ndarray] = []
-        self._stream_buffer: np.ndarray = np.zeros((0,), dtype=np.float32)
-        self._level_ready: list[float] = []
         self._lock = threading.Lock()
         self._stream: sd.InputStream | None = None
 
@@ -102,95 +69,46 @@ class AudioInput:
     def start_session(self) -> None:
         """Begin accumulating audio for a new session (includes pre-roll)."""
         with self._lock:
-            pre_roll_chunks = self._bounded_pre_roll_chunks()
-            self._session_chunks = pre_roll_chunks
-            self._session_pre_roll_samples = sum(int(chunk.size) for chunk in pre_roll_chunks)
-            # Pre-roll is clipped up front so low session caps still start cleanly.
-            # The live session budget applies to post-start capture.
-            self._session_samples = 0
-            self._session_limit_exceeded = False
-            self._session_active = True
-            self._stream_ready = []
-            self._level_ready = []
-            if self._stream_chunk_size:
-                # Seed the streaming buffer with the pre-roll so the streaming path
-                # sees the leading audio instead of starting from the first post-start chunk.
-                self._stream_buffer = (
-                    np.concatenate(pre_roll_chunks, dtype=np.float32)
-                    if pre_roll_chunks
-                    else np.zeros((0,), dtype=np.float32)
-                )
-            else:
-                self._stream_buffer = np.zeros((0,), dtype=np.float32)
-            self._enforce_session_sample_limit()
+            self._buffer.start_session()
 
     def stop_session(self) -> np.ndarray:
         """Stop accumulation and return the captured samples."""
         with self._lock:
-            self._session_active = False
-            chunks = self._session_chunks
-            self._reset_session_runtime_state()
-        if not chunks:
-            return np.zeros((0,), dtype=self.dtype)
-        return np.concatenate(chunks).astype(self.dtype, copy=False)
+            chunks = self._buffer.stop_session_chunks()
+        return self._buffer.audio_samples_from_chunks(chunks)
 
     def abort_session(self) -> None:
         """Stop accumulation and discard any captured session audio."""
         with self._lock:
-            self._session_active = False
-            self._reset_session_runtime_state()
+            self._buffer.abort_session()
 
     def stop_session_with_streaming(self) -> CaptureSessionResult:
         """Stop accumulation and return captured samples plus streaming slices."""
         with self._lock:
-            self._session_active = False
-            chunks = self._session_chunks
-            ready = self._stream_ready
-            tail = self._stream_buffer.copy()
-            pre_roll_samples = self._session_pre_roll_samples
-            post_start_samples = self._session_samples
-            self._reset_session_runtime_state()
-        audio = (
-            np.concatenate(chunks).astype(self.dtype, copy=False)
-            if chunks
-            else np.zeros((0,), dtype=self.dtype)
-        )
-        return CaptureSessionResult(
-            audio_samples=audio,
-            ready_chunks=ready,
-            tail_buffer=tail,
-            pre_roll_samples=pre_roll_samples,
-            post_start_samples=post_start_samples,
-        )
+            snapshot = self._buffer.stop_session_with_streaming_snapshot()
+        return self._buffer.capture_result_from_snapshot(snapshot)
 
     def session_limit_exceeded(self) -> bool:
         with self._lock:
-            return self._session_limit_exceeded
+            return self._buffer.session_limit_exceeded()
 
     def session_sample_limit(self) -> int | None:
-        return self._max_session_samples
+        return self._buffer.session_sample_limit()
 
     def configure_stream_chunk_size(self, chunk_samples: int) -> None:
         """Set desired streaming chunk size in samples."""
         with self._lock:
-            self._stream_chunk_size = max(1, int(chunk_samples))
-            self._stream_ready = []
-            self._level_ready = []
-            self._stream_buffer = np.zeros((0,), dtype=np.float32)
+            self._buffer.configure_stream_chunk_size(chunk_samples)
 
     def take_stream_chunks(self) -> list[np.ndarray]:
         """Take any ready-to-process streaming chunks."""
         with self._lock:
-            ready = self._stream_ready
-            self._stream_ready = []
-        return ready
+            return self._buffer.take_stream_chunks()
 
     def take_audio_levels(self) -> list[float]:
         """Take any ready-to-process RMS audio levels for the active session."""
         with self._lock:
-            levels = self._level_ready
-            self._level_ready = []
-        return levels
+            return self._buffer.take_audio_levels()
 
     def _callback(
         self, indata: np.ndarray, frames: int, time: Any, status: sd.CallbackFlags
@@ -201,102 +119,7 @@ class AudioInput:
         # Flatten to mono array and copy because the buffer is reused by sounddevice.
         chunk = np.copy(np.reshape(indata, (frames, self.channels))[:, 0])
         with self._lock:
-            self._pre_roll.append(chunk)
-            self._pre_roll_frames += len(chunk)
-            self._trim_pre_roll()
-            if self._session_active:
-                accepted = self._clip_chunk_to_session_limit(chunk)
-                if accepted is None:
-                    return
-                self._session_chunks.append(accepted)
-                self._session_samples += int(accepted.size)
-                self._collect_stream_chunks(accepted)
-                self._collect_audio_level(accepted)
-                self._enforce_session_sample_limit()
-
-    def _trim_pre_roll(self) -> None:
-        while self._pre_roll_frames > self._pre_roll_capacity and self._pre_roll:
-            removed = self._pre_roll.popleft()
-            self._pre_roll_frames -= len(removed)
-
-    def _collect_stream_chunks(self, chunk: np.ndarray) -> None:
-        if not self._stream_chunk_size:
-            return
-        combined = (
-            chunk
-            if self._stream_buffer.size == 0
-            else np.concatenate([self._stream_buffer, chunk], dtype=np.float32)
-        )
-        idx = 0
-        chunk_size = self._stream_chunk_size
-        while combined.size - idx >= chunk_size:
-            next_idx = idx + chunk_size
-            self._stream_ready.append(np.array(combined[idx:next_idx], copy=True))
-            idx = next_idx
-        self._stream_buffer = combined[idx:]
-
-    def _collect_audio_level(self, chunk: np.ndarray) -> None:
-        audio = np.asarray(chunk, dtype=np.float32).reshape(-1)
-        if audio.size == 0:
-            return
-        finite = np.isfinite(audio)
-        if not bool(np.all(finite)):
-            audio = audio[finite]
-        if audio.size == 0:
-            return
-        rms = float(np.sqrt(np.mean(audio * audio)))
-        if np.isfinite(rms):
-            self._level_ready.append(rms)
-
-    def _bounded_pre_roll_chunks(self) -> list[np.ndarray]:
-        if self._max_session_samples is None:
-            return [chunk.copy() for chunk in self._pre_roll]
-
-        remaining = self._max_session_samples
-        if remaining <= 0:
-            return []
-
-        retained: list[np.ndarray] = []
-        for chunk in reversed(self._pre_roll):
-            if remaining <= 0:
-                break
-            if chunk.size <= remaining:
-                retained.append(chunk.copy())
-                remaining -= int(chunk.size)
-                continue
-            retained.append(np.array(chunk[-remaining:], copy=True))
-            remaining = 0
-        retained.reverse()
-        return retained
-
-    def _clip_chunk_to_session_limit(self, chunk: np.ndarray) -> np.ndarray | None:
-        if self._max_session_samples is None:
-            return chunk
-        remaining = self._max_session_samples - self._session_samples
-        if remaining <= 0:
-            self._session_limit_exceeded = True
-            self._session_active = False
-            return None
-        if chunk.size <= remaining:
-            return chunk
-        return np.array(chunk[:remaining], copy=True)
-
-    def _enforce_session_sample_limit(self) -> None:
-        if self._max_session_samples is None:
-            return
-        if self._session_samples < self._max_session_samples:
-            return
-        self._session_limit_exceeded = True
-        self._session_active = False
-
-    def _reset_session_runtime_state(self) -> None:
-        self._session_chunks = []
-        self._session_pre_roll_samples = 0
-        self._session_samples = 0
-        self._session_limit_exceeded = False
-        self._stream_ready = []
-        self._level_ready = []
-        self._stream_buffer = np.zeros((0,), dtype=np.float32)
+            self._buffer.ingest_chunk(chunk)
 
 
 __all__ = ["AudioInput", "CaptureSessionResult"]

--- a/parakeet-stt-daemon/src/parakeet_stt_daemon/audio_buffer.py
+++ b/parakeet-stt-daemon/src/parakeet_stt_daemon/audio_buffer.py
@@ -1,0 +1,279 @@
+"""Pure Pre-roll buffer and Session audio buffer policy."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass(frozen=True, slots=True)
+class CaptureSessionResult:
+    """Stop-time audio facts captured for one Session."""
+
+    audio_samples: np.ndarray
+    ready_chunks: list[np.ndarray]
+    tail_buffer: np.ndarray
+    pre_roll_samples: int
+    post_start_samples: int
+
+    @property
+    def captured_samples(self) -> int:
+        return int(self.audio_samples.size)
+
+    @property
+    def ready_chunk_count(self) -> int:
+        return len(self.ready_chunks)
+
+    @property
+    def tail_samples(self) -> int:
+        return int(self.tail_buffer.size)
+
+
+@dataclass(frozen=True, slots=True)
+class _CaptureSessionSnapshot:
+    audio_chunks: list[np.ndarray]
+    ready_chunks: list[np.ndarray]
+    tail_buffer: np.ndarray
+    pre_roll_samples: int
+    post_start_samples: int
+
+
+class SessionAudioBuffer:
+    """Own Pre-roll retention, Session accumulation, streaming slices, and levels."""
+
+    def __init__(
+        self,
+        *,
+        sample_rate: int = 16_000,
+        dtype: str = "float32",
+        pre_roll_seconds: float = 2.5,
+        max_session_samples: int | None = None,
+    ) -> None:
+        self.sample_rate = sample_rate
+        self.dtype = dtype
+        self._pre_roll_capacity = int(pre_roll_seconds * sample_rate)
+        self._pre_roll: deque[np.ndarray] = deque()
+        self._pre_roll_frames = 0
+        self._session_chunks: list[np.ndarray] = []
+        self._session_active = False
+        self._max_session_samples = (
+            max(1, int(max_session_samples)) if max_session_samples is not None else None
+        )
+        self._session_pre_roll_samples = 0
+        self._session_samples = 0
+        self._session_limit_exceeded = False
+        self._stream_chunk_size: int | None = None
+        self._stream_ready: list[np.ndarray] = []
+        self._stream_buffer: np.ndarray = np.zeros((0,), dtype=np.float32)
+        self._level_ready: list[float] = []
+
+    def ingest_chunk(self, chunk: np.ndarray) -> None:
+        """Append one flat audio chunk to the Pre-roll buffer and active Session."""
+        audio = np.array(chunk, copy=True).reshape(-1)
+        self._pre_roll.append(audio)
+        self._pre_roll_frames += int(audio.size)
+        self._trim_pre_roll()
+        if not self._session_active:
+            return
+
+        accepted = self._clip_chunk_to_session_limit(audio)
+        if accepted is None:
+            return
+        self._session_chunks.append(accepted)
+        self._session_samples += int(accepted.size)
+        self._collect_stream_chunks(accepted)
+        self._collect_audio_level(accepted)
+        self._enforce_session_sample_limit()
+
+    def start_session(self) -> None:
+        """Begin accumulating audio for a new Session, including bounded Pre-roll."""
+        pre_roll_chunks = self._bounded_pre_roll_chunks()
+        self._session_chunks = pre_roll_chunks
+        self._session_pre_roll_samples = sum(int(chunk.size) for chunk in pre_roll_chunks)
+        # Pre-roll is clipped up front so low session caps still start cleanly.
+        # The live session budget applies to post-start capture.
+        self._session_samples = 0
+        self._session_limit_exceeded = False
+        self._session_active = True
+        self._stream_ready = []
+        self._level_ready = []
+        if self._stream_chunk_size:
+            # Seed the Stream path with Pre-roll so live chunks keep the leading audio.
+            self._stream_buffer = (
+                np.concatenate(pre_roll_chunks, dtype=np.float32)
+                if pre_roll_chunks
+                else np.zeros((0,), dtype=np.float32)
+            )
+        else:
+            self._stream_buffer = np.zeros((0,), dtype=np.float32)
+        self._enforce_session_sample_limit()
+
+    def stop_session(self) -> np.ndarray:
+        """Stop accumulation and return the captured samples."""
+        return self.audio_samples_from_chunks(self.stop_session_chunks())
+
+    def stop_session_chunks(self) -> list[np.ndarray]:
+        """Stop accumulation and return captured chunks for out-of-lock assembly."""
+        self._session_active = False
+        chunks = self._session_chunks
+        self._reset_session_runtime_state()
+        return chunks
+
+    def abort_session(self) -> None:
+        """Stop accumulation and discard any captured Session audio."""
+        self._session_active = False
+        self._reset_session_runtime_state()
+
+    def stop_session_with_streaming(self) -> CaptureSessionResult:
+        """Stop accumulation and return captured samples plus Stream path facts."""
+        return self.capture_result_from_snapshot(self.stop_session_with_streaming_snapshot())
+
+    def stop_session_with_streaming_snapshot(self) -> _CaptureSessionSnapshot:
+        """Stop accumulation and snapshot stop-time Stream path facts."""
+        self._session_active = False
+        snapshot = _CaptureSessionSnapshot(
+            audio_chunks=self._session_chunks,
+            ready_chunks=self._stream_ready,
+            tail_buffer=self._stream_buffer.copy(),
+            pre_roll_samples=self._session_pre_roll_samples,
+            post_start_samples=self._session_samples,
+        )
+        self._reset_session_runtime_state()
+        return snapshot
+
+    def audio_samples_from_chunks(self, chunks: list[np.ndarray]) -> np.ndarray:
+        """Build captured audio samples from a stopped Session snapshot."""
+        if not chunks:
+            return np.zeros((0,), dtype=self.dtype)
+        return np.concatenate(chunks).astype(self.dtype, copy=False)
+
+    def capture_result_from_snapshot(
+        self, snapshot: _CaptureSessionSnapshot
+    ) -> CaptureSessionResult:
+        """Build a compatible capture result from a stopped Session snapshot."""
+        audio = (
+            self.audio_samples_from_chunks(snapshot.audio_chunks)
+            if snapshot.audio_chunks
+            else np.zeros((0,), dtype=self.dtype)
+        )
+        return CaptureSessionResult(
+            audio_samples=audio,
+            ready_chunks=snapshot.ready_chunks,
+            tail_buffer=snapshot.tail_buffer,
+            pre_roll_samples=snapshot.pre_roll_samples,
+            post_start_samples=snapshot.post_start_samples,
+        )
+
+    def session_limit_exceeded(self) -> bool:
+        return self._session_limit_exceeded
+
+    def session_sample_limit(self) -> int | None:
+        return self._max_session_samples
+
+    def configure_stream_chunk_size(self, chunk_samples: int) -> None:
+        """Set desired Stream path chunk size in samples."""
+        self._stream_chunk_size = max(1, int(chunk_samples))
+        self._stream_ready = []
+        self._level_ready = []
+        self._stream_buffer = np.zeros((0,), dtype=np.float32)
+
+    def take_stream_chunks(self) -> list[np.ndarray]:
+        """Take any ready-to-process Stream path chunks."""
+        ready = self._stream_ready
+        self._stream_ready = []
+        return ready
+
+    def take_audio_levels(self) -> list[float]:
+        """Take RMS audio levels collected for the active Session."""
+        levels = self._level_ready
+        self._level_ready = []
+        return levels
+
+    def _trim_pre_roll(self) -> None:
+        while self._pre_roll_frames > self._pre_roll_capacity and self._pre_roll:
+            removed = self._pre_roll.popleft()
+            self._pre_roll_frames -= int(removed.size)
+
+    def _collect_stream_chunks(self, chunk: np.ndarray) -> None:
+        if not self._stream_chunk_size:
+            return
+        combined = (
+            chunk
+            if self._stream_buffer.size == 0
+            else np.concatenate([self._stream_buffer, chunk], dtype=np.float32)
+        )
+        idx = 0
+        chunk_size = self._stream_chunk_size
+        while combined.size - idx >= chunk_size:
+            next_idx = idx + chunk_size
+            self._stream_ready.append(np.array(combined[idx:next_idx], copy=True))
+            idx = next_idx
+        self._stream_buffer = combined[idx:]
+
+    def _collect_audio_level(self, chunk: np.ndarray) -> None:
+        audio = np.asarray(chunk, dtype=np.float32).reshape(-1)
+        if audio.size == 0:
+            return
+        finite = np.isfinite(audio)
+        if not bool(np.all(finite)):
+            audio = audio[finite]
+        if audio.size == 0:
+            return
+        rms = float(np.sqrt(np.mean(audio * audio)))
+        if np.isfinite(rms):
+            self._level_ready.append(rms)
+
+    def _bounded_pre_roll_chunks(self) -> list[np.ndarray]:
+        if self._max_session_samples is None:
+            return [chunk.copy() for chunk in self._pre_roll]
+
+        remaining = self._max_session_samples
+        if remaining <= 0:
+            return []
+
+        retained: list[np.ndarray] = []
+        for chunk in reversed(self._pre_roll):
+            if remaining <= 0:
+                break
+            if chunk.size <= remaining:
+                retained.append(chunk.copy())
+                remaining -= int(chunk.size)
+                continue
+            retained.append(np.array(chunk[-remaining:], copy=True))
+            remaining = 0
+        retained.reverse()
+        return retained
+
+    def _clip_chunk_to_session_limit(self, chunk: np.ndarray) -> np.ndarray | None:
+        if self._max_session_samples is None:
+            return chunk
+        remaining = self._max_session_samples - self._session_samples
+        if remaining <= 0:
+            self._session_limit_exceeded = True
+            self._session_active = False
+            return None
+        if chunk.size <= remaining:
+            return chunk
+        return np.array(chunk[:remaining], copy=True)
+
+    def _enforce_session_sample_limit(self) -> None:
+        if self._max_session_samples is None:
+            return
+        if self._session_samples < self._max_session_samples:
+            return
+        self._session_limit_exceeded = True
+        self._session_active = False
+
+    def _reset_session_runtime_state(self) -> None:
+        self._session_chunks = []
+        self._session_pre_roll_samples = 0
+        self._session_samples = 0
+        self._session_limit_exceeded = False
+        self._stream_ready = []
+        self._level_ready = []
+        self._stream_buffer = np.zeros((0,), dtype=np.float32)
+
+
+__all__ = ["CaptureSessionResult", "SessionAudioBuffer"]

--- a/parakeet-stt-daemon/tests/test_audio_buffer.py
+++ b/parakeet-stt-daemon/tests/test_audio_buffer.py
@@ -1,0 +1,154 @@
+"""Pure Pre-roll buffer and Session audio buffer invariants."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import numpy as np
+import pytest
+
+from parakeet_stt_daemon.audio import AudioInput
+from parakeet_stt_daemon.audio_buffer import CaptureSessionResult, SessionAudioBuffer
+
+
+def test_pre_roll_is_clipped_to_session_sample_limit() -> None:
+    buffer = SessionAudioBuffer(
+        sample_rate=16_000,
+        dtype="float32",
+        max_session_samples=3,
+    )
+
+    buffer.ingest_chunk(np.array([0.1, 0.2], dtype=np.float32))
+    buffer.ingest_chunk(np.array([0.3, 0.4], dtype=np.float32))
+
+    buffer.start_session()
+
+    assert buffer.session_limit_exceeded() is False
+    assert np.allclose(buffer.stop_session(), np.array([0.2, 0.3, 0.4], dtype=np.float32))
+
+
+def test_post_start_audio_is_clipped_to_session_sample_limit() -> None:
+    buffer = SessionAudioBuffer(
+        sample_rate=16_000,
+        dtype="float32",
+        max_session_samples=5,
+    )
+    buffer.start_session()
+
+    buffer.ingest_chunk(np.array([0.1, 0.2, 0.3, 0.4], dtype=np.float32))
+    buffer.ingest_chunk(np.array([0.5, 0.6, 0.7, 0.8], dtype=np.float32))
+
+    assert buffer.session_limit_exceeded() is True
+    assert np.allclose(
+        buffer.stop_session(),
+        np.array([0.1, 0.2, 0.3, 0.4, 0.5], dtype=np.float32),
+    )
+
+
+def test_stream_ready_chunks_and_tail_facts_include_seeded_pre_roll() -> None:
+    buffer = SessionAudioBuffer(sample_rate=10, dtype="float32", pre_roll_seconds=1.0)
+    buffer.configure_stream_chunk_size(4)
+    buffer.ingest_chunk(np.array([0.1, 0.2, 0.3], dtype=np.float32))
+
+    buffer.start_session()
+    buffer.ingest_chunk(np.array([0.4, 0.5], dtype=np.float32))
+
+    result = buffer.stop_session_with_streaming()
+
+    assert isinstance(result, CaptureSessionResult)
+    assert np.allclose(
+        result.audio_samples,
+        np.array([0.1, 0.2, 0.3, 0.4, 0.5], dtype=np.float32),
+    )
+    assert result.captured_samples == 5
+    assert result.pre_roll_samples == 3
+    assert result.post_start_samples == 2
+    assert result.ready_chunk_count == 1
+    assert np.allclose(
+        result.ready_chunks[0],
+        np.array([0.1, 0.2, 0.3, 0.4], dtype=np.float32),
+    )
+    assert np.allclose(result.tail_buffer, np.array([0.5], dtype=np.float32))
+    assert result.tail_samples == 1
+
+
+def test_empty_session_result_has_empty_audio_and_facts() -> None:
+    buffer = SessionAudioBuffer(sample_rate=16_000, dtype="float32")
+
+    buffer.start_session()
+    result = buffer.stop_session_with_streaming()
+
+    assert isinstance(result, CaptureSessionResult)
+    assert result.audio_samples.size == 0
+    assert result.ready_chunks == []
+    assert result.tail_buffer.size == 0
+    assert result.pre_roll_samples == 0
+    assert result.post_start_samples == 0
+    assert result.captured_samples == 0
+    assert result.ready_chunk_count == 0
+    assert result.tail_samples == 0
+
+
+def test_audio_levels_are_collected_without_sounddevice() -> None:
+    buffer = SessionAudioBuffer(sample_rate=16_000, dtype="float32")
+    buffer.start_session()
+
+    buffer.ingest_chunk(np.array([3.0, 4.0], dtype=np.float32))
+    buffer.ingest_chunk(np.array([np.nan, 1.0], dtype=np.float32))
+    buffer.ingest_chunk(np.array([np.nan], dtype=np.float32))
+
+    assert buffer.take_audio_levels() == pytest.approx([np.sqrt(12.5), 1.0])
+    assert buffer.take_audio_levels() == []
+
+
+def test_audio_input_releases_lock_before_building_stopped_audio(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    audio = AudioInput(sample_rate=16_000, channels=1)
+    audio.start_session()
+    audio._callback(
+        np.array([[0.1], [0.2]], dtype=np.float32),
+        frames=2,
+        time=None,
+        status=cast(Any, 0),
+    )
+
+    def build_audio(chunks: list[np.ndarray]) -> np.ndarray:
+        _assert_audio_lock_is_unheld(audio)
+        return np.concatenate(chunks).astype("float32", copy=False)
+
+    monkeypatch.setattr(audio._buffer, "audio_samples_from_chunks", build_audio)
+
+    assert np.allclose(audio.stop_session(), np.array([0.1, 0.2], dtype=np.float32))
+
+
+def test_audio_input_releases_lock_before_building_streaming_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    audio = AudioInput(sample_rate=16_000, channels=1)
+    audio.configure_stream_chunk_size(4)
+    audio.start_session()
+    audio._callback(
+        np.array([[0.1], [0.2]], dtype=np.float32),
+        frames=2,
+        time=None,
+        status=cast(Any, 0),
+    )
+    original_build = audio._buffer.capture_result_from_snapshot
+
+    def build_result(snapshot: Any) -> CaptureSessionResult:
+        _assert_audio_lock_is_unheld(audio)
+        return original_build(snapshot)
+
+    monkeypatch.setattr(audio._buffer, "capture_result_from_snapshot", build_result)
+
+    result = audio.stop_session_with_streaming()
+
+    assert result.post_start_samples == 2
+    assert np.allclose(result.audio_samples, np.array([0.1, 0.2], dtype=np.float32))
+
+
+def _assert_audio_lock_is_unheld(audio: AudioInput) -> None:
+    acquired = audio._lock.acquire(blocking=False)
+    assert acquired is True
+    audio._lock.release()


### PR DESCRIPTION
## Summary

- Extracted `SessionAudioBuffer` and `CaptureSessionResult` into a pure Daemon audio buffer module.
- Kept `AudioInput` responsible for sounddevice lifecycle, callback flattening, and locking while delegating chunk ingestion and buffer policy.
- Preserved stop-time capture facts and added sounddevice-free coverage for Pre-roll clipping, post-start caps, Stream path chunks/tail facts, empty audio, audio-level collection, and out-of-lock stop result assembly.

Closes #172

## Verification

- Red regression before implementation: `uv run pytest tests/test_audio_buffer.py` failed with missing `parakeet_stt_daemon.audio_buffer`.
- `uv run pytest tests/test_audio_buffer.py tests/test_session_cleanup.py::test_audio_input_enforces_session_sample_limit tests/test_session_cleanup.py::test_audio_input_clips_pre_roll_to_session_sample_limit tests/test_session_cleanup.py::test_audio_input_streaming_stop_returns_capture_session_result_facts`
- `uv run pytest -q` -> 242 passed
- `uv run ruff format --check .`
- `uv run ruff check .`
- `ty check --project parakeet-stt-daemon --error-on-warning`
- `uv build`
- `uv run deptry .`
- `prek run --all-files`
- `prek run --stage pre-push --all-files`

## Review

- Local CodeRabbit watcher `20260524T160318Z` fell back to Codex and found a valid lock/concatenation regression.
- Fixed by snapshotting under lock and building audio/results after release.
- Local CodeRabbit watcher `20260524T161045Z` fell back to Codex and reported no actionable findings.

## Deferrals

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized audio buffering architecture to improve session management and streaming chunk processing.

* **Tests**
  * Added comprehensive test coverage for audio session lifecycle and streaming functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SystemicVoid/parakeet-stt/pull/178?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->