### PR TITLE
Add Stream/Seal inference-overlap stress gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,11 +225,14 @@ prek run --stage pre-push --all-files
 Overlay reliability gates (repo root):
 ```bash
 just daemon-resource-soak
+just daemon-inference-overlap
 just phase6-contract
 just phase6-promotion 3
 ```
 `phase6-contract` includes the Daemon resource-limit soak; it prints retained sample
 count, active Session state, and termination evidence for the Session sample cap.
+It also includes the Stream/Seal inference-overlap stress, which prints call-order
+evidence for live interim, Stream helper feed, and Seal finalization serialization.
 Hook stages are split for speed:
 - `pre-commit`: maintenance cadence reminder, `ruff format`, `ruff check`, `ty check`, `cargo fmt`
 - `pre-push`: `pytest`, `cargo clippy`, `cargo test`

--- a/docs/engineering/harness-engineering-playbook.md
+++ b/docs/engineering/harness-engineering-playbook.md
@@ -105,6 +105,9 @@ scripts/harness-maintenance.sh mark
 
 # Release/promotion resource guard
 just daemon-resource-soak
+
+# Release/promotion Stream/Seal inference-overlap guard
+just daemon-inference-overlap
 ```
 
 ## Local STT Eval Policy

--- a/justfile
+++ b/justfile
@@ -78,8 +78,11 @@ runbook:
 daemon-resource-soak:
     @bash -lc 'cd "{{daemon_dir}}" && uv run pytest tests/test_session_orchestrator.py::test_phase6_resource_limit_soak_stops_retaining_audio_and_emits_limit_signal --capture=tee-sys'
 
+daemon-inference-overlap:
+    @bash -lc 'cd "{{daemon_dir}}" && uv run pytest tests/test_session_orchestrator.py::test_phase6_stream_seal_live_interim_overlap_waits_for_in_flight_only tests/test_session_orchestrator.py::test_stream_feed_cancellation_keeps_inference_gate_until_feed_finishes --capture=tee-sys'
+
 phase6-contract:
-    @bash -lc 'cd "{{repo_root}}" && echo ">>> daemon resource-limit soak" && just daemon-resource-soak && echo ">>> daemon overlay contract suite" && cd parakeet-stt-daemon && uv run pytest tests/test_overlay_event_stream.py && echo ">>> ptt mixed-version + overlay fault-isolation suite" && cd ../parakeet-ptt && cargo test decode_server_message_mixed_version_stream_tolerates_unknown_between_known_messages && cargo test mixed_stream_enqueues_exactly_one_final_result && cargo test overlay_crash_restart_replays_current_state_and_preserves_final_injection && cargo test repeated_overlay_failures_remain_non_fatal_to_final_injection'
+    @bash -lc 'cd "{{repo_root}}" && echo ">>> daemon resource-limit soak" && just daemon-resource-soak && echo ">>> daemon Stream/Seal inference-overlap stress" && just daemon-inference-overlap && echo ">>> daemon overlay contract suite" && cd parakeet-stt-daemon && uv run pytest tests/test_overlay_event_stream.py && echo ">>> ptt mixed-version + overlay fault-isolation suite" && cd ../parakeet-ptt && cargo test decode_server_message_mixed_version_stream_tolerates_unknown_between_known_messages && cargo test mixed_stream_enqueues_exactly_one_final_result && cargo test overlay_crash_restart_replays_current_state_and_preserves_final_injection && cargo test repeated_overlay_failures_remain_non_fatal_to_final_injection'
 
 phase6-promotion runs="3":
     @bash -lc 'cd "{{repo_root}}" && runs="{{runs}}" && if ! [[ "$runs" =~ ^[0-9]+$ ]] || (( runs < 3 )); then echo "runs must be an integer >= 3" >&2; exit 1; fi && outfile="/tmp/parakeet-overlay-phase6-gate-$(date +%Y%m%d-%H%M%S).log" && { echo ">>> phase6 promotion gate (${runs} clean runs required)"; for run in $(seq 1 "$runs"); do echo ""; echo "=== reliability run ${run}/${runs} ==="; just phase6-contract; done; echo ""; echo "=== stream/seal regression gate ==="; just eval compare; echo ""; echo "artifact=$outfile"; } 2>&1 | tee "$outfile"'

--- a/parakeet-stt-daemon/src/parakeet_stt_daemon/session_orchestrator.py
+++ b/parakeet-stt-daemon/src/parakeet_stt_daemon/session_orchestrator.py
@@ -10,10 +10,11 @@ from __future__ import annotations
 import asyncio
 import math
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from functools import partial
-from typing import Literal
+from typing import Literal, TypeVar
 from uuid import UUID
 
 import numpy as np
@@ -81,6 +82,7 @@ from .tail_trim import SealPathTailTrimmer
 SESSION_GUARD_POLL_SECS = 0.1
 SESSION_GUARD_WARNING_FRACTION = 0.8  # emit warning at 80% of limit
 _REAL_ASYNCIO_SLEEP = asyncio.sleep
+_InferenceResult = TypeVar("_InferenceResult")
 
 
 @dataclass(frozen=True, slots=True)
@@ -707,16 +709,17 @@ class SessionOrchestrator:
             self._inference_lock = lock
         return lock
 
-    async def _transcribe_samples_serialized(self, samples: np.ndarray) -> str:
+    async def _run_inference_call_serialized(
+        self,
+        call: Callable[..., _InferenceResult],
+        *args: object,
+        **kwargs: object,
+    ) -> _InferenceResult:
         loop = asyncio.get_running_loop()
         async with self._inference_lock_for_runtime():
             inference = loop.run_in_executor(
                 None,
-                partial(
-                    self.transcriber.transcribe_samples,
-                    samples,
-                    sample_rate=self.audio.sample_rate,
-                ),
+                partial(call, *args, **kwargs),
             )
             try:
                 return await asyncio.shield(inference)
@@ -729,6 +732,13 @@ class SessionOrchestrator:
                         exc.__class__.__name__,
                     )
                 raise
+
+    async def _transcribe_samples_serialized(self, samples: np.ndarray) -> str:
+        return await self._run_inference_call_serialized(
+            self.transcriber.transcribe_samples,
+            samples,
+            sample_rate=self.audio.sample_rate,
+        )
 
     def interim_transcript_runtime_facts(
         self,
@@ -999,8 +1009,7 @@ class SessionOrchestrator:
         )
 
     async def _feed_stream_chunk(self, stream: ParakeetStreamingSession, chunk: np.ndarray) -> None:
-        async with self._inference_lock_for_runtime():
-            processed = await asyncio.to_thread(stream.feed, chunk)
+        processed = await self._run_inference_call_serialized(stream.feed, chunk)
         if processed:
             self._stream_path_runtime_for_runtime().record_chunk_processed()
             return

--- a/parakeet-stt-daemon/tests/test_session_orchestrator.py
+++ b/parakeet-stt-daemon/tests/test_session_orchestrator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import threading
 from datetime import UTC, datetime, timedelta
 from typing import Any, TypeVar, cast
 from uuid import UUID, uuid4
@@ -133,6 +134,114 @@ class FakeTranscriber:
     def transcribe_samples(self, samples: np.ndarray, *, sample_rate: int = 16_000) -> str:
         self.calls.append((samples.copy(), sample_rate))
         return self.text
+
+
+class InferenceOverlapProbe:
+    def __init__(self) -> None:
+        self.live_started = threading.Event()
+        self.release_live = threading.Event()
+        self.stream_feed_started = threading.Event()
+        self.release_stream_feed = threading.Event()
+        self.final_started = threading.Event()
+        self.order: list[str] = []
+        self.max_active_calls = 0
+        self._active_calls = 0
+        self._lock = threading.Lock()
+
+    def run(
+        self,
+        name: str,
+        *,
+        started: threading.Event | None = None,
+        release: threading.Event | None = None,
+        result: Any = None,
+    ) -> Any:
+        with self._lock:
+            self._active_calls += 1
+            self.max_active_calls = max(self.max_active_calls, self._active_calls)
+            self.order.append(f"{name}:start")
+        if started is not None:
+            started.set()
+        try:
+            if release is not None and not release.wait(timeout=2.0):
+                raise AssertionError(f"timed out waiting to release {name}")
+            return result
+        finally:
+            with self._lock:
+                self._active_calls -= 1
+                self.order.append(f"{name}:finish")
+
+
+class LiveFinalOverlapTranscriber:
+    def __init__(self, probe: InferenceOverlapProbe) -> None:
+        self.probe = probe
+        self.calls = 0
+        self._lock = threading.Lock()
+
+    def transcribe_samples(self, samples: np.ndarray, *, sample_rate: int = 16_000) -> str:
+        del samples, sample_rate
+        with self._lock:
+            self.calls += 1
+            call_number = self.calls
+        if call_number == 1:
+            return cast(
+                str,
+                self.probe.run(
+                    "live",
+                    started=self.probe.live_started,
+                    release=self.probe.release_live,
+                    result="live interim",
+                ),
+            )
+        if call_number == 2:
+            return cast(
+                str,
+                self.probe.run("final", started=self.probe.final_started, result="final text"),
+            )
+        return cast(str, self.probe.run(f"unexpected_live_{call_number}", result="queued live"))
+
+
+class FinalOnlyOverlapTranscriber:
+    def __init__(self, probe: InferenceOverlapProbe) -> None:
+        self.probe = probe
+
+    def transcribe_samples(self, samples: np.ndarray, *, sample_rate: int = 16_000) -> str:
+        del samples, sample_rate
+        return cast(
+            str,
+            self.probe.run("final", started=self.probe.final_started, result="final text"),
+        )
+
+
+class BlockingStreamSession:
+    def __init__(self, probe: InferenceOverlapProbe) -> None:
+        self.probe = probe
+        self.feed_calls = 0
+        self.stream_fallback_reason: str | None = None
+
+    def feed(self, chunk: np.ndarray) -> bool:
+        del chunk
+        self.feed_calls += 1
+        return cast(
+            bool,
+            self.probe.run(
+                "stream_feed",
+                started=self.probe.stream_feed_started,
+                release=self.probe.release_stream_feed,
+                result=True,
+            ),
+        )
+
+
+class BlockingStreamingTranscriber:
+    helper_active = True
+    fallback_reason: str | None = None
+
+    def __init__(self, probe: InferenceOverlapProbe) -> None:
+        self.stream_session = BlockingStreamSession(probe)
+
+    def start_session(self, _sample_rate: int) -> BlockingStreamSession:
+        return self.stream_session
 
 
 class FakeSealPathRuntime(SealPathRuntime):
@@ -629,6 +738,149 @@ def test_phase6_resource_limit_soak_stops_retaining_audio_and_emits_limit_signal
         assert finals[-1].audio_ms == int((sample_cap * 1000) / sample_rate)
         assert ended
         assert ended[-1].reason == SessionEndReason.FINAL
+
+    asyncio.run(scenario())
+
+
+def test_phase6_stream_seal_live_interim_overlap_waits_for_in_flight_only() -> None:
+    async def scenario() -> None:
+        probe = InferenceOverlapProbe()
+        ready_live_chunks = [
+            np.full((400,), 0.2, dtype=np.float32),
+            np.full((400,), 0.3, dtype=np.float32),
+            np.full((400,), 0.4, dtype=np.float32),
+        ]
+        orchestrator = _build_orchestrator(
+            streaming_enabled=True,
+            stream_chunks=ready_live_chunks,
+        )
+        cast(Any, orchestrator).streaming_transcriber = FakeStreamingTranscriber(
+            helper_active=False,
+            fallback_reason="init_failed:stress",
+        )
+        tail_trimmer = SealPathTailTrimmer(vad_enabled=False, silence_floor_db=-40.0)
+        orchestrator.tail_trimmer = tail_trimmer
+        orchestrator.seal_path_runtime = SealPathRuntime(
+            sample_rate=16_000,
+            tail_trimmer=tail_trimmer,
+            release_device_cache=lambda _device: None,
+        )
+        transcriber = LiveFinalOverlapTranscriber(probe)
+        cast(Any, orchestrator).transcriber = transcriber
+        sink = RecordingEventSink()
+        session_id = uuid4()
+
+        await _start(orchestrator, sink, session_id)
+        assert await asyncio.to_thread(probe.live_started.wait, 1.0)
+
+        stop_task = asyncio.create_task(
+            orchestrator.stop(
+                StopSessionIntent(
+                    session_id=session_id,
+                    owner_token=1,
+                    event_sink=sink,
+                    post_roll_secs=0.0,
+                )
+            )
+        )
+        for _ in range(20):
+            if probe.final_started.is_set():
+                break
+            await asyncio.sleep(0)
+        final_started_before_live_finished = probe.final_started.is_set()
+        probe.release_live.set()
+        await stop_task
+
+        truth = orchestrator.runtime_truth(overlay_events_enabled=True)
+        evidence = {
+            "calls": transcriber.calls,
+            "final_started_before_live_finished": final_started_before_live_finished,
+            "live_chunks_processed": truth.interim_transcript_live_chunks_processed,
+            "max_active_calls": probe.max_active_calls,
+            "order": probe.order,
+            "queued_live_chunks": len(ready_live_chunks)
+            - int(truth.interim_transcript_live_chunks_processed or 0),
+            "stop_replay_chunks_processed": truth.interim_transcript_stop_replay_chunks_processed,
+        }
+        print("inference_overlap_live_evidence=" + json.dumps(evidence, sort_keys=True))
+
+        assert final_started_before_live_finished is False
+        assert probe.order == ["live:start", "live:finish", "final:start", "final:finish"]
+        assert probe.max_active_calls == 1
+        assert transcriber.calls == 2
+        assert truth.interim_transcript_live_chunks_processed == 1
+        assert truth.interim_transcript_stop_replay_chunks_processed == 0
+        assert _events_of_type(sink, FinalResultEvent)
+        ended = _events_of_type(sink, SessionEndedEvent)
+        assert ended
+        assert ended[-1].reason == SessionEndReason.FINAL
+
+    asyncio.run(scenario())
+
+
+def test_stream_feed_cancellation_keeps_inference_gate_until_feed_finishes() -> None:
+    async def scenario() -> None:
+        probe = InferenceOverlapProbe()
+        orchestrator = _build_orchestrator(
+            streaming_enabled=True,
+            stream_chunks=[np.full((400,), 0.2, dtype=np.float32)],
+        )
+        streaming_transcriber = BlockingStreamingTranscriber(probe)
+        cast(Any, orchestrator).streaming_transcriber = streaming_transcriber
+        tail_trimmer = SealPathTailTrimmer(vad_enabled=False, silence_floor_db=-40.0)
+        orchestrator.tail_trimmer = tail_trimmer
+        orchestrator.seal_path_runtime = SealPathRuntime(
+            sample_rate=16_000,
+            tail_trimmer=tail_trimmer,
+            release_device_cache=lambda _device: None,
+        )
+        cast(Any, orchestrator).transcriber = FinalOnlyOverlapTranscriber(probe)
+        sink = RecordingEventSink()
+        session_id = uuid4()
+
+        await _start(orchestrator, sink, session_id)
+        assert await asyncio.to_thread(probe.stream_feed_started.wait, 1.0)
+
+        stop_task = asyncio.create_task(
+            orchestrator.stop(
+                StopSessionIntent(
+                    session_id=session_id,
+                    owner_token=1,
+                    event_sink=sink,
+                    post_roll_secs=0.0,
+                )
+            )
+        )
+        try:
+            for _ in range(50):
+                if probe.final_started.is_set():
+                    break
+                await asyncio.sleep(0.001)
+            final_started_before_stream_feed_finished = probe.final_started.is_set()
+        finally:
+            probe.release_stream_feed.set()
+            await stop_task
+
+        evidence = {
+            "final_started_before_stream_feed_finished": (
+                final_started_before_stream_feed_finished
+            ),
+            "max_active_calls": probe.max_active_calls,
+            "order": probe.order,
+            "stream_feed_calls": streaming_transcriber.stream_session.feed_calls,
+        }
+        print("inference_overlap_stream_feed_evidence=" + json.dumps(evidence, sort_keys=True))
+
+        assert final_started_before_stream_feed_finished is False
+        assert probe.order == [
+            "stream_feed:start",
+            "stream_feed:finish",
+            "final:start",
+            "final:finish",
+        ]
+        assert probe.max_active_calls == 1
+        assert streaming_transcriber.stream_session.feed_calls == 1
+        assert _events_of_type(sink, FinalResultEvent)
 
     asyncio.run(scenario())
 


### PR DESCRIPTION
## Summary
- Add a shared serialized inference helper so cancelled executor work keeps the inference gate held until the worker finishes.
- Add a named Daemon Stream/Seal overlap gate with live-interim stop overlap and Stream helper feed cancellation coverage.
- Wire the new gate into phase6-contract and document it in the release/promotion surfaces.

Closes #170

## Verification
- Red check before implementation: just daemon-inference-overlap failed because the recipe was missing.
- just daemon-inference-overlap passed with live and Stream feed call-order evidence.
- just phase6-contract passed with the new gate included.
- uv run pytest -q passed: 246 tests.
- uv run ruff format --check ., uv run ruff check ., ty check --project parakeet-stt-daemon --error-on-warning, uv run deptry ., and uv build passed.
- prek run --all-files and prek run --stage pre-push --all-files passed.

## Deferrals
None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated overlay reliability gates section with new test command and expanded descriptions of Stream/Seal inference-overlap stress testing scenarios.

* **New Features**  
  * Added daemon-inference-overlap test command for running Stream-Seal inference overlap verification tests.

* **Tests**
  * Added test coverage verifying Stream-Seal live interim overlap sequencing and feed cancellation behavior during inference execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SystemicVoid/parakeet-stt/pull/180?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->