### PR TITLE
Gate Daemon Session resource-limit soak

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,9 +224,12 @@ prek run --stage pre-push --all-files
 
 Overlay reliability gates (repo root):
 ```bash
+just daemon-resource-soak
 just phase6-contract
 just phase6-promotion 3
 ```
+`phase6-contract` includes the Daemon resource-limit soak; it prints retained sample
+count, active Session state, and termination evidence for the Session sample cap.
 Hook stages are split for speed:
 - `pre-commit`: maintenance cadence reminder, `ruff format`, `ruff check`, `ty check`, `cargo fmt`
 - `pre-push`: `pytest`, `cargo clippy`, `cargo test`

--- a/docs/engineering/harness-engineering-playbook.md
+++ b/docs/engineering/harness-engineering-playbook.md
@@ -102,6 +102,9 @@ scripts/harness-maintenance.sh check --threshold 10
 scripts/harness-maintenance.sh code-shape
 scripts/harness-maintenance.sh run
 scripts/harness-maintenance.sh mark
+
+# Release/promotion resource guard
+just daemon-resource-soak
 ```
 
 ## Local STT Eval Policy

--- a/justfile
+++ b/justfile
@@ -75,8 +75,11 @@ runbook:
       "8) Promotion gate: just phase6-promotion 3" \
       "9) Stop helper stack: just stop"
 
+daemon-resource-soak:
+    @bash -lc 'cd "{{daemon_dir}}" && uv run pytest tests/test_session_orchestrator.py::test_phase6_resource_limit_soak_stops_retaining_audio_and_emits_limit_signal --capture=tee-sys'
+
 phase6-contract:
-    @bash -lc 'cd "{{repo_root}}" && echo ">>> daemon overlay contract suite" && cd parakeet-stt-daemon && uv run pytest tests/test_overlay_event_stream.py && echo ">>> ptt mixed-version + overlay fault-isolation suite" && cd ../parakeet-ptt && cargo test decode_server_message_mixed_version_stream_tolerates_unknown_between_known_messages && cargo test mixed_stream_enqueues_exactly_one_final_result && cargo test overlay_crash_restart_replays_current_state_and_preserves_final_injection && cargo test repeated_overlay_failures_remain_non_fatal_to_final_injection'
+    @bash -lc 'cd "{{repo_root}}" && echo ">>> daemon resource-limit soak" && just daemon-resource-soak && echo ">>> daemon overlay contract suite" && cd parakeet-stt-daemon && uv run pytest tests/test_overlay_event_stream.py && echo ">>> ptt mixed-version + overlay fault-isolation suite" && cd ../parakeet-ptt && cargo test decode_server_message_mixed_version_stream_tolerates_unknown_between_known_messages && cargo test mixed_stream_enqueues_exactly_one_final_result && cargo test overlay_crash_restart_replays_current_state_and_preserves_final_injection && cargo test repeated_overlay_failures_remain_non_fatal_to_final_injection'
 
 phase6-promotion runs="3":
     @bash -lc 'cd "{{repo_root}}" && runs="{{runs}}" && if ! [[ "$runs" =~ ^[0-9]+$ ]] || (( runs < 3 )); then echo "runs must be an integer >= 3" >&2; exit 1; fi && outfile="/tmp/parakeet-overlay-phase6-gate-$(date +%Y%m%d-%H%M%S).log" && { echo ">>> phase6 promotion gate (${runs} clean runs required)"; for run in $(seq 1 "$runs"); do echo ""; echo "=== reliability run ${run}/${runs} ==="; just phase6-contract; done; echo ""; echo "=== stream/seal regression gate ==="; just eval compare; echo ""; echo "artifact=$outfile"; } 2>&1 | tee "$outfile"'

--- a/parakeet-stt-daemon/src/parakeet_stt_daemon/audio_buffer.py
+++ b/parakeet-stt-daemon/src/parakeet_stt_daemon/audio_buffer.py
@@ -108,7 +108,6 @@ class SessionAudioBuffer:
             )
         else:
             self._stream_buffer = np.zeros((0,), dtype=np.float32)
-        self._enforce_session_sample_limit()
 
     def stop_session(self) -> np.ndarray:
         """Stop accumulation and return the captured samples."""
@@ -249,7 +248,8 @@ class SessionAudioBuffer:
     def _clip_chunk_to_session_limit(self, chunk: np.ndarray) -> np.ndarray | None:
         if self._max_session_samples is None:
             return chunk
-        remaining = self._max_session_samples - self._session_samples
+        retained_samples = self._session_pre_roll_samples + self._session_samples
+        remaining = self._max_session_samples - retained_samples
         if remaining <= 0:
             self._session_limit_exceeded = True
             self._session_active = False
@@ -261,7 +261,8 @@ class SessionAudioBuffer:
     def _enforce_session_sample_limit(self) -> None:
         if self._max_session_samples is None:
             return
-        if self._session_samples < self._max_session_samples:
+        retained_samples = self._session_pre_roll_samples + self._session_samples
+        if retained_samples < self._max_session_samples:
             return
         self._session_limit_exceeded = True
         self._session_active = False

--- a/parakeet-stt-daemon/tests/test_audio_buffer.py
+++ b/parakeet-stt-daemon/tests/test_audio_buffer.py
@@ -45,6 +45,29 @@ def test_post_start_audio_is_clipped_to_session_sample_limit() -> None:
     )
 
 
+def test_post_start_limit_accounts_for_seeded_pre_roll() -> None:
+    buffer = SessionAudioBuffer(
+        sample_rate=16_000,
+        dtype="float32",
+        max_session_samples=5,
+    )
+    buffer.ingest_chunk(np.array([0.1, 0.2, 0.3], dtype=np.float32))
+
+    buffer.start_session()
+    buffer.ingest_chunk(np.array([0.4, 0.5, 0.6, 0.7], dtype=np.float32))
+
+    assert buffer.session_limit_exceeded() is True
+    result = buffer.stop_session_with_streaming()
+
+    assert result.pre_roll_samples == 3
+    assert result.post_start_samples == 2
+    assert result.captured_samples == 5
+    assert np.allclose(
+        result.audio_samples,
+        np.array([0.1, 0.2, 0.3, 0.4, 0.5], dtype=np.float32),
+    )
+
+
 def test_stream_ready_chunks_and_tail_facts_include_seeded_pre_roll() -> None:
     buffer = SessionAudioBuffer(sample_rate=10, dtype="float32", pre_roll_seconds=1.0)
     buffer.configure_stream_chunk_size(4)

--- a/parakeet-stt-daemon/tests/test_session_orchestrator.py
+++ b/parakeet-stt-daemon/tests/test_session_orchestrator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from datetime import UTC, datetime, timedelta
 from typing import Any, TypeVar, cast
 from uuid import UUID, uuid4
@@ -11,7 +12,7 @@ import numpy as np
 from pytest import MonkeyPatch
 
 from parakeet_stt_daemon import session_orchestrator as orchestrator_module
-from parakeet_stt_daemon.audio import CaptureSessionResult
+from parakeet_stt_daemon.audio import AudioInput, CaptureSessionResult
 from parakeet_stt_daemon.config import ServerSettings
 from parakeet_stt_daemon.events import (
     FinalResultEvent,
@@ -85,6 +86,17 @@ class FakeAudio:
         return self.limit_exceeded
 
 
+class RecordingAudioInput(AudioInput):
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.last_capture_result: CaptureSessionResult | None = None
+
+    def stop_session_with_streaming(self) -> CaptureSessionResult:
+        result = super().stop_session_with_streaming()
+        self.last_capture_result = result
+        return result
+
+
 class FakeStreamSession:
     def __init__(self, feed_results: list[bool] | None = None) -> None:
         self.feed_calls = 0
@@ -131,6 +143,7 @@ class FakeSealPathRuntime(SealPathRuntime):
             release_device_cache=lambda _device: None,
         )
         self.text = text
+        self.finalize_calls: list[np.ndarray] = []
 
     async def finalize(
         self,
@@ -140,6 +153,7 @@ class FakeSealPathRuntime(SealPathRuntime):
         effective_device: str,
     ) -> SealPathFinalizationResult | SealPathFinalizationFailure:
         del transcribe, effective_device
+        self.finalize_calls.append(audio_samples.copy())
         if audio_samples.size == 0:
             return SealPathFinalizationFailure(
                 code="AUDIO_DEVICE",
@@ -159,19 +173,26 @@ def _build_orchestrator(
     *,
     streaming_enabled: bool = False,
     max_session_seconds: float = 90.0,
+    max_session_samples: int | None = None,
+    audio: Any | None = None,
     samples: np.ndarray | None = None,
     stream_chunks: list[np.ndarray] | None = None,
 ) -> SessionOrchestrator:
     orchestrator = cast(Any, SessionOrchestrator.__new__(SessionOrchestrator))
+    audio_obj = (
+        audio if audio is not None else FakeAudio(samples=samples, stream_chunks=stream_chunks)
+    )
+    sample_rate = int(getattr(audio_obj, "sample_rate", FakeAudio.sample_rate))
     settings = ServerSettings(
         device="cpu",
         streaming_enabled=streaming_enabled,
         overlay_events_enabled=True,
         max_session_seconds=max_session_seconds,
+        max_session_samples=max_session_samples,
     )
     orchestrator.settings = settings
     orchestrator.sessions = SessionManager()
-    orchestrator.audio = FakeAudio(samples=samples, stream_chunks=stream_chunks)
+    orchestrator.audio = audio_obj
     orchestrator.model = object()
     orchestrator.transcriber = FakeTranscriber()
     orchestrator._session_lock = asyncio.Lock()
@@ -182,8 +203,12 @@ def _build_orchestrator(
     orchestrator._stream_drain_running = False
     orchestrator._session_guard_task = None
     orchestrator._session_guard_running = False
-    orchestrator._session_sample_limit = int(max_session_seconds * FakeAudio.sample_rate)
-    orchestrator._session_age_limit_ms = int(max_session_seconds * 1000)
+    duration_limit_samples = max(1, int(max_session_seconds * sample_rate))
+    explicit_sample_limit = (
+        int(max_session_samples) if max_session_samples is not None else duration_limit_samples
+    )
+    orchestrator._session_sample_limit = max(1, min(duration_limit_samples, explicit_sample_limit))
+    orchestrator._session_age_limit_ms = max(1, int(max_session_seconds * 1000))
     orchestrator._requested_device = "cpu"
     orchestrator._effective_device = "cpu"
     orchestrator._vad_enabled = False
@@ -516,6 +541,92 @@ def test_guard_loop_auto_stops_when_audio_sample_limit_is_exceeded(
         finals = _events_of_type(sink, FinalResultEvent)
         ended = _events_of_type(sink, SessionEndedEvent)
         assert len(finals) == 1
+        assert ended
+        assert ended[-1].reason == SessionEndReason.FINAL
+
+    asyncio.run(scenario())
+
+
+def test_phase6_resource_limit_soak_stops_retaining_audio_and_emits_limit_signal(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    async def scenario() -> None:
+        sample_rate = 16_000
+        sample_cap = 64
+        chunk_frames = 16
+        pre_start_chunks = 10
+        post_start_chunks = 50
+        audio = RecordingAudioInput(
+            sample_rate=sample_rate,
+            channels=1,
+            pre_roll_seconds=0.002,
+            max_session_samples=sample_cap,
+        )
+        pre_roll_chunk = np.ones((chunk_frames, 1), dtype=np.float32)
+        for _ in range(pre_start_chunks):
+            audio._callback(
+                pre_roll_chunk,
+                frames=chunk_frames,
+                time=None,
+                status=cast(Any, 0),
+            )
+        orchestrator = _build_orchestrator(
+            max_session_seconds=90.0,
+            max_session_samples=sample_cap,
+            audio=audio,
+        )
+        seal_runtime = cast(FakeSealPathRuntime, orchestrator.seal_path_runtime)
+        sink = RecordingEventSink()
+        session_id = uuid4()
+        limit_exceeded_after_feed = False
+
+        async def fake_guard_sleep(_seconds: float) -> None:
+            nonlocal limit_exceeded_after_feed
+            chunk = np.ones((chunk_frames, 1), dtype=np.float32)
+            for _ in range(post_start_chunks):
+                audio._callback(chunk, frames=chunk_frames, time=None, status=cast(Any, 0))
+            limit_exceeded_after_feed = audio.session_limit_exceeded()
+            await asyncio.sleep(0)
+
+        monkeypatch.setattr(orchestrator_module, "_REAL_ASYNCIO_SLEEP", fake_guard_sleep)
+
+        await _start(orchestrator, sink, session_id)
+        for _ in range(20):
+            if orchestrator.sessions.active is None:
+                break
+            await asyncio.sleep(0)
+
+        warnings = _events_of_type(sink, SessionWarningEvent)
+        finals = _events_of_type(sink, FinalResultEvent)
+        ended = _events_of_type(sink, SessionEndedEvent)
+        capture_result = audio.last_capture_result
+        assert capture_result is not None
+        retained_samples = int(seal_runtime.finalize_calls[-1].size)
+        evidence = {
+            "active_session_after_guard": orchestrator.sessions.active is not None,
+            "fed_samples": (pre_start_chunks + post_start_chunks) * chunk_frames,
+            "limit_exceeded_after_feed": limit_exceeded_after_feed,
+            "post_start_fed_samples": post_start_chunks * chunk_frames,
+            "post_start_samples": capture_result.post_start_samples,
+            "pre_roll_samples": capture_result.pre_roll_samples,
+            "retained_samples": retained_samples,
+            "sample_cap": sample_cap,
+            "session_end_reason": str(ended[-1].reason) if ended else None,
+            "warning_count": len(warnings),
+        }
+        print("resource_limit_soak_evidence=" + json.dumps(evidence, sort_keys=True))
+
+        assert evidence["fed_samples"] > sample_cap
+        assert limit_exceeded_after_feed is True
+        assert capture_result.pre_roll_samples == 32
+        assert capture_result.post_start_samples == 32
+        assert retained_samples == sample_cap
+        assert capture_result.captured_samples == sample_cap
+        assert orchestrator.sessions.active is None
+        assert warnings
+        assert warnings[-1].warning == "approaching_limit"
+        assert finals
+        assert finals[-1].audio_ms == int((sample_cap * 1000) / sample_rate)
         assert ended
         assert ended[-1].reason == SessionEndReason.FINAL
 


### PR DESCRIPTION
## Summary

- Added a named `just daemon-resource-soak` gate and wired it into `phase6-contract` / `phase6-promotion`.
- Strengthened Session sample-cap accounting so seeded Pre-roll and post-start audio share the configured cap.
- Added deterministic soak evidence for delayed stop/abort flow: Pre-roll seeded first, then 800 post-start samples fed while only 64 total samples are retained and the guard emits visible termination events.
- Documented the resource-limit soak in the release/promotion gate docs.

Closes #169

## Verification

- Red before implementation: `just daemon-resource-soak` failed because the recipe did not exist.
- `uv run pytest tests/test_audio_buffer.py tests/test_session_orchestrator.py::test_phase6_resource_limit_soak_stops_retaining_audio_and_emits_limit_signal`
- `just daemon-resource-soak` -> evidence included `fed_samples=960`, `pre_roll_samples=32`, `post_start_samples=32`, `retained_samples=64`, `sample_cap=64`, `active_session_after_guard=false`, `warning_count=1`
- `just phase6-contract`
- `uv run pytest -q` -> 244 passed
- `uv run ruff format --check .`
- `uv run ruff check .`
- `ty check --project parakeet-stt-daemon --error-on-warning`
- `uv run deptry .`
- `uv build`
- `prek run --all-files`
- `prek run --stage pre-push --all-files` -> passed on rerun; first run hit an unrelated Rust test spawn race (`Text file busy`) after Python and clippy passed

## Review

- Local CodeRabbit watcher `20260524T163117Z` fell back to Codex and found a valid missing Pre-roll coverage gap.
- Fixed by seeding Pre-roll in the soak and budgeting Pre-roll plus post-start samples against one configured cap.
- Local CodeRabbit watcher `20260524T164151Z` fell back to Codex and reported no actionable findings.

## Deferrals

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated overlay reliability gates documentation and engineering playbook with resource guard command references.

* **New Features**
  * Added daemon-resource-soak command for resource limit verification; improved session sample limit calculations to account for both pre-roll and post-start audio samples.

* **Tests**
  * Added comprehensive unit and soak tests validating session resource limit behavior and audio sample accounting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SystemicVoid/parakeet-stt/pull/179?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->