### PR TITLE
Fix stream-seal final accuracy regression

### DIFF
--- a/parakeet-stt-daemon/check_model_lib/runner.py
+++ b/parakeet-stt-daemon/check_model_lib/runner.py
@@ -75,6 +75,7 @@ def _run_benchmark_once(
                 raise ValueError("streaming transcriber is required for stream-seal runtime")
             hypothesis, infer_ms = _transcribe_stream_seal(
                 streaming_transcriber,
+                transcriber,
                 samples,
                 sample_rate=sample_rate,
                 silence_floor_db=stream_silence_floor_db,
@@ -256,8 +257,9 @@ def run_offline_benchmark(args: argparse.Namespace) -> int:
     transcriber = ParakeetTranscriber(model)
     streaming_transcriber: ParakeetStreamingTranscriber | None = None
     if args.bench_runtime == "stream-seal":
+        stream_model = load_parakeet_model(args.model, device=args.device)
         streaming_transcriber = ParakeetStreamingTranscriber(
-            model,
+            stream_model,
             chunk_secs=args.stream_chunk_secs,
             right_context_secs=args.stream_right_context_secs,
             left_context_secs=args.stream_left_context_secs,
@@ -338,6 +340,7 @@ def run_offline_benchmark(args: argparse.Namespace) -> int:
             "fallback_reason": (
                 streaming_transcriber.fallback_reason if streaming_transcriber is not None else None
             ),
+            "stream_model_isolated": streaming_transcriber is not None,
         }
     report = {
         "benchmark": "offline",

--- a/parakeet-stt-daemon/check_model_lib/runner.py
+++ b/parakeet-stt-daemon/check_model_lib/runner.py
@@ -46,6 +46,7 @@ from check_model_lib.runtime import (
 )
 from check_model_lib.thresholds import evaluate_regression_thresholds
 from parakeet_stt_daemon.model import (
+    STREAMING_HELPER_DISABLED_FOR_SEAL_ACCURACY,
     ParakeetStreamingTranscriber,
     ParakeetTranscriber,
     load_parakeet_model,
@@ -257,13 +258,14 @@ def run_offline_benchmark(args: argparse.Namespace) -> int:
     transcriber = ParakeetTranscriber(model)
     streaming_transcriber: ParakeetStreamingTranscriber | None = None
     if args.bench_runtime == "stream-seal":
-        stream_model = load_parakeet_model(args.model, device=args.device)
         streaming_transcriber = ParakeetStreamingTranscriber(
-            stream_model,
+            model,
             chunk_secs=args.stream_chunk_secs,
             right_context_secs=args.stream_right_context_secs,
             left_context_secs=args.stream_left_context_secs,
             batch_size=args.stream_batch_size,
+            enable_helper=False,
+            helper_disabled_reason=STREAMING_HELPER_DISABLED_FOR_SEAL_ACCURACY,
         )
     effective_device = str(getattr(model, "_parakeet_effective_device", args.device))
 
@@ -340,7 +342,8 @@ def run_offline_benchmark(args: argparse.Namespace) -> int:
             "fallback_reason": (
                 streaming_transcriber.fallback_reason if streaming_transcriber is not None else None
             ),
-            "stream_model_isolated": streaming_transcriber is not None,
+            "stream_model_isolated": False,
+            "streaming_helper_policy": "disabled_for_seal_accuracy",
         }
     report = {
         "benchmark": "offline",
@@ -484,6 +487,7 @@ def run_streaming_probe(model, samples: np.ndarray) -> str:
             right_context_secs=PROBE_STREAM_RIGHT_CONTEXT_SECS,
             left_context_secs=PROBE_STREAM_LEFT_CONTEXT_SECS,
             batch_size=PROBE_STREAM_BATCH_SIZE,
+            enable_helper=True,
         )
     except Exception as exc:  # noqa: BLE001 - probe command must report any helper init failure
         return f"streaming helper init failed: {exc}"

--- a/parakeet-stt-daemon/check_model_lib/runtime.py
+++ b/parakeet-stt-daemon/check_model_lib/runtime.py
@@ -10,7 +10,7 @@ from typing import Any
 import numpy as np
 
 from check_model_lib.constants import SAMPLE_RATE
-from parakeet_stt_daemon.model import ParakeetStreamingTranscriber
+from parakeet_stt_daemon.model import ParakeetStreamingTranscriber, ParakeetTranscriber
 
 
 def _read_wav_samples(path: Path) -> tuple[np.ndarray, int]:
@@ -100,6 +100,7 @@ def _split_stream_ready_and_tail(
 
 def _transcribe_stream_seal(
     streamer: ParakeetStreamingTranscriber,
+    seal_transcriber: ParakeetTranscriber,
     samples: np.ndarray,
     *,
     sample_rate: int,
@@ -128,7 +129,13 @@ def _transcribe_stream_seal(
             session.feed(chunk)
         if active_tail.size:
             session.feed(active_tail)
-        return session.finalize()
+        if ready_chunks:
+            final_audio = np.concatenate([*ready_chunks, active_tail]).astype(
+                np.float32, copy=False
+            )
+        else:
+            final_audio = active_tail.astype(np.float32, copy=False)
+        return seal_transcriber.transcribe_samples(final_audio, sample_rate=sample_rate)
 
     infer_start = time.perf_counter()
     hypothesis = _finalize_with_tail(trimmed_tail)

--- a/parakeet-stt-daemon/src/parakeet_stt_daemon/model.py
+++ b/parakeet-stt-daemon/src/parakeet_stt_daemon/model.py
@@ -19,6 +19,7 @@ import numpy as np
 from loguru import logger
 
 DEFAULT_MODEL_NAME = "nvidia/parakeet-tdt-0.6b-v3"
+STREAMING_HELPER_DISABLED_FOR_SEAL_ACCURACY = "streaming_helper_disabled:seal_accuracy"
 
 if TYPE_CHECKING:  # pragma: no cover
     import nemo.collections.asr as nemo_asr
@@ -383,6 +384,15 @@ class ParakeetStreamingSession:
         self._chunks.append(np.array(audio, dtype=np.float32, copy=True))
         if self.stream_fallback_reason is not None:
             return False
+        if not bool(getattr(self._parent, "helper_active", True)):
+            reason = str(
+                getattr(self._parent, "fallback_reason", None) or "streaming_helper_unavailable"
+            )
+            self.stream_fallback_reason = reason
+            mark_fallback = getattr(self._parent, "mark_stream_fallback", None)
+            if callable(mark_fallback):
+                mark_fallback(reason)
+            return False
         try:
             self._parent.process_stream_chunk(audio, self.sample_rate)
         except Exception as exc:  # noqa: BLE001 - session should fall back to Seal path
@@ -414,6 +424,8 @@ class ParakeetStreamingTranscriber:
         right_context_secs: float = 2.0,
         left_context_secs: float = 10.0,
         batch_size: int = 32,
+        enable_helper: bool = False,
+        helper_disabled_reason: str | None = None,
     ) -> None:
         self.model = model
         self.chunk_secs = float(chunk_secs)
@@ -425,6 +437,16 @@ class ParakeetStreamingTranscriber:
         self._helper_class_name: str | None = None
 
         self.offline = ParakeetTranscriber(model)
+        if not enable_helper:
+            self.fallback_reason = (
+                helper_disabled_reason or STREAMING_HELPER_DISABLED_FOR_SEAL_ACCURACY
+            )
+            logger.info(
+                "NeMo streaming helper disabled ({}); using Seal path for final "
+                "transcription and rolling offline interim updates",
+                self.fallback_reason,
+            )
+            return
         self._init_helper()
 
     @property
@@ -524,27 +546,19 @@ class ParakeetStreamingTranscriber:
             if model_is_tdt and batched_frame_asr_tdt is None:
                 logger.warning(
                     "TDT model detected but BatchedFrameASRTDT is unavailable; "
-                    "falling back to RNNT helper"
+                    "using offline fallback"
                 )
+                self.chunk_helper = None
+                self.fallback_reason = "init_failed:BatchedFrameASRTDTUnavailable"
+                return
             if model_is_tdt and batched_frame_asr_tdt is not None:
                 try:
                     change_decoding = getattr(self.model, "change_decoding_strategy", None)
-                    if callable(change_decoding) and decoding_cfg is not None:
-                        try:
-                            if open_dict_fn is not None:
-                                with open_dict_fn(decoding_cfg):
-                                    _set_cfg_value(decoding_cfg, "strategy", "greedy")
-                                    _disable_cuda_graph_decoder_config(decoding_cfg)
-                                    _set_cfg_value(decoding_cfg, "preserve_alignments", True)
-                                    _set_cfg_value(decoding_cfg, "fused_batch_size", -1)
-                                    beam_cfg = _get_cfg_value(decoding_cfg, "beam")
-                                    _set_cfg_value(beam_cfg, "return_best_hypothesis", True)
-                                    _set_cfg_value(
-                                        greedy_cfg,
-                                        "max_symbols_per_step",
-                                        int(max_steps_per_timestep),
-                                    )
-                            else:
+                    if not callable(change_decoding) or decoding_cfg is None:
+                        raise RuntimeError("streaming_decoding_builder_unavailable")
+                    try:
+                        if open_dict_fn is not None:
+                            with open_dict_fn(decoding_cfg):
                                 _set_cfg_value(decoding_cfg, "strategy", "greedy")
                                 _disable_cuda_graph_decoder_config(decoding_cfg)
                                 _set_cfg_value(decoding_cfg, "preserve_alignments", True)
@@ -552,16 +566,32 @@ class ParakeetStreamingTranscriber:
                                 beam_cfg = _get_cfg_value(decoding_cfg, "beam")
                                 _set_cfg_value(beam_cfg, "return_best_hypothesis", True)
                                 _set_cfg_value(
-                                    greedy_cfg, "max_symbols_per_step", int(max_steps_per_timestep)
+                                    greedy_cfg,
+                                    "max_symbols_per_step",
+                                    int(max_steps_per_timestep),
                                 )
-                            change_decoding(decoding_cfg)
-                            # change_decoding_strategy recreates the decoder with
-                            # CUDA graphs re-enabled; disable them again.
-                            _disable_cuda_graph_decoder(self.model)
-                        except Exception as exc:  # noqa: BLE001 - NeMo config shape varies by build
-                            logger.warning(
-                                "Failed to adjust decoding strategy for TDT streaming: {}", exc
+                        else:
+                            _set_cfg_value(decoding_cfg, "strategy", "greedy")
+                            _disable_cuda_graph_decoder_config(decoding_cfg)
+                            _set_cfg_value(decoding_cfg, "preserve_alignments", True)
+                            _set_cfg_value(decoding_cfg, "fused_batch_size", -1)
+                            beam_cfg = _get_cfg_value(decoding_cfg, "beam")
+                            _set_cfg_value(beam_cfg, "return_best_hypothesis", True)
+                            _set_cfg_value(
+                                greedy_cfg,
+                                "max_symbols_per_step",
+                                int(max_steps_per_timestep),
                             )
+                    except Exception as exc:  # noqa: BLE001 - NeMo config shape varies by build
+                        logger.warning(
+                            "Failed to adjust decoding strategy for TDT streaming: {}",
+                            exc,
+                        )
+                        raise
+                    change_decoding(decoding_cfg)
+                    # change_decoding_strategy recreates the decoder with
+                    # CUDA graphs re-enabled; disable them again.
+                    _disable_cuda_graph_decoder(self.model)
                     tdt_batch_size = 1
                     if self.batch_size != tdt_batch_size:
                         logger.info(
@@ -592,9 +622,12 @@ class ParakeetStreamingTranscriber:
                     return
                 except Exception as exc:  # noqa: BLE001 - helper init is best-effort
                     logger.warning(
-                        "TDT streaming helper init failed; falling back to RNNT helper: {}",
+                        "TDT streaming helper init failed; using offline fallback: {}",
                         exc,
                     )
+                    self.chunk_helper = None
+                    self.fallback_reason = f"init_failed:{exc.__class__.__name__}"
+                    return
             self.chunk_helper = FrameBatchChunkedRNNT(
                 asr_model=self.model,
                 frame_len=cast(Any, self.chunk_secs),
@@ -635,4 +668,5 @@ __all__ = [
     "ParakeetStreamingTranscriber",
     "ParakeetStreamingSession",
     "DEFAULT_MODEL_NAME",
+    "STREAMING_HELPER_DISABLED_FOR_SEAL_ACCURACY",
 ]

--- a/parakeet-stt-daemon/src/parakeet_stt_daemon/model.py
+++ b/parakeet-stt-daemon/src/parakeet_stt_daemon/model.py
@@ -166,6 +166,17 @@ def _disable_cuda_graph_decoder_config(decoding_cfg: Any) -> bool:
     return changed
 
 
+def _apply_greedy_decoding_defaults(decoding_cfg: Any, max_steps_per_timestep: int) -> None:
+    _set_cfg_value(decoding_cfg, "strategy", "greedy")
+    _disable_cuda_graph_decoder_config(decoding_cfg)
+    _set_cfg_value(decoding_cfg, "preserve_alignments", True)
+    _set_cfg_value(decoding_cfg, "fused_batch_size", -1)
+    beam_cfg = _get_cfg_value(decoding_cfg, "beam")
+    _set_cfg_value(beam_cfg, "return_best_hypothesis", True)
+    greedy_cfg = _get_cfg_value(decoding_cfg, "greedy")
+    _set_cfg_value(greedy_cfg, "max_symbols_per_step", int(max_steps_per_timestep))
+
+
 def _iter_cuda_graph_decoder_candidates(model: ASRModel) -> Iterator[Any]:
     """Yield likely NeMo decoder objects that may own CUDA graph state."""
     seen: set[int] = set()
@@ -538,7 +549,7 @@ class ParakeetStreamingTranscriber:
         max_steps_per_timestep = 5
         cfg = getattr(self.model, "_cfg", None) or getattr(self.model, "cfg", None)
         decoding_cfg = _get_cfg_value(cfg, "decoding")
-        greedy_cfg = getattr(decoding_cfg, "greedy", None)
+        greedy_cfg = _get_cfg_value(decoding_cfg, "greedy")
         configured = _get_cfg_value(greedy_cfg, "max_symbols_per_step")
         if configured is not None:
             max_steps_per_timestep = int(configured)
@@ -559,28 +570,14 @@ class ParakeetStreamingTranscriber:
                     try:
                         if open_dict_fn is not None:
                             with open_dict_fn(decoding_cfg):
-                                _set_cfg_value(decoding_cfg, "strategy", "greedy")
-                                _disable_cuda_graph_decoder_config(decoding_cfg)
-                                _set_cfg_value(decoding_cfg, "preserve_alignments", True)
-                                _set_cfg_value(decoding_cfg, "fused_batch_size", -1)
-                                beam_cfg = _get_cfg_value(decoding_cfg, "beam")
-                                _set_cfg_value(beam_cfg, "return_best_hypothesis", True)
-                                _set_cfg_value(
-                                    greedy_cfg,
-                                    "max_symbols_per_step",
-                                    int(max_steps_per_timestep),
+                                _apply_greedy_decoding_defaults(
+                                    decoding_cfg,
+                                    max_steps_per_timestep,
                                 )
                         else:
-                            _set_cfg_value(decoding_cfg, "strategy", "greedy")
-                            _disable_cuda_graph_decoder_config(decoding_cfg)
-                            _set_cfg_value(decoding_cfg, "preserve_alignments", True)
-                            _set_cfg_value(decoding_cfg, "fused_batch_size", -1)
-                            beam_cfg = _get_cfg_value(decoding_cfg, "beam")
-                            _set_cfg_value(beam_cfg, "return_best_hypothesis", True)
-                            _set_cfg_value(
-                                greedy_cfg,
-                                "max_symbols_per_step",
-                                int(max_steps_per_timestep),
+                            _apply_greedy_decoding_defaults(
+                                decoding_cfg,
+                                max_steps_per_timestep,
                             )
                     except Exception as exc:  # noqa: BLE001 - NeMo config shape varies by build
                         logger.warning(

--- a/parakeet-stt-daemon/src/parakeet_stt_daemon/session_orchestrator.py
+++ b/parakeet-stt-daemon/src/parakeet_stt_daemon/session_orchestrator.py
@@ -14,7 +14,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from functools import partial
-from typing import Literal, TypeVar
+from typing import Any, Literal, TypeVar
 from uuid import UUID
 
 import numpy as np
@@ -166,17 +166,8 @@ class SessionOrchestrator:
         )
         self._session_lock = asyncio.Lock()
         self._inference_lock = asyncio.Lock()
-        self.streaming_transcriber: ParakeetStreamingTranscriber | None = (
-            ParakeetStreamingTranscriber(
-                self.model,
-                chunk_secs=settings.chunk_secs,
-                right_context_secs=settings.right_context_secs,
-                left_context_secs=settings.left_context_secs,
-                batch_size=settings.batch_size,
-            )
-            if settings.streaming_enabled
-            else None
-        )
+        self._streaming_model: Any | None = None
+        self.streaming_transcriber = self._load_isolated_streaming_transcriber(settings)
         self._active_stream: ParakeetStreamingSession | None = None
         self._stream_drain_task: asyncio.Task | None = None
         self._stream_drain_running = False
@@ -203,6 +194,30 @@ class SessionOrchestrator:
         self.interim_transcript_runtime = InterimTranscriptRuntime.from_settings(
             settings,
             sample_rate=self.audio.sample_rate,
+        )
+
+    def _load_isolated_streaming_transcriber(
+        self, settings: ServerSettings
+    ) -> ParakeetStreamingTranscriber | None:
+        if not settings.streaming_enabled:
+            return None
+        try:
+            self._streaming_model = load_parakeet_model(device=settings.device)
+        except Exception as exc:  # noqa: BLE001 - stream path must not take down Seal path
+            logger.warning(
+                "Failed to load isolated streaming model; disabling Stream path to preserve "
+                "Seal path accuracy: {}",
+                exc,
+            )
+            self._streaming_model = None
+            return None
+        logger.info("Loaded isolated Parakeet model for Stream path")
+        return ParakeetStreamingTranscriber(
+            self._streaming_model,
+            chunk_secs=settings.chunk_secs,
+            right_context_secs=settings.right_context_secs,
+            left_context_secs=settings.left_context_secs,
+            batch_size=settings.batch_size,
         )
 
     async def start(self, intent: StartSessionIntent) -> None:

--- a/parakeet-stt-daemon/src/parakeet_stt_daemon/session_orchestrator.py
+++ b/parakeet-stt-daemon/src/parakeet_stt_daemon/session_orchestrator.py
@@ -14,7 +14,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from functools import partial
-from typing import Any, Literal, TypeVar
+from typing import Literal, TypeVar
 from uuid import UUID
 
 import numpy as np
@@ -40,6 +40,7 @@ from .messages import (
     SessionEndReason,
 )
 from .model import (
+    STREAMING_HELPER_DISABLED_FOR_SEAL_ACCURACY,
     ParakeetStreamingSession,
     ParakeetStreamingTranscriber,
     ParakeetTranscriber,
@@ -166,8 +167,7 @@ class SessionOrchestrator:
         )
         self._session_lock = asyncio.Lock()
         self._inference_lock = asyncio.Lock()
-        self._streaming_model: Any | None = None
-        self.streaming_transcriber = self._load_isolated_streaming_transcriber(settings)
+        self.streaming_transcriber = self._load_streaming_transcriber(settings)
         self._active_stream: ParakeetStreamingSession | None = None
         self._stream_drain_task: asyncio.Task | None = None
         self._stream_drain_running = False
@@ -196,28 +196,19 @@ class SessionOrchestrator:
             sample_rate=self.audio.sample_rate,
         )
 
-    def _load_isolated_streaming_transcriber(
+    def _load_streaming_transcriber(
         self, settings: ServerSettings
     ) -> ParakeetStreamingTranscriber | None:
         if not settings.streaming_enabled:
             return None
-        try:
-            self._streaming_model = load_parakeet_model(device=settings.device)
-        except Exception as exc:  # noqa: BLE001 - stream path must not take down Seal path
-            logger.warning(
-                "Failed to load isolated streaming model; disabling Stream path to preserve "
-                "Seal path accuracy: {}",
-                exc,
-            )
-            self._streaming_model = None
-            return None
-        logger.info("Loaded isolated Parakeet model for Stream path")
         return ParakeetStreamingTranscriber(
-            self._streaming_model,
+            self.model,
             chunk_secs=settings.chunk_secs,
             right_context_secs=settings.right_context_secs,
             left_context_secs=settings.left_context_secs,
             batch_size=settings.batch_size,
+            enable_helper=False,
+            helper_disabled_reason=STREAMING_HELPER_DISABLED_FOR_SEAL_ACCURACY,
         )
 
     async def start(self, intent: StartSessionIntent) -> None:

--- a/parakeet-stt-daemon/tests/test_offline_benchmark_harness.py
+++ b/parakeet-stt-daemon/tests/test_offline_benchmark_harness.py
@@ -652,12 +652,14 @@ def test_run_streaming_probe_uses_probe_stream_constants(monkeypatch) -> None:
             right_context_secs: float,
             left_context_secs: float,
             batch_size: int,
+            enable_helper: bool = False,
         ) -> None:
             del model
             captured["chunk_secs"] = chunk_secs
             captured["right_context_secs"] = right_context_secs
             captured["left_context_secs"] = left_context_secs
             captured["batch_size"] = batch_size
+            captured["enable_helper"] = enable_helper
             self.chunk_secs = chunk_secs
             self.chunk_helper = object()
 
@@ -678,6 +680,123 @@ def test_run_streaming_probe_uses_probe_stream_constants(monkeypatch) -> None:
         "right_context_secs": PROBE_STREAM_RIGHT_CONTEXT_SECS,
         "left_context_secs": PROBE_STREAM_LEFT_CONTEXT_SECS,
         "batch_size": PROBE_STREAM_BATCH_SIZE,
+        "enable_helper": True,
+    }
+
+
+def test_run_offline_benchmark_stream_seal_uses_single_model(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    from parakeet_stt_daemon.model import STREAMING_HELPER_DISABLED_FOR_SEAL_ACCURACY
+
+    model = object()
+    load_calls: list[tuple[str, str]] = []
+    captured: dict[str, Any] = {}
+
+    class _FakeSealTranscriber:
+        def __init__(self, model_arg: object) -> None:
+            captured["seal_model"] = model_arg
+
+    class _FakeStreamer:
+        helper_active = False
+        _helper_class_name = None
+
+        def __init__(self, model_arg: object, **kwargs: Any) -> None:
+            captured["stream_model"] = model_arg
+            captured["stream_kwargs"] = kwargs
+            self.chunk_secs = kwargs["chunk_secs"]
+            self.fallback_reason = kwargs["helper_disabled_reason"]
+
+    def fake_load_parakeet_model(model_name: str, *, device: str) -> object:
+        load_calls.append((model_name, device))
+        return model
+
+    aggregate = {
+        "avg_wer": 0.0,
+        "infer_ms": {"avg": 0.0, "p50": 0.0, "p95": 0.0},
+        "finalize_ms": {"avg": 0.0, "p50": 0.0, "p95": 0.0},
+        "weighted_wer": 0.0,
+        "command_exact_match_rate": 1.0,
+        "command_exact_match_rate_strict": 1.0,
+        "command_exact_match_rate_normalized": 1.0,
+        "command_intent_slot_match_rate": 1.0,
+        "critical_token_recall": 1.0,
+        "warm_finalize_ms": {"avg": 0.0, "p50": 0.0, "p95": 0.0},
+        "punctuation": {"precision": 1.0, "recall": 1.0},
+        "punctuation_f1": 1.0,
+        "terminal_punctuation_accuracy": 1.0,
+        "aggregation_strategy": "single_run",
+    }
+
+    monkeypatch.setattr(_RUNNER, "load_parakeet_model", fake_load_parakeet_model)
+    monkeypatch.setattr(_RUNNER, "ParakeetTranscriber", _FakeSealTranscriber)
+    monkeypatch.setattr(_RUNNER, "ParakeetStreamingTranscriber", _FakeStreamer)
+    monkeypatch.setattr(_RUNNER, "_resolve_benchmark_cases", lambda **_kwargs: ([], None, None))
+    monkeypatch.setattr(
+        _RUNNER,
+        "_run_benchmark_once",
+        lambda **_kwargs: {"samples": []},
+    )
+    monkeypatch.setattr(_RUNNER, "_aggregate_run_results", lambda _runs: aggregate)
+    monkeypatch.setattr(_RUNNER, "_compute_baseline_comparison", lambda _baseline, _agg: None)
+    monkeypatch.setattr(_RUNNER, "evaluate_regression_thresholds", lambda **_kwargs: [])
+
+    args = argparse.Namespace(
+        bench_tier=None,
+        bench_runs=1,
+        warmup_samples=0,
+        bench_runtime="stream-seal",
+        stream_chunk_secs=2.0,
+        stream_right_context_secs=2.0,
+        stream_left_context_secs=10.0,
+        stream_batch_size=32,
+        stream_silence_floor_db=-40.0,
+        stream_max_tail_trim_secs=0.35,
+        bench_dir=tmp_path,
+        bench_output=tmp_path / "report.json",
+        bench_transcripts=None,
+        bench_manifest=None,
+        bench_append_legacy=False,
+        model="test-model",
+        device="cuda",
+        baseline=None,
+        calibrate_baseline=False,
+        baseline_output=None,
+        max_avg_wer=None,
+        max_p95_infer_ms=None,
+        max_p95_finalize_ms=None,
+        max_weighted_wer=None,
+        min_command_exact_match=None,
+        min_command_normalized_exact_match=None,
+        min_command_intent_slot_match=None,
+        min_critical_token_recall=None,
+        min_punctuation_f1=None,
+        min_terminal_punctuation_accuracy=None,
+        max_warm_p95_finalize_ms=None,
+        max_weighted_wer_delta=None,
+        max_command_exact_match_drop=None,
+        max_command_normalized_exact_match_drop=None,
+        max_command_intent_slot_match_drop=None,
+        max_critical_token_recall_drop=None,
+        max_punctuation_f1_drop=None,
+        max_terminal_punctuation_accuracy_drop=None,
+        max_warm_p95_finalize_ms_delta=None,
+    )
+
+    exit_code = _RUNNER.run_offline_benchmark(args)
+
+    assert exit_code == 0
+    assert load_calls == [("test-model", "cuda")]
+    assert captured["seal_model"] is model
+    assert captured["stream_model"] is model
+    assert captured["stream_kwargs"] == {
+        "chunk_secs": 2.0,
+        "right_context_secs": 2.0,
+        "left_context_secs": 10.0,
+        "batch_size": 32,
+        "enable_helper": False,
+        "helper_disabled_reason": STREAMING_HELPER_DISABLED_FOR_SEAL_ACCURACY,
     }
 
 
@@ -689,7 +808,7 @@ class _DummyStreamSession:
         self._parent.fed_sample_counts[-1] += len(chunk)
 
     def finalize(self) -> str:
-        raise AssertionError("stream-seal finalization must use the isolated Seal transcriber")
+        raise AssertionError("stream-seal finalization must use the Seal transcriber")
 
 
 class _DummyStreamer:

--- a/parakeet-stt-daemon/tests/test_offline_benchmark_harness.py
+++ b/parakeet-stt-daemon/tests/test_offline_benchmark_harness.py
@@ -684,19 +684,12 @@ def test_run_streaming_probe_uses_probe_stream_constants(monkeypatch) -> None:
 class _DummyStreamSession:
     def __init__(self, parent: _DummyStreamer) -> None:
         self._parent = parent
-        self._chunks: list[list[float]] = []
 
     def feed(self, chunk: list[float]) -> None:
-        self._chunks.append(list(chunk))
+        self._parent.fed_sample_counts[-1] += len(chunk)
 
     def finalize(self) -> str:
-        total_samples = sum(len(chunk) for chunk in self._chunks)
-        self._parent.finalized_sample_counts.append(total_samples)
-        if total_samples in self._parent.finalize_outputs_by_sample_count:
-            return self._parent.finalize_outputs_by_sample_count[total_samples]
-        if self._parent.finalize_outputs:
-            return self._parent.finalize_outputs.pop(0)
-        return "ok"
+        raise AssertionError("stream-seal finalization must use the isolated Seal transcriber")
 
 
 class _DummyStreamer:
@@ -704,25 +697,46 @@ class _DummyStreamer:
         self,
         *,
         chunk_secs: float,
-        finalize_outputs: list[str] | None = None,
-        finalize_outputs_by_sample_count: dict[int, str] | None = None,
     ) -> None:
         self.chunk_secs = chunk_secs
-        self.finalize_outputs = list(finalize_outputs or [])
-        self.finalize_outputs_by_sample_count = dict(finalize_outputs_by_sample_count or {})
-        self.finalized_sample_counts: list[int] = []
+        self.fed_sample_counts: list[int] = []
 
     def start_session(self, sample_rate: int) -> _DummyStreamSession:
         del sample_rate
+        self.fed_sample_counts.append(0)
         return _DummyStreamSession(self)
+
+
+class _DummySealTranscriber:
+    def __init__(
+        self,
+        *,
+        outputs: list[str] | None = None,
+        outputs_by_sample_count: dict[int, str] | None = None,
+    ) -> None:
+        self.outputs = list(outputs or [])
+        self.outputs_by_sample_count = dict(outputs_by_sample_count or {})
+        self.transcribed_sample_counts: list[int] = []
+
+    def transcribe_samples(self, samples: np.ndarray, *, sample_rate: int) -> str:
+        del sample_rate
+        total_samples = int(samples.size)
+        self.transcribed_sample_counts.append(total_samples)
+        if total_samples in self.outputs_by_sample_count:
+            return self.outputs_by_sample_count[total_samples]
+        if self.outputs:
+            return self.outputs.pop(0)
+        return "ok"
 
 
 def test_transcribe_stream_seal_caps_tail_trimming() -> None:
     streamer = _DummyStreamer(chunk_secs=1.0)
+    seal_transcriber = _DummySealTranscriber()
     samples = np.zeros((160,), dtype=np.float32)  # sample_rate=100 => ready=100, tail=60
 
     hypothesis, _ = transcribe_stream_seal(
         streamer,
+        seal_transcriber,
         samples=samples,
         sample_rate=100,
         silence_floor_db=-40.0,
@@ -731,15 +745,18 @@ def test_transcribe_stream_seal_caps_tail_trimming() -> None:
 
     # Tail trim is capped to 0.2s (20 samples), so at least 40 tail samples are kept.
     assert hypothesis == "ok"
-    assert streamer.finalized_sample_counts == [140]
+    assert streamer.fed_sample_counts == [140]
+    assert seal_transcriber.transcribed_sample_counts == [140]
 
 
 def test_transcribe_stream_seal_retries_with_full_tail_when_empty() -> None:
-    streamer = _DummyStreamer(chunk_secs=1.0, finalize_outputs=["", "ok"])
+    streamer = _DummyStreamer(chunk_secs=1.0)
+    seal_transcriber = _DummySealTranscriber(outputs=["", "ok"])
     samples = np.zeros((160,), dtype=np.float32)  # ready=100, tail=60
 
     hypothesis, _ = transcribe_stream_seal(
         streamer,
+        seal_transcriber,
         samples=samples,
         sample_rate=100,
         silence_floor_db=-40.0,
@@ -748,13 +765,14 @@ def test_transcribe_stream_seal_retries_with_full_tail_when_empty() -> None:
 
     # First finalize uses capped tail (140 samples), retry uses full tail (160 samples).
     assert hypothesis == "ok"
-    assert streamer.finalized_sample_counts == [140, 160]
+    assert streamer.fed_sample_counts == [140, 160]
+    assert seal_transcriber.transcribed_sample_counts == [140, 160]
 
 
 def test_stream_seal_regression_cmd_087_non_empty_for_non_empty_reference() -> None:
-    streamer = _DummyStreamer(
-        chunk_secs=1.0,
-        finalize_outputs_by_sample_count={
+    streamer = _DummyStreamer(chunk_secs=1.0)
+    seal_transcriber = _DummySealTranscriber(
+        outputs_by_sample_count={
             140: "",
             160: _CMD_087_RECOVERED_HYPOTHESIS,
         },
@@ -763,6 +781,7 @@ def test_stream_seal_regression_cmd_087_non_empty_for_non_empty_reference() -> N
 
     hypothesis, _ = transcribe_stream_seal(
         streamer,
+        seal_transcriber,
         samples=samples,
         sample_rate=100,
         silence_floor_db=-40.0,
@@ -772,13 +791,14 @@ def test_stream_seal_regression_cmd_087_non_empty_for_non_empty_reference() -> N
     assert normalize_transcript(_CMD_087_REFERENCE)
     assert hypothesis.strip() != ""
     assert compute_normalized_wer(_CMD_087_REFERENCE, hypothesis) <= 0.15
-    assert streamer.finalized_sample_counts == [140, 160]
+    assert streamer.fed_sample_counts == [140, 160]
+    assert seal_transcriber.transcribed_sample_counts == [140, 160]
 
 
 def test_stream_seal_regression_cmd_073_retains_suffix_with_tail_trim_cap() -> None:
-    streamer = _DummyStreamer(
-        chunk_secs=1.0,
-        finalize_outputs_by_sample_count={
+    streamer = _DummyStreamer(chunk_secs=1.0)
+    seal_transcriber = _DummySealTranscriber(
+        outputs_by_sample_count={
             # No cap can trim all 60 tail samples and lose the suffix clause.
             100: _CMD_073_TRIMMED_HYPOTHESIS,
             # 0.35s cap (35 samples @100Hz) keeps 25 tail samples and preserves suffix.
@@ -789,6 +809,7 @@ def test_stream_seal_regression_cmd_073_retains_suffix_with_tail_trim_cap() -> N
 
     hypothesis, _ = transcribe_stream_seal(
         streamer,
+        seal_transcriber,
         samples=samples,
         sample_rate=100,
         silence_floor_db=-40.0,
@@ -798,4 +819,5 @@ def test_stream_seal_regression_cmd_073_retains_suffix_with_tail_trim_cap() -> N
     assert compute_normalized_wer(_CMD_073_REFERENCE, _CMD_073_TRIMMED_HYPOTHESIS) > 0.35
     assert compute_normalized_wer(_CMD_073_REFERENCE, hypothesis) <= 0.10
     assert _CMD_073_SUFFIX in normalize_transcript(hypothesis)
-    assert streamer.finalized_sample_counts == [125]
+    assert streamer.fed_sample_counts == [125]
+    assert seal_transcriber.transcribed_sample_counts == [125]

--- a/parakeet-stt-daemon/tests/test_session_orchestrator.py
+++ b/parakeet-stt-daemon/tests/test_session_orchestrator.py
@@ -337,6 +337,74 @@ def _stream_runtime(orchestrator: SessionOrchestrator) -> StreamPathRuntime:
     return orchestrator._stream_path_runtime_for_runtime()
 
 
+def test_constructor_stream_seal_uses_single_model_with_helper_disabled(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    from parakeet_stt_daemon.model import STREAMING_HELPER_DISABLED_FOR_SEAL_ACCURACY
+
+    model = object()
+    load_calls: list[str] = []
+    captured: dict[str, Any] = {}
+
+    class _ConstructAudio:
+        def __init__(self, *, sample_rate: int, **_kwargs: Any) -> None:
+            self.sample_rate = sample_rate
+
+        def configure_stream_chunk_size(self, chunk_samples: int) -> None:
+            captured["stream_chunk_samples"] = chunk_samples
+
+    class _ConstructSealTranscriber:
+        def __init__(self, model_arg: object) -> None:
+            captured["seal_model"] = model_arg
+
+    class _ConstructStreamingTranscriber:
+        helper_active = False
+        _helper_class_name = None
+
+        def __init__(self, model_arg: object, **kwargs: Any) -> None:
+            captured["stream_model"] = model_arg
+            captured["stream_kwargs"] = kwargs
+            self.fallback_reason = kwargs["helper_disabled_reason"]
+
+    def fake_load_parakeet_model(*, device: str) -> object:
+        load_calls.append(device)
+        return model
+
+    monkeypatch.setattr(orchestrator_module, "AudioInput", _ConstructAudio)
+    monkeypatch.setattr(orchestrator_module, "load_parakeet_model", fake_load_parakeet_model)
+    monkeypatch.setattr(
+        orchestrator_module,
+        "ParakeetTranscriber",
+        _ConstructSealTranscriber,
+    )
+    monkeypatch.setattr(
+        orchestrator_module,
+        "ParakeetStreamingTranscriber",
+        _ConstructStreamingTranscriber,
+    )
+
+    settings = ServerSettings(device="cpu", streaming_enabled=True)
+    orchestrator = SessionOrchestrator(settings)
+
+    assert load_calls == ["cpu"]
+    assert orchestrator.model is model
+    assert captured["seal_model"] is model
+    assert captured["stream_model"] is model
+    assert captured["stream_chunk_samples"] == int(settings.chunk_secs * 16_000)
+    assert captured["stream_kwargs"] == {
+        "chunk_secs": settings.chunk_secs,
+        "right_context_secs": settings.right_context_secs,
+        "left_context_secs": settings.left_context_secs,
+        "batch_size": settings.batch_size,
+        "enable_helper": False,
+        "helper_disabled_reason": STREAMING_HELPER_DISABLED_FOR_SEAL_ACCURACY,
+    }
+    assert orchestrator.streaming_transcriber is not None
+    assert orchestrator.streaming_transcriber.fallback_reason == (
+        STREAMING_HELPER_DISABLED_FOR_SEAL_ACCURACY
+    )
+
+
 T = TypeVar("T")
 
 

--- a/parakeet-stt-daemon/tests/test_streaming_chunk_padding.py
+++ b/parakeet-stt-daemon/tests/test_streaming_chunk_padding.py
@@ -80,6 +80,27 @@ def test_finalize_uses_offline_seal_even_with_retired_streaming_envs(monkeypatch
     assert parent.last_sample_rate == 16_000
 
 
+def test_streaming_transcriber_can_disable_helper_without_importing_nemo() -> None:
+    from parakeet_stt_daemon.model import ParakeetStreamingTranscriber
+
+    transcriber = ParakeetStreamingTranscriber(
+        cast(Any, object()),
+        enable_helper=False,
+        helper_disabled_reason="streaming_helper_disabled:test",
+    )
+
+    session = transcriber.start_session(16_000)
+    processed = session.feed(np.array([0.1, 0.2], dtype=np.float32))
+
+    assert transcriber.helper_active is False
+    assert transcriber.fallback_reason == "streaming_helper_disabled:test"
+    assert transcriber._helper_class_name is None
+    assert processed is False
+    assert session.stream_path_executed is False
+    assert session.stream_chunks_processed == 0
+    assert session.stream_fallback_reason == "streaming_helper_disabled:test"
+
+
 def test_cuda_graph_decoder_config_is_disabled_before_decoder_rebuild() -> None:
     from parakeet_stt_daemon.model import _disable_cuda_graph_decoder_config
 
@@ -185,12 +206,18 @@ def test_tdt_streaming_helper_rebuilds_decoder_with_cuda_graphs_disabled(monkeyp
             self.decoding = SimpleNamespace(decoding=rebuilt_decoder)
 
     model = _FakeTDTModel()
+    original_decoding = model.decoding
 
-    transcriber = ParakeetStreamingTranscriber(cast(Any, model), batch_size=32)
+    transcriber = ParakeetStreamingTranscriber(
+        cast(Any, model),
+        batch_size=32,
+        enable_helper=True,
+    )
 
     assert transcriber.helper_active is True
     assert transcriber._helper_class_name == "BatchedFrameASRTDT"
     assert model.change_decoding_flags == [(False, False)]
+    assert model.decoding is not original_decoding
     assert rebuilt_decoder.disable_calls == 1
 
 
@@ -275,12 +302,18 @@ def test_tdt_stream_chunk_pads_terminal_frame_and_records_execution(monkeypatch)
         loss=SimpleNamespace(_loss=_FakeTDTLoss()),
         decoding=SimpleNamespace(decoding=SimpleNamespace()),
     )
+    model.change_decoding_strategy = lambda _decoding_cfg: setattr(
+        model,
+        "decoding",
+        SimpleNamespace(decoding=SimpleNamespace()),
+    )
 
     transcriber = ParakeetStreamingTranscriber(
         cast(Any, model),
         chunk_secs=0.2,
         right_context_secs=0.1,
         batch_size=32,
+        enable_helper=True,
     )
     session = transcriber.start_session(16_001)
 


### PR DESCRIPTION
## Summary
- keep the two existing stream-seal isolation commits on a dedicated review branch
- replace the expensive two-full-model daemon/eval architecture with a one-model stream-seal policy
- disable unsafe NeMo `BatchedFrameASRTDT` helper feeds on the Seal model while preserving rolling offline interim overlay and final Seal accuracy

## Why
`BatchedFrameASRTDT` feeds mutate shared NeMo state used by later offline Seal transcription. Decoder restore and decoder-proxy probes were not reliable, so the lower-cost verified fix is to avoid feeding the helper on the final Seal model and make the fallback explicit.

Refs #110

## Verification
- `uv run ruff check src/parakeet_stt_daemon/model.py src/parakeet_stt_daemon/session_orchestrator.py check_model_lib/runner.py tests/test_streaming_chunk_padding.py tests/test_offline_benchmark_harness.py tests/test_session_orchestrator.py`
- `uv run ty check src/parakeet_stt_daemon/model.py src/parakeet_stt_daemon/session_orchestrator.py check_model_lib/runner.py tests/test_streaming_chunk_padding.py tests/test_offline_benchmark_harness.py tests/test_session_orchestrator.py`
- `uv run pytest`
- targeted GPU probe: `bench_audio/sample_06.wav` and `bench_audio/personal/audio/cmd_059.wav` remained byte-for-byte equal before/after stream feed and had no Cyrillic
- pre-push hook: `python pytest`

## Tradeoff
Native NeMo helper truth is disabled in default stream-seal, so helper chunks remain at zero with `streaming_helper_disabled:seal_accuracy`. User-visible interim text still comes from the rolling offline interim path; final dictation stays on Seal.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Adjusted streaming setup to disable the helper for accuracy-focused seal runs and to share a single model instance between streaming and seal modes, improving resource use and consistency.
  * Finalization now concatenates buffered audio with tail audio for more reliable seal transcriptions.

* **Tests**
  * Added and updated tests to cover helper enable/disable behavior, single-model stream-seal flows, tail-finalization retries, and sample-count tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SystemicVoid/parakeet-stt/pull/183?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->